### PR TITLE
 ibm-sherpa-operator folder created

### DIFF
--- a/operators/ibm-sherpa-operator/ci.yaml
+++ b/operators/ibm-sherpa-operator/ci.yaml
@@ -1,0 +1,1 @@
+cert_project_id: 61829a722bfbc00e94ed9585


### PR DESCRIPTION
Added ibm-sherpa-operator under operators fold to add bundle image details for certification. This is for testing purpose only.