### PR TITLE
remove yugabyte-platform-operator-bundle according to case#03129018

### DIFF
--- a/operators/yugabyte-platform-operator-bundle/ci.yaml
+++ b/operators/yugabyte-platform-operator-bundle/ci.yaml
@@ -1,1 +1,0 @@
-cert_project_id: 5ffc47caf17d11e9ec9e2c87


### PR DESCRIPTION
According to the comment from case#03129018
[snip]
We have been publishing our operator in Red Hat Marketplace only, but we can't see our operator directory in the redhat-marketplace-operator repo on GitHub. We can see the operator directory in the certified-operator repo, but it isn't the right place. 
Operator directory in the wrong repository: https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/yugabyte-platform-operator-bundle ,
[/snip]