### PR TITLE
Add conjur-follower-operator 1.4.0

### DIFF
--- a/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-conjurfollower-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-conjurfollower-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: conjur-follower-operator-conjurfollower-editor-role
+rules:
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers/status
+  verbs:
+  - get

--- a/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-conjurfollower-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-conjurfollower-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: conjur-follower-operator-conjurfollower-viewer-role
+rules:
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers/status
+  verbs:
+  - get

--- a/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: conjur-follower-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: conjur-follower-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator.clusterserviceversion.yaml
+++ b/operators/conjur-follower-operator/1.4.0/manifests/conjur-follower-operator.clusterserviceversion.yaml
@@ -1,0 +1,415 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "conjur.cyberark.com/v1",
+          "kind": "ConjurFollower",
+          "metadata": {
+            "labels": {
+              "app": "conjur-follower"
+            },
+            "name": "conjur-follower-operator-my-conjur-follower",
+            "namespace": "conjur-follower-operator-system"
+          },
+          "spec": {
+            "images": {
+              "configurator": "docker-registry.default.svc:5000/my-follower-namespace/configurator",
+              "conjur": "docker-registry.default.svc:5000/my-follower-namespace/conjur",
+              "info": "docker-registry.default.svc:5000/my-follower-namespace/info",
+              "nginx": "docker-registry.default.svc:5000/my-follower-namespace/nginx",
+              "postgres": "docker-registry.default.svc:5000/my-follower-namespace/postgres",
+              "syslogNg": "docker-registry.default.svc:5000/my-follower-namespace/syslog-ng"
+            },
+            "master": {
+              "account": "my-company",
+              "authenticatorID": "conjur-openshift-follower",
+              "authnLogin": "host/conjur-openshift-follower",
+              "caCertificateFrom": {
+                "configMapKeyRef": {
+                  "key": "conjur.master-cert",
+                  "name": "follower"
+                }
+              },
+              "hostname": "conjur.my-company.net"
+            },
+            "replicas": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+    operators.operatorframework.io/builder: operator-sdk-v1.11.0+git
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+  name: conjur-follower-operator.v1.4.0
+  namespace: placeholder
+spec:
+  relatedImages: 
+    - name: conjur-follower-operator 
+      image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-operator@sha256:2502119099c2ebfb2da5deee08ee51969bf2a9bfbe2adc0cae0e5afd3beb66ab
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ConjurFollower is the Schema for the conjurfollowers API
+      displayName: ConjurFollower
+      kind: ConjurFollower
+      name: conjurfollowers.conjur.cyberark.com
+      resources:
+      - kind: Deployment
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: ServiceAccount
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: The configuration for resources of Conjur Follower Containers
+        displayName: Container Resources Configuration
+        path: containerResources
+      - description: Info Resources describes the resource limits to provision this
+          container with
+        displayName: Info Resources
+        path: containerResources.configurator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Conjur Resources describes the resource limits to provision this
+          container with
+        displayName: Conjur Resources
+        path: containerResources.conjur
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Postgres Resources describes the resource limits to provision
+          this container with
+        displayName: Postgres Resources
+        path: containerResources.info
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Nginx Resources describes the resource limits to provision this
+          container with
+        displayName: Nginx Resources
+        path: containerResources.nginx
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: SyslogNg Resources describes the resource limits to provision
+          this container with
+        displayName: SyslogNg Resources
+        path: containerResources.postgres
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Nginx Resources describes the resource limits to provision this
+          container with
+        displayName: Nginx Resources
+        path: containerResources.syslogNg
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The paths to the Images used by the ConjurFollower.
+        displayName: Image Paths
+        path: images
+      - description: The path of the Configurator container image.
+        displayName: Configurator Image
+        path: images.configurator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Conjur container image.
+        displayName: Conjur Image
+        path: images.conjur
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Info container image.
+        displayName: Info Image
+        path: images.info
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Nginx container image.
+        displayName: Nginx Image
+        path: images.nginx
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Postgres container image.
+        displayName: Postgres Image
+        path: images.postgres
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Syslog-ng container image.
+        displayName: Syslog-ng Image
+        path: images.syslogNg
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The configuration for the Conjur Master.
+        displayName: Master Configuration
+        path: master
+      - description: The Account used for Conjur Enterprise.
+        displayName: Conjur Account
+        path: master.account
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The ID of the Authenticator
+        displayName: Authenticator ID
+        path: master.authenticatorID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Conjur Authentication Login.
+        displayName: AuthN Login
+        path: master.authnLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Hostname where Conjur Enterprise Leader is hosted.
+        displayName: Conjur Enterprise Leader Hostname
+        path: master.hostname
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The desired number of member Pods for the Conjur Enterprise Followers.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The configuration for names of Downstream Resources.
+        displayName: Resource Configuration
+        path: resourceNames
+      - description: The name of the Deployment of which to deploy the Conjur Enterprise
+          Follower into.
+        displayName: Deployment
+        path: resourceNames.deployment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Conjur Service name.
+        displayName: Service
+        path: resourceNames.service
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Conjur Service Account.
+        displayName: Service Account
+        path: resourceNames.serviceAccount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Namespece
+        path: lastReconciled.controller.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Pod
+        path: lastReconciled.controller.pod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Version
+        path: lastReconciled.controller.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Timestamp
+        path: lastReconciled.timestamp
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: status
+        path: status
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1
+  description: Manages Conjur Enterprise Followers in Kubernetes
+  displayName: Conjur Enterprise Follower Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAADwAAAAmCAYAAACYsfiPAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAGAAAAABAAAAYAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAJgAAAAC96Oe7AAAACXBIWXMAAA7EAAAOxAGVKw4bAAACymlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj45NjwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6UmVzb2x1dGlvblVuaXQ+MjwvdGlmZjpSZXNvbHV0aW9uVW5pdD4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+OTY8L3RpZmY6WFJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4zODA8L2V4aWY6UGl4ZWxYRGltZW5zaW9uPgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjI0MjwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoQu0uyAAANGUlEQVRoBd0aCXBURba7//8zkwyokBkCKFhSyCoBSTIERAIGkURUanV10AyHCgiuCivrIipYOygYQFEOUYiIiiSRzHoiK8gqgSgIZBI5ggcRPDAck4CQZI5/dO97f+azYXVra4uhirWr/nT/169fv9fv6Nf9h5BzXPI2Cdma4qbdP7crqNFm51er2wtq1AkW3FsuJG95uWS9n8uanivicQG8JDCSGjhHQbV6H6XsaiH45/BkM0kJCmFcS3W+en2O4++I46mqUoIej04oFfj+/1H8fuZZXqVYzBZUNt9ww7bw6vxgdCrC8l496Bi2tWkhtguqRKeCnbF5+VtbluVvauqFMCzx8eKcKSM+SxJ+Wws6ZP3hjPyPGpflf/Lz/IItLZ0s8vmbG7vkbzy22HrHOr+yxZP/yYkV+Rsanhr69qE0qy/Pv+m0O1iws62TSjA4qa82qHy/26GkTCa66CwoX7YxP60KmZxYJZTivlSL1p8gNofN1B767oFuQfZRX2cQUCYM+/DorZLMFl//zg+f5u7qstzvpzoRoOkkmjg72xVrPX7wG1+NlIk8Sxhi18abO0/YeJO7CoOW3y9YMIgyEaJJ9gY9EothO7Bvluh24ABHwf1CsI3D09+RvvtinDAIq7ji4KJBr9UONYVFoc+XYpld7sp91w9cuTc2sHjPSIu34Yv3283+BMNo8gNf3v3ENS/v3t8aDwVGPG95rc0am7ti79JBr9aus94JSY7QSTNppqppXOfTiELduS9Ul5Co+tyHUy6Pq9VPSO7z2wuJzm4gTN9NdGMzUWxdc5dUv071WDFE8s8swQYt/Pw2YbPfQXT1g8oJ2Q/E4ShsciJ30gSmzTHGCD+55cEBr+c9v+Mzg5L7B8/7rJ5o+kfEJo8nnP/YGLLf23X7x7Q5L3Nu5fScZwcv+vxywcnU3Pmf3myosbWKzXEXMURInGye9Oljg04k/BdkTo6wuHhJE1gLxwSViLkdVUzt9wXQnjiwaPMdgogFckwfu+WJa/fjhO38G7saEdXE2/KnqxF2f+7sihFUSAt1TR239ZEhexEPzb9bIMADhJj7OMKSUZIWtAwtQrSWqMnTgKnlKdiIHjy63ojE/oHCZvjj/tkSDutaRDODlgU7VHdwowZ4W2cM2Yu+7Jm4XIGIrwdGjkyqsMhT8gRujhIRi5r0Th1KaKVdyoU8EmuDE5HaWrNSWoyYiEY7miB/hop1eucuFxJVdUKTNtV/Q4PFkzRoi76T38vK8JafDmSIe7YlaQJTVeMkop6REsphlZOobm4ptYGRqmdiWX9uaHOoplPPpDVzc+4p64ICsMhxTURimEsLFNYz8c3svveVLyFcK3amk4sRx+tNTq6dNB8GvwS24tulo103U/BIJAJBWz7eo3C5K9XunEE4cXAuFlWv8H6Zfe+aAkMSRZljVlWFGyMByeYIeQDPsDn/LDjvaDDxJIvxUQYnF6DAySpnL3BFnBUVBKYsruCT9mOm5WjRFoMYis/BbOkQaEuCKwq3Ijb6aYV/yAZobugzdvWtXNOeN9TmTEptXWUi3qte4Xsf8TJHrXICAY7tZJWzF5hsjvOiqoRxYh7x6pbcGOsz4qWRooUME0zdQrmw8R+bD1tMN639Jm4KAKBHTh4lTtkuGFu0963xSxEH/RZdgEfBJVhy41YSBI6LIaFJS9LxjLznujOH8lcw3QM8LE2v3TDheO/fL+lN2qbO7F2wqEEP84XBykmH+1y/OEvI7H54jhPVuLt23aQTJiX01X374kQjGgQvPd5O0m/SBOZhTRUi9iRT5FLw1Tl71t//FfKI2toTGLkHmuN7DV14syST2RmDF4QNDh5sGEtr1z+IezYxt6Liw0ZeaB+tqPWb0duIRDtTRk9bA+KdByWe43Yf9LQ7Y8D8tb1y5v7lX0z5wZdBY3BGzsvzm4ubkTO/I+C9beF4PMshCRHU6kf4Vf2euSyj/7ylGQOeeRLHJnCTIngSNIxpn5/VVT4eAsZG9MyZN6pXv3lrBKHranc8sgqZ9daWSyESN9OYrhvgsJhhmVtNKLQPxlNSUUF0j8efGqOOhwzCe8B545V926ZVkm2IaYb/eEQ0X8+LH9BEQhuXDJiaktFv3nR4VmX0K7quNXu9+s9J75lTtAhhrbXaq++8MRk5c8t65Twz2sJP7L1J0axFM6nELCEqKvxmpLky69lLmWw8BCarSIIu2V01/eveuUXteIw+Vbvz0QcRv3fO/Gs5JeOEEF+l8MiiYNAfRhP3egMsEEh+apl0geMrKajHUywHg2aKSMCvrwETnwiG+aXO1XdlKo0mnL1MJDoNHIIzyhbu3jHtII5Fn7bGxWkl9/ccCWwx6YdgBbcXCY2D4HA5QG+HW8vekKVUMkJL9ux8ZDNiJwRFyzjffBXZ+99K3Bfj0TYjz9/mypy5gy0KcT+O91mw30zt8Uw0z8GWQK2DlgX7DdYYkMyTzzl2p9/g0p2tSBQyAUj+z/CnX9MCwhJwxLUeC2axYcGt+nQ/jLVgWP+nYvb9+/yJsUjrF/0WrBXB1jhmRpigl5d3ZsZlCm6Na81U67bV36o+Y1wr+H9r/nJcgjFzYOv2Lyn9cizi/Irw8aFIDB9xwQBv+5SYrUdMiMM/15R+j90X9xub9tOOVY2YCCSUKuA0YGvfxuY4vr2kyeUZ3VE3dLudG1RxkiOHtgUiCXqkTZbXJQvJaR6SBadwUtAadwV+umSANyWsSy6uwyUnFGuuhNbx7Gvyk37VmA4p7aVT31W8hhdlJgzHNjUrDkVtNhObhq/fb0IaZgG+LmSK82RafRPkqWZ/W+DfqUXYkZpA6KIs36WpTLTgpMKVVfiwPWYrg4zHJ1O61J3tW4lEVE1b4M4uxL1TkDy/edZ12ZV3lYia5u5TOBD20w0ykx7lsvJENKasc3t8XqTnzvR1d1BlvUTZLIXQWYAzl8o282NaNCY9yQxWCvPMkBl5Guba4PLckQ0Cc1zMxPhMQzaONp2KvYh8dO8+3LzXUqPKY4rMG0iq8zBxOk+4sgvrXVm+OxHHbZdvURR+rMOpTj3Nd49vrl3TjulE7glHMQUuFsapnI+VXZmFE+BzxtBQdUkBImJJy/KN6eyZmBrTT8ygsvJBx6x7Nh2p8IdcHt8CWOrdR3cHDro9owbDgX9dqKbkMRzTzjO2qyz0tdAMwGfRVJB7f0NNyV3Y17rAh6I0MJinYdyHCIcFvYEKeQ40hxNHu3jSwcQUJjuI0CK+9Bzf7LqdpQcQV1CRRqkE04ppkKo2CWJMF5SVQVL+N3IK7sbkVJlr4QZ3VuFkpqRO12PhsY01pZs7e0akqjylgks0IhNGfYwa9yLB7t0n2+vqlsQA6Q0kD5oNu7N8Lxg0Nq9D5p0rgJveoWBpPuISwSOQLrouyrzlIsadbRjXr4ERH5t95l2Pnury/KGTxBwpcHHHonLKiSZwDwFcMgnZixeYpB4EMa2HBIs1V9adnWGee7genU4pfUg3xBTAhHwcC4WUWzQ1Vpe+hG+gmLaSzf6iq+kSN4cbf6pHQXfscXCjBww1PBrkKEHt1geLIT8nm3CMDCsuiyg/Cm1aV5emYaTuXtNRrqujKqycHKoofQW0kM0pWyN07WochAWYihBGBivEOYdIwgbHuYEAew37DKqpVNArKEkp4uiVxHaBXTdWgsN9gG/cEI938PjggzhpD2M6wlOEcLNQAotPiSLsr2o0+jtwpgnuDO/MUG2gGfp1yqS2oMGtINkpEH6IUCNbG2rKDoNb2incLhBhPAB9hHJuN+lFT6D/YzFrxIhQm9wbANvg4MpIIGDUWbf9TT0AqQKUKQJgCW0x6KB51AfXhsEAnKDhQEN1yUyTHPyAP74FFjFY5uR7g9Gdx4Ild1t9rWr4Nii2c115k0h6MXxOWdtQXbYJNUGCy+HzaOFdVJKIzqP1ICxjsh2uBgXEEQJxhUsEAg1Y0rfAVCHI0KywtsMs2rAYxND0sbAuOZLN+Uq6Z9TOo8GSPag4K5AxkOg5TukL7fsUZqCw7TzeruirGNXQxJAYXLM4oDIDh61tmqkzWC80w07Y7c65uyP6MGgsHVR/yoB7HmDSDZppg30d+hem4wO4uM5OwPu0Ydeqbxqqe1wHZnt7h2xfAc6V5vH9kSkplwHX4zkxbgbs67geq4WFjVuAAD5Ae7BAYyiVhzBbyoWqaPLHyYoU8G8iMWNrY03ZFK5FfuCC78CdJi5sfEtlx6pLN4D5zWQSnevK9q2VhPICrOJ+c7tI7HGcs0Zg1Px08F2oxRSYC3EA1rqrO3vUCmKoRTLRFghKl4W+KP1CZzG43xKqsCvLhKHO5xpZLDRqWgLA98Iqm3dWGJkh0k+GIHSbybQgV3EtWhaqeXPl8eryDWCqm+FK62HoO5nWZ+zFnNBq+F9IpWvguLah6tWVYM5FoLDh+A6L8q2uNe/VuWyaMrjNjTDXD1FdG4+0wXpNk/4ncv7TQ+5yDS4AAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - pods/exec
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - conjur.cyberark.com
+          resources:
+          - conjurfollowers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - conjur.cyberark.com
+          resources:
+          - conjurfollowers
+          - conjurfollowers/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - conjur.cyberark.com
+          resources:
+          - conjurfollowers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: conjur-follower-operator-controller-manager
+      deployments:
+      - name: conjur-follower-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: controller-manager
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: conjur-follower-operator
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-operator@sha256:2502119099c2ebfb2da5deee08ee51969bf2a9bfbe2adc0cae0e5afd3beb66ab
+                imagePullPolicy: Always
+                name: conjur-follower-operator
+                resources: {}
+              serviceAccountName: conjur-follower-operator-controller-manager
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: conjur-follower-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - cyberark
+  - conjur
+  - conjur enterprise follower operator
+  links:
+  - name: Conjur Follower Operator
+    url: https://docs.conjur.org/Latest/en/Content/Integrations/kubernetes.htm
+  maturity: alpha
+  minKubeVersion: 1.21.4
+  provider:
+    name: CyberArk
+    url: https://docs.conjur.org/Latest/en/Content/Integrations/kubernetes.htm
+  version: 1.4.0

--- a/operators/conjur-follower-operator/1.4.0/manifests/conjur.cyberark.com_conjurfollowers.yaml
+++ b/operators/conjur-follower-operator/1.4.0/manifests/conjur.cyberark.com_conjurfollowers.yaml
@@ -1,0 +1,449 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: conjurfollowers.conjur.cyberark.com
+spec:
+  group: conjur.cyberark.com
+  names:
+    kind: ConjurFollower
+    listKind: ConjurFollowerList
+    plural: conjurfollowers
+    singular: conjurfollower
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConjurFollower is the Schema for the conjurfollowers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConjurFollowerSpec defines the desired state of ConjurFollower
+            properties:
+              configFileFrom:
+                description: The Conjur follow certificate authority (CA) certificate.
+                properties:
+                  configMapKeyRef:
+                    description: Selects a key of a ConfigMap.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its key must
+                          be defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                  secretKeyRef:
+                    description: Selects a key of a secret in the pod's namespace
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                type: object
+              containerResources:
+                description: The configuration for resources of Conjur Follower Containers
+                properties:
+                  configurator:
+                    description: Info Resources describes the resource limits to provision
+                      this container with
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  conjur:
+                    description: Conjur Resources describes the resource limits to
+                      provision this container with
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  info:
+                    description: Postgres Resources describes the resource limits
+                      to provision this container with
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  nginx:
+                    description: Nginx Resources describes the resource limits to
+                      provision this container with
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  postgres:
+                    description: SyslogNg Resources describes the resource limits
+                      to provision this container with
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  syslogNg:
+                    description: Nginx Resources describes the resource limits to
+                      provision this container with
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                type: object
+              images:
+                description: The paths to the Images used by the ConjurFollower.
+                properties:
+                  configurator:
+                    description: The path of the Configurator container image.
+                    type: string
+                  conjur:
+                    description: The path of the Conjur container image.
+                    type: string
+                  info:
+                    description: The path of the Info container image.
+                    type: string
+                  nginx:
+                    description: The path of the Nginx container image.
+                    type: string
+                  postgres:
+                    description: The path of the Postgres container image.
+                    type: string
+                  syslogNg:
+                    description: The path of the Syslog-ng container image.
+                    type: string
+                type: object
+              master:
+                description: The configuration for the Conjur Master.
+                properties:
+                  account:
+                    description: The Account used for Conjur Enterprise.
+                    type: string
+                  authenticatorID:
+                    description: The ID of the Authenticator
+                    type: string
+                  authnLogin:
+                    description: The Conjur Authentication Login.
+                    type: string
+                  caCertificateFrom:
+                    description: The Conjur Master certificate authority (CA) certificate.
+                    properties:
+                      configMapKeyRef:
+                        description: Selects a key of a ConfigMap.
+                        properties:
+                          key:
+                            description: The key to select.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap or its key
+                              must be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      secretKeyRef:
+                        description: Selects a key of a secret in the pod's namespace
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  hostname:
+                    description: The Hostname where Conjur Enterprise Leader is hosted.
+                    type: string
+                required:
+                - account
+                - authenticatorID
+                - authnLogin
+                - caCertificateFrom
+                - hostname
+                type: object
+              replicas:
+                default: 1
+                description: The desired number of member Pods for the Conjur Enterprise
+                  Followers.
+                format: int32
+                type: integer
+              resourceNames:
+                description: The configuration for names of Downstream Resources.
+                properties:
+                  deployment:
+                    description: The name of the Deployment of which to deploy the
+                      Conjur Enterprise Follower into.
+                    type: string
+                  service:
+                    description: The Conjur Service name.
+                    type: string
+                  serviceAccount:
+                    description: The Conjur Service Account.
+                    type: string
+                type: object
+            required:
+            - images
+            - master
+            type: object
+          status:
+            description: ConjurFollowerStatus defines the observed state of ConjurFollower
+            properties:
+              lastReconciled:
+                description: ConjurFollowerLastReconciled defines the time the follower
+                  was last reconciled
+                properties:
+                  controller:
+                    description: ConjurFollowerController defines the operator information
+                    properties:
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  timestamp:
+                    format: date-time
+                    type: string
+                required:
+                - controller
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ConjurFollowerResources defines the resources of the
+                  ConjurFollower
+                properties:
+                  deployment:
+                    description: ConjurFollowerResourceStatus defines the status for
+                      the different resources
+                    properties:
+                      error:
+                        type: boolean
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                  service:
+                    description: ConjurFollowerResourceStatus defines the status for
+                      the different resources
+                    properties:
+                      error:
+                        type: boolean
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                  serviceAccount:
+                    description: ConjurFollowerResourceStatus defines the status for
+                      the different resources
+                    properties:
+                      error:
+                        type: boolean
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                required:
+                - deployment
+                - service
+                - serviceAccount
+                type: object
+              selector:
+                type: string
+              status:
+                type: string
+              version:
+                type: string
+            required:
+            - lastReconciled
+            - resources
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/conjur-follower-operator/1.4.0/metadata/annotations.yaml
+++ b/operators/conjur-follower-operator/1.4.0/metadata/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: conjur-follower-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.11.0+git
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.6-v4.9

--- a/operators/conjur-follower-operator/1.4.0/scorecard/config.yaml
+++ b/operators/conjur-follower-operator/1.4.0/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: conjur-follower-operator-config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/operators/conjur-follower-operator/ci.yaml
+++ b/operators/conjur-follower-operator/ci.yaml
@@ -1,0 +1,2 @@
+cert_project_id: 61765b7140a2d8e95c82d4d7
+merge: False


### PR DESCRIPTION
- Found `conjur-operator-bundle` with our project id in it, renamed to `conjur-follower-operator`
since this must match `operators.operatorframework.io.bundle.package.v1` in `metadata/annotations.yaml`
- Update CSV, point deployment image to published operator image
- Update CSV, add `relatedImages` to same image
- Note: the bundle was built using makefile with additions to the `make bundle` command,
  adding CHANNEL, DEFAULT_CHANNEL fields; these are not in master yet
- Set `merge: False` in ci.yaml so that their bot doesn't auto-merge our operator
  if it passes certification tests