### PR TITLE
operator seldon-operator-certified (1.12.0)

### DIFF
--- a/operators/seldon-operator-certified/1.12.0/manifests/machinelearning.seldon.io_seldondeployments.yaml
+++ b/operators/seldon-operator-certified/1.12.0/manifests/machinelearning.seldon.io_seldondeployments.yaml
@@ -1,0 +1,10752 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/instance: seldon1
+    app.kubernetes.io/name: seldon
+    app.kubernetes.io/version: v0.5
+  name: seldondeployments.machinelearning.seldon.io
+spec:
+  group: machinelearning.seldon.io
+  names:
+    kind: SeldonDeployment
+    listKind: SeldonDeploymentList
+    plural: seldondeployments
+    shortNames:
+    - sdep
+    singular: seldondeployment
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SeldonDeployment is the Schema for the seldondeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SeldonDeploymentSpec defines the desired state of SeldonDeployment
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              name:
+                description: Name is Deprecated will be removed in future
+                type: string
+              oauth_key:
+                type: string
+              oauth_secret:
+                type: string
+              predictors:
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    componentSpecs:
+                      items:
+                        properties:
+                          hpaSpec:
+                            properties:
+                              maxReplicas:
+                                format: int32
+                                type: integer
+                              metrics:
+                                items:
+                                  description: MetricSpec specifies how to scale based
+                                    on a single metric (only `type` and one other
+                                    matching field should be set at once).
+                                  properties:
+                                    containerResource:
+                                      description: container resource refers to a
+                                        resource metric (such as those specified in
+                                        requests and limits) known to Kubernetes describing
+                                        a single container in each pod of the current
+                                        scale target (e.g. CPU or memory). Such metrics
+                                        are built in to Kubernetes, and have special
+                                        scaling options on top of those available
+                                        to normal per-pod metrics using the "pods"
+                                        source. This is an alpha feature and can be
+                                        enabled by the HPAContainerMetrics feature
+                                        flag.
+                                      properties:
+                                        container:
+                                          description: container is the name of the
+                                            container in the pods of the scaling target
+                                          type: string
+                                        name:
+                                          description: name is the name of the resource
+                                            in question.
+                                          type: string
+                                        targetAverageUtilization:
+                                          description: targetAverageUtilization is
+                                            the target value of the average of the
+                                            resource metric across all relevant pods,
+                                            represented as a percentage of the requested
+                                            value of the resource for the pods.
+                                          format: int32
+                                          type: integer
+                                        targetAverageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: targetAverageValue is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, as a raw value
+                                            (instead of as a percentage of the request),
+                                            similar to the "pods" metric source type.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - container
+                                      - name
+                                      type: object
+                                    external:
+                                      description: external refers to a global metric
+                                        that is not associated with any Kubernetes
+                                        object. It allows autoscaling based on information
+                                        coming from components running outside of
+                                        cluster (for example length of queue in cloud
+                                        messaging service, or QPS from loadbalancer
+                                        running outside of cluster).
+                                      properties:
+                                        metricName:
+                                          description: metricName is the name of the
+                                            metric in question.
+                                          type: string
+                                        metricSelector:
+                                          description: metricSelector is used to identify
+                                            a specific time series within a given
+                                            metric.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        targetAverageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: targetAverageValue is the target
+                                            per-pod value of global metric (as a quantity).
+                                            Mutually exclusive with TargetValue.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        targetValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: targetValue is the target value
+                                            of the metric (as a quantity). Mutually
+                                            exclusive with TargetAverageValue.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - metricName
+                                      type: object
+                                    object:
+                                      description: object refers to a metric describing
+                                        a single kubernetes object (for example, hits-per-second
+                                        on an Ingress object).
+                                      properties:
+                                        averageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: averageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        metricName:
+                                          description: metricName is the name of the
+                                            metric in question.
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        target:
+                                          description: target is the described Kubernetes
+                                            object.
+                                          properties:
+                                            apiVersion:
+                                              description: API version of the referent
+                                              type: string
+                                            kind:
+                                              description: 'Kind of the referent;
+                                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent;
+                                                More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        targetValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: targetValue is the target value
+                                            of the metric (as a quantity).
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - metricName
+                                      - target
+                                      - targetValue
+                                      type: object
+                                    pods:
+                                      description: pods refers to a metric describing
+                                        each pod in the current scale target (for
+                                        example, transactions-processed-per-second).  The
+                                        values will be averaged together before being
+                                        compared to the target value.
+                                      properties:
+                                        metricName:
+                                          description: metricName is the name of the
+                                            metric in question
+                                          type: string
+                                        selector:
+                                          description: selector is the string-encoded
+                                            form of a standard kubernetes label selector
+                                            for the given metric When set, it is passed
+                                            as an additional parameter to the metrics
+                                            server for more specific metrics scoping
+                                            When unset, just the metricName will be
+                                            used to gather metrics.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        targetAverageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: targetAverageValue is the target
+                                            value of the average of the metric across
+                                            all relevant pods (as a quantity)
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - metricName
+                                      - targetAverageValue
+                                      type: object
+                                    resource:
+                                      description: resource refers to a resource metric
+                                        (such as those specified in requests and limits)
+                                        known to Kubernetes describing each pod in
+                                        the current scale target (e.g. CPU or memory).
+                                        Such metrics are built in to Kubernetes, and
+                                        have special scaling options on top of those
+                                        available to normal per-pod metrics using
+                                        the "pods" source.
+                                      properties:
+                                        name:
+                                          description: name is the name of the resource
+                                            in question.
+                                          type: string
+                                        targetAverageUtilization:
+                                          description: targetAverageUtilization is
+                                            the target value of the average of the
+                                            resource metric across all relevant pods,
+                                            represented as a percentage of the requested
+                                            value of the resource for the pods.
+                                          format: int32
+                                          type: integer
+                                        targetAverageValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: targetAverageValue is the target
+                                            value of the average of the resource metric
+                                            across all relevant pods, as a raw value
+                                            (instead of as a percentage of the request),
+                                            similar to the "pods" metric source type.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - name
+                                      type: object
+                                    type:
+                                      description: 'type is the type of metric source.  It
+                                        should be one of "ContainerResource", "External",
+                                        "Object", "Pods" or "Resource", each mapping
+                                        to a matching field in the object. Note: "ContainerResource"
+                                        type is available on when the feature-gate
+                                        HPAContainerMetrics is enabled'
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                type: array
+                              minReplicas:
+                                format: int32
+                                type: integer
+                            required:
+                            - maxReplicas
+                            type: object
+                          kedaSpec:
+                            description: SeldonScaledObjectSpec is the spec for a
+                              KEDA ScaledObject resource
+                            properties:
+                              advanced:
+                                description: AdvancedConfig specifies advance scaling
+                                  options
+                                properties:
+                                  horizontalPodAutoscalerConfig:
+                                    description: HorizontalPodAutoscalerConfig specifies
+                                      horizontal scale config
+                                    properties:
+                                      behavior:
+                                        description: HorizontalPodAutoscalerBehavior
+                                          configures the scaling behavior of the target
+                                          in both Up and Down directions (scaleUp
+                                          and scaleDown fields respectively).
+                                        properties:
+                                          scaleDown:
+                                            description: scaleDown is scaling policy
+                                              for scaling Down. If not set, the default
+                                              value is to allow to scale down to minReplicas
+                                              pods, with a 300 second stabilization
+                                              window (i.e., the highest recommendation
+                                              for the last 300sec is used).
+                                            properties:
+                                              policies:
+                                                description: policies is a list of
+                                                  potential scaling polices which
+                                                  can be used during scaling. At least
+                                                  one policy must be specified, otherwise
+                                                  the HPAScalingRules will be discarded
+                                                  as invalid
+                                                items:
+                                                  description: HPAScalingPolicy is
+                                                    a single policy which must hold
+                                                    true for a specified past interval.
+                                                  properties:
+                                                    periodSeconds:
+                                                      description: PeriodSeconds specifies
+                                                        the window of time for which
+                                                        the policy should hold true.
+                                                        PeriodSeconds must be greater
+                                                        than zero and less than or
+                                                        equal to 1800 (30 min).
+                                                      format: int32
+                                                      type: integer
+                                                    type:
+                                                      description: Type is used to
+                                                        specify the scaling policy.
+                                                      type: string
+                                                    value:
+                                                      description: Value contains
+                                                        the amount of change which
+                                                        is permitted by the policy.
+                                                        It must be greater than zero
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - periodSeconds
+                                                  - type
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              selectPolicy:
+                                                description: selectPolicy is used
+                                                  to specify which policy should be
+                                                  used. If not set, the default value
+                                                  MaxPolicySelect is used.
+                                                type: string
+                                              stabilizationWindowSeconds:
+                                                description: 'StabilizationWindowSeconds
+                                                  is the number of seconds for which
+                                                  past recommendations should be considered
+                                                  while scaling up or scaling down.
+                                                  StabilizationWindowSeconds must
+                                                  be greater than or equal to zero
+                                                  and less than or equal to 3600 (one
+                                                  hour). If not set, use the default
+                                                  values: - For scale up: 0 (i.e.
+                                                  no stabilization is done). - For
+                                                  scale down: 300 (i.e. the stabilization
+                                                  window is 300 seconds long).'
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          scaleUp:
+                                            description: 'scaleUp is scaling policy
+                                              for scaling Up. If not set, the default
+                                              value is the higher of:   * increase
+                                              no more than 4 pods per 60 seconds   *
+                                              double the number of pods per 60 seconds
+                                              No stabilization is used.'
+                                            properties:
+                                              policies:
+                                                description: policies is a list of
+                                                  potential scaling polices which
+                                                  can be used during scaling. At least
+                                                  one policy must be specified, otherwise
+                                                  the HPAScalingRules will be discarded
+                                                  as invalid
+                                                items:
+                                                  description: HPAScalingPolicy is
+                                                    a single policy which must hold
+                                                    true for a specified past interval.
+                                                  properties:
+                                                    periodSeconds:
+                                                      description: PeriodSeconds specifies
+                                                        the window of time for which
+                                                        the policy should hold true.
+                                                        PeriodSeconds must be greater
+                                                        than zero and less than or
+                                                        equal to 1800 (30 min).
+                                                      format: int32
+                                                      type: integer
+                                                    type:
+                                                      description: Type is used to
+                                                        specify the scaling policy.
+                                                      type: string
+                                                    value:
+                                                      description: Value contains
+                                                        the amount of change which
+                                                        is permitted by the policy.
+                                                        It must be greater than zero
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - periodSeconds
+                                                  - type
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              selectPolicy:
+                                                description: selectPolicy is used
+                                                  to specify which policy should be
+                                                  used. If not set, the default value
+                                                  MaxPolicySelect is used.
+                                                type: string
+                                              stabilizationWindowSeconds:
+                                                description: 'StabilizationWindowSeconds
+                                                  is the number of seconds for which
+                                                  past recommendations should be considered
+                                                  while scaling up or scaling down.
+                                                  StabilizationWindowSeconds must
+                                                  be greater than or equal to zero
+                                                  and less than or equal to 3600 (one
+                                                  hour). If not set, use the default
+                                                  values: - For scale up: 0 (i.e.
+                                                  no stabilization is done). - For
+                                                  scale down: 300 (i.e. the stabilization
+                                                  window is 300 seconds long).'
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      resourceMetrics:
+                                        items:
+                                          description: ResourceMetricSource indicates
+                                            how to scale on a resource metric known
+                                            to Kubernetes, as specified in requests
+                                            and limits, describing each pod in the
+                                            current scale target (e.g. CPU or memory).  The
+                                            values will be averaged together before
+                                            being compared to the target.  Such metrics
+                                            are built in to Kubernetes, and have special
+                                            scaling options on top of those available
+                                            to normal per-pod metrics using the "pods"
+                                            source.  Only one "target" type should
+                                            be set.
+                                          properties:
+                                            name:
+                                              description: name is the name of the
+                                                resource in question.
+                                              type: string
+                                            target:
+                                              description: target specifies the target
+                                                value for the given metric
+                                              properties:
+                                                averageUtilization:
+                                                  description: averageUtilization
+                                                    is the target value of the average
+                                                    of the resource metric across
+                                                    all relevant pods, represented
+                                                    as a percentage of the requested
+                                                    value of the resource for the
+                                                    pods. Currently only valid for
+                                                    Resource metric source type
+                                                  format: int32
+                                                  type: integer
+                                                averageValue:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: averageValue is the
+                                                    target value of the average of
+                                                    the metric across all relevant
+                                                    pods (as a quantity)
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type:
+                                                  description: type represents whether
+                                                    the metric type is Utilization,
+                                                    Value, or AverageValue
+                                                  type: string
+                                                value:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: value is the target
+                                                    value of the metric (as a quantity).
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - type
+                                              type: object
+                                          required:
+                                          - name
+                                          - target
+                                          type: object
+                                        type: array
+                                    type: object
+                                  restoreToOriginalReplicaCount:
+                                    type: boolean
+                                type: object
+                              cooldownPeriod:
+                                format: int32
+                                type: integer
+                              maxReplicaCount:
+                                format: int32
+                                type: integer
+                              minReplicaCount:
+                                format: int32
+                                type: integer
+                              pollingInterval:
+                                format: int32
+                                type: integer
+                              triggers:
+                                items:
+                                  description: ScaleTriggers reference the scaler
+                                    that will be used
+                                  properties:
+                                    authenticationRef:
+                                      description: ScaledObjectAuthRef points to the
+                                        TriggerAuthentication object that is used
+                                        to authenticate the scaler with the environment
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    metadata:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    name:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - metadata
+                                  - type
+                                  type: object
+                                type: array
+                            required:
+                            - triggers
+                            type: object
+                          metadata:
+                            description: 'ObjectMeta is a copy of the "k8s.io/apimachinery/pkg/apis/meta/v1"
+                              ObjectMeta. We copy it for 2 reasons: * to be included
+                              in the structural schema of the CRD. * to edit the CreationTimestamp
+                              to be nullable and a pointer to metav1.Time instead
+                              of a struct which allows better serialization. * remove
+                              ManagedFields which contain unsupported "Any" type.'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value
+                                  map stored with a resource that may be set by external
+                                  tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              clusterName:
+                                description: The name of the cluster which the object
+                                  belongs to. This is used to distinguish resources
+                                  with same name and namespace in different clusters.
+                                  This field is not set anywhere right now and apiserver
+                                  is going to ignore it if set in create or update
+                                  request.
+                                type: string
+                              creationTimestamp:
+                                description: "CreationTimestamp is a timestamp representing
+                                  the server time when this object was created. It
+                                  is not guaranteed to be set in happens-before order
+                                  across separate operations. Clients may not set
+                                  this value. It is represented in RFC3339 form and
+                                  is in UTC. \n Populated by the system. Read-only.
+                                  Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+                                format: date-time
+                                nullable: true
+                                type: string
+                              deletionGracePeriodSeconds:
+                                description: Number of seconds allowed for this object
+                                  to gracefully terminate before it will be removed
+                                  from the system. Only set when deletionTimestamp
+                                  is also set. May only be shortened. Read-only.
+                                format: int64
+                                type: integer
+                              deletionTimestamp:
+                                description: "DeletionTimestamp is RFC 3339 date and
+                                  time at which this resource will be deleted. This
+                                  field is set by the server when a graceful deletion
+                                  is requested by the user, and is not directly settable
+                                  by a client. The resource is expected to be deleted
+                                  (no longer visible from resource lists, and not
+                                  reachable by name) after the time in this field,
+                                  once the finalizers list is empty. As long as the
+                                  finalizers list contains items, deletion is blocked.
+                                  Once the deletionTimestamp is set, this value may
+                                  not be unset or be set further into the future,
+                                  although it may be shortened or the resource may
+                                  be deleted prior to this time. For example, a user
+                                  may request that a pod is deleted in 30 seconds.
+                                  The Kubelet will react by sending a graceful termination
+                                  signal to the containers in the pod. After that
+                                  30 seconds, the Kubelet will send a hard termination
+                                  signal (SIGKILL) to the container and after cleanup,
+                                  remove the pod from the API. In the presence of
+                                  network partitions, this object may still exist
+                                  after this timestamp, until an administrator or
+                                  automated process can determine the resource is
+                                  fully terminated. If not set, graceful deletion
+                                  of the object has not been requested. \n Populated
+                                  by the system when a graceful deletion is requested.
+                                  Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+                                format: date-time
+                                type: string
+                              finalizers:
+                                description: Must be empty before the object is deleted
+                                  from the registry. Each entry is an identifier for
+                                  the responsible component that will remove the entry
+                                  from the list. If the deletionTimestamp of the object
+                                  is non-nil, entries in this list can only be removed.
+                                  Finalizers may be processed and removed in any order.  Order
+                                  is NOT enforced because it introduces significant
+                                  risk of stuck finalizers. finalizers is a shared
+                                  field, any actor with permission can reorder it.
+                                  If the finalizer list is processed in order, then
+                                  this can lead to a situation in which the component
+                                  responsible for the first finalizer in the list
+                                  is waiting for a signal (field value, external system,
+                                  or other) produced by a component responsible for
+                                  a finalizer later in the list, resulting in a deadlock.
+                                  Without enforced ordering finalizers are free to
+                                  order amongst themselves and are not vulnerable
+                                  to ordering changes in the list.
+                                items:
+                                  type: string
+                                type: array
+                              generateName:
+                                description: "GenerateName is an optional prefix,
+                                  used by the server, to generate a unique name ONLY
+                                  IF the Name field has not been provided. If this
+                                  field is used, the name returned to the client will
+                                  be different than the name passed. This value will
+                                  also be combined with a unique suffix. The provided
+                                  value has the same validation rules as the Name
+                                  field, and may be truncated by the length of the
+                                  suffix required to make the value unique on the
+                                  server. \n If this field is specified and the generated
+                                  name exists, the server will NOT return a 409 -
+                                  instead, it will either return 201 Created or 500
+                                  with Reason ServerTimeout indicating a unique name
+                                  could not be found in the time allotted, and the
+                                  client should retry (optionally after the time indicated
+                                  in the Retry-After header). \n Applied only if Name
+                                  is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                                type: string
+                              generation:
+                                description: A sequence number representing a specific
+                                  generation of the desired state. Populated by the
+                                  system. Read-only.
+                                format: int64
+                                type: integer
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: 'Map of string keys and values that can
+                                  be used to organize and categorize (scope and select)
+                                  objects. May match selectors of replication controllers
+                                  and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                              name:
+                                description: 'Name must be unique within a namespace.
+                                  Is required when creating resources, although some
+                                  resources may allow a client to request the generation
+                                  of an appropriate name automatically. Name is primarily
+                                  intended for creation idempotence and configuration
+                                  definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              namespace:
+                                description: "Namespace defines the space within each
+                                  name must be unique. An empty namespace is equivalent
+                                  to the \"default\" namespace, but \"default\" is
+                                  the canonical representation. Not all objects are
+                                  required to be scoped to a namespace - the value
+                                  of this field for those objects will be empty. \n
+                                  Must be a DNS_LABEL. Cannot be updated. More info:
+                                  http://kubernetes.io/docs/user-guide/namespaces"
+                                type: string
+                              ownerReferences:
+                                description: List of objects depended by this object.
+                                  If ALL objects in the list have been deleted, this
+                                  object will be garbage collected. If this object
+                                  is managed by a controller, then an entry in this
+                                  list will point to this controller, with the controller
+                                  field set to true. There cannot be more than one
+                                  managing controller.
+                                items:
+                                  description: OwnerReference contains enough information
+                                    to let you identify an owning object. An owning
+                                    object must be in the same namespace as the dependent,
+                                    or be cluster-scoped, so there is no namespace
+                                    field.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    blockOwnerDeletion:
+                                      description: If true, AND if the owner has the
+                                        "foregroundDeletion" finalizer, then the owner
+                                        cannot be deleted from the key-value store
+                                        until this reference is removed. Defaults
+                                        to false. To set this field, a user needs
+                                        "delete" permission of the owner, otherwise
+                                        422 (Unprocessable Entity) will be returned.
+                                      type: boolean
+                                    controller:
+                                      description: If true, this reference points
+                                        to the managing controller.
+                                      type: boolean
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  required:
+                                  - apiVersion
+                                  - kind
+                                  - name
+                                  - uid
+                                  type: object
+                                type: array
+                              resourceVersion:
+                                description: "An opaque value that represents the
+                                  internal version of this object that can be used
+                                  by clients to determine when objects have changed.
+                                  May be used for optimistic concurrency, change detection,
+                                  and the watch operation on a resource or set of
+                                  resources. Clients must treat these values as opaque
+                                  and passed unmodified back to the server. They may
+                                  only be valid for a particular resource or set of
+                                  resources. \n Populated by the system. Read-only.
+                                  Value must be treated as opaque by clients and .
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency"
+                                type: string
+                              selfLink:
+                                description: "SelfLink is a URL representing this
+                                  object. Populated by the system. Read-only. \n DEPRECATED
+                                  Kubernetes will stop propagating this field in 1.20
+                                  release and the field is planned to be removed in
+                                  1.21 release."
+                                type: string
+                              uid:
+                                description: "UID is the unique in time and space
+                                  value for this object. It is typically generated
+                                  by the server on successful creation of a resource
+                                  and is not allowed to change on PUT operations.
+                                  \n Populated by the system. Read-only. More info:
+                                  http://kubernetes.io/docs/user-guide/identifiers#uids"
+                                type: string
+                            type: object
+                          pdbSpec:
+                            properties:
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: An eviction is allowed if at most "maxUnavailable"
+                                  pods in the deployment corresponding to a componentSpec
+                                  are unavailable after the eviction, i.e. even in
+                                  absence of the evicted pod. For example, one can
+                                  prevent all voluntary evictions by specifying 0.
+                                  MaxUnavailable and MinAvailable are mutually exclusive.
+                                x-kubernetes-int-or-string: true
+                              minAvailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: An eviction is allowed if at least "minAvailable"
+                                  pods in the deployment corresponding to a componentSpec
+                                  will still be available after the eviction, i.e.
+                                  even in the absence of the evicted pod.  So for
+                                  example you can prevent all voluntary evictions
+                                  by specifying "100%".
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          replicas:
+                            format: int32
+                            type: integer
+                          spec:
+                            description: PodSpec is a description of a pod.
+                            properties:
+                              activeDeadlineSeconds:
+                                description: Optional duration in seconds the pod
+                                  may be active on the node relative to StartTime
+                                  before the system will actively try to mark it failed
+                                  and kill associated containers. Value must be a
+                                  positive integer.
+                                format: int64
+                                type: integer
+                              affinity:
+                                description: If specified, the pod's scheduling constraints
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is alpha-level and
+                                                    is only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is alpha-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is alpha-level and
+                                                    is only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is alpha-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                description: AutomountServiceAccountToken indicates
+                                  whether a service account token should be automatically
+                                  mounted.
+                                type: boolean
+                              containers:
+                                description: List of containers belonging to the pod.
+                                  Containers cannot currently be added or removed.
+                                  There must be at least one container in a Pod. Cannot
+                                  be updated.
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        docker image''s CMD is used if this is not
+                                        provided. Variable references $(VAR_NAME)
+                                        are expanded using the container''s environment.
+                                        If a variable cannot be resolved, the reference
+                                        in the input string will be unchanged. The
+                                        $(VAR_NAME) syntax can be escaped with a double
+                                        $$, ie: $$(VAR_NAME). Escaped references will
+                                        never be expanded, regardless of whether the
+                                        variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The docker image''s ENTRYPOINT
+                                        is used if this is not provided. Variable
+                                        references $(VAR_NAME) are expanded using
+                                        the container''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. The $(VAR_NAME)
+                                        syntax can be escaped with a double $$, ie:
+                                        $$(VAR_NAME). Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previous defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. The $(VAR_NAME) syntax can
+                                              be escaped with a double $$, ie: $$(VAR_NAME).
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the container. The keys defined
+                                        within a source must be a C_IDENTIFIER. All
+                                        invalid keys will be reported as an event
+                                        when the container is starting. When a key
+                                        exists in multiple sources, the value associated
+                                        with the last source will take precedence.
+                                        Values defined by an Env with a duplicate
+                                        key will take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                    image:
+                                      description: 'Docker image name. More info:
+                                        https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level
+                                        config management to default or override container
+                                        images in workload controllers like Deployments
+                                        and StatefulSets.'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: 'Image pull policy. One of Always,
+                                        Never, IfNotPresent. Defaults to Always if
+                                        :latest tag is specified, or IfNotPresent
+                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      type: string
+                                    lifecycle:
+                                      description: Actions that the management system
+                                        should take in response to container lifecycle
+                                        events. Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies an
+                                                action involving a TCP port. TCP hooks
+                                                not yet supported TODO: implement
+                                                a realistic TCP lifecycle hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The reason for termination is
+                                            passed to the handler. The Pod''s termination
+                                            grace period countdown begins before the
+                                            PreStop hooked is executed. Regardless
+                                            of the outcome of the handler, the container
+                                            will eventually terminate within the Pod''s
+                                            termination grace period. Other management
+                                            of the container blocks until the hook
+                                            completes or until the termination grace
+                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies an
+                                                action involving a TCP port. TCP hooks
+                                                not yet supported TODO: implement
+                                                a realistic TCP lifecycle hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: 'Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Name of the container specified
+                                        as a DNS_LABEL. Each container in a pod must
+                                        have a unique name (DNS_LABEL). Cannot be
+                                        updated.
+                                      type: string
+                                    ports:
+                                      description: List of ports to expose from the
+                                        container. Exposing a port here gives the
+                                        system additional information about the network
+                                        connections a container uses, but is primarily
+                                        informational. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed.
+                                        Any port which is listening on the default
+                                        "0.0.0.0" address inside a container will
+                                        be accessible from the network. Cannot be
+                                        updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: Protocol for port. Must be
+                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: 'Periodic probe of container service
+                                        readiness. Container will be removed from
+                                        service endpoints if the probe fails. Cannot
+                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: 'Compute Resources required by
+                                        this container. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: 'Security options the pod should
+                                        run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: 'StartupProbe indicates that the
+                                        Pod has successfully initialized. If specified,
+                                        no other probes are executed until this completes
+                                        successfully. If this probe fails, the Pod
+                                        will be restarted, just as if the livenessProbe
+                                        failed. This can be used to provide different
+                                        probe parameters at the beginning of a Pod''s
+                                        lifecycle, when it might take a long time
+                                        to load data or warm a cache, than during
+                                        steady-state operation. This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Whether this container should allocate
+                                        a buffer for stdin in the container runtime.
+                                        If this is not set, reads from stdin in the
+                                        container will always result in EOF. Default
+                                        is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Whether the container runtime should
+                                        close the stdin channel after it has been
+                                        opened by a single attach. When stdin is true
+                                        the stdin stream will remain open across multiple
+                                        attach sessions. If stdinOnce is set to true,
+                                        stdin is opened on container start, is empty
+                                        until the first client attaches to stdin,
+                                        and then remains open and accepts data until
+                                        the client disconnects, at which time stdin
+                                        is closed and remains closed until the container
+                                        is restarted. If this flag is false, a container
+                                        processes that reads from stdin will never
+                                        receive an EOF. Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: 'Optional: Path at which the file
+                                        to which the container''s termination message
+                                        will be written is mounted into the container''s
+                                        filesystem. Message written is intended to
+                                        be brief final status, such as an assertion
+                                        failure message. Will be truncated by the
+                                        node if greater than 4096 bytes. The total
+                                        message length across all containers will
+                                        be limited to 12kb. Defaults to /dev/termination-log.
+                                        Cannot be updated.'
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: Indicate how the termination message
+                                        should be populated. File will use the contents
+                                        of terminationMessagePath to populate the
+                                        container status message on both success and
+                                        failure. FallbackToLogsOnError will use the
+                                        last chunk of container log output if the
+                                        termination message file is empty and the
+                                        container exited with an error. The log output
+                                        is limited to 2048 bytes or 80 lines, whichever
+                                        is smaller. Defaults to File. Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: Whether this container should allocate
+                                        a TTY for itself, also requires 'stdin' to
+                                        be true. Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      description: Pod volumes to mount into the container's
+                                        filesystem. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      description: Container's working directory.
+                                        If not specified, the container runtime's
+                                        default will be used, which might be configured
+                                        in the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              dnsConfig:
+                                description: Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the
+                                  generated DNS configuration based on DNSPolicy.
+                                properties:
+                                  nameservers:
+                                    description: A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers
+                                      generated from DNSPolicy. Duplicated nameservers
+                                      will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                  options:
+                                    description: A list of DNS resolver options. This
+                                      will be merged with the base options generated
+                                      from DNSPolicy. Duplicated entries will be removed.
+                                      Resolution options given in Options will override
+                                      those that appear in the base DNSPolicy.
+                                    items:
+                                      description: PodDNSConfigOption defines DNS
+                                        resolver options of a pod.
+                                      properties:
+                                        name:
+                                          description: Required.
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  searches:
+                                    description: A list of DNS search domains for
+                                      host-name lookup. This will be appended to the
+                                      base search paths generated from DNSPolicy.
+                                      Duplicated search paths will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              dnsPolicy:
+                                description: Set DNS policy for the pod. Defaults
+                                  to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
+                                  'ClusterFirst', 'Default' or 'None'. DNS parameters
+                                  given in DNSConfig will be merged with the policy
+                                  selected with DNSPolicy. To have DNS options set
+                                  along with hostNetwork, you have to specify DNS
+                                  policy explicitly to 'ClusterFirstWithHostNet'.
+                                type: string
+                              enableServiceLinks:
+                                description: 'EnableServiceLinks indicates whether
+                                  information about services should be injected into
+                                  pod''s environment variables, matching the syntax
+                                  of Docker links. Optional: Defaults to true.'
+                                type: boolean
+                              ephemeralContainers:
+                                description: List of ephemeral containers run in this
+                                  pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging.
+                                  This list cannot be specified when creating a pod,
+                                  and it cannot be modified by updating the pod spec.
+                                  In order to add an ephemeral container to an existing
+                                  pod, use the pod's ephemeralcontainers subresource.
+                                  This field is alpha-level and is only honored by
+                                  servers that enable the EphemeralContainers feature.
+                                items:
+                                  description: An EphemeralContainer is a container
+                                    that may be added temporarily to an existing pod
+                                    for user-initiated activities such as debugging.
+                                    Ephemeral containers have no resource or scheduling
+                                    guarantees, and they will not be restarted when
+                                    they exit or when a pod is removed or restarted.
+                                    If an ephemeral container causes a pod to exceed
+                                    its resource allocation, the pod may be evicted.
+                                    Ephemeral containers may not be added by directly
+                                    updating the pod spec. They must be added via
+                                    the pod's ephemeralcontainers subresource, and
+                                    they will appear in the pod spec once added. This
+                                    is an alpha feature enabled by the EphemeralContainers
+                                    feature flag.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        docker image''s CMD is used if this is not
+                                        provided. Variable references $(VAR_NAME)
+                                        are expanded using the container''s environment.
+                                        If a variable cannot be resolved, the reference
+                                        in the input string will be unchanged. The
+                                        $(VAR_NAME) syntax can be escaped with a double
+                                        $$, ie: $$(VAR_NAME). Escaped references will
+                                        never be expanded, regardless of whether the
+                                        variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The docker image''s ENTRYPOINT
+                                        is used if this is not provided. Variable
+                                        references $(VAR_NAME) are expanded using
+                                        the container''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. The $(VAR_NAME)
+                                        syntax can be escaped with a double $$, ie:
+                                        $$(VAR_NAME). Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previous defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. The $(VAR_NAME) syntax can
+                                              be escaped with a double $$, ie: $$(VAR_NAME).
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the container. The keys defined
+                                        within a source must be a C_IDENTIFIER. All
+                                        invalid keys will be reported as an event
+                                        when the container is starting. When a key
+                                        exists in multiple sources, the value associated
+                                        with the last source will take precedence.
+                                        Values defined by an Env with a duplicate
+                                        key will take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                    image:
+                                      description: 'Docker image name. More info:
+                                        https://kubernetes.io/docs/concepts/containers/images'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: 'Image pull policy. One of Always,
+                                        Never, IfNotPresent. Defaults to Always if
+                                        :latest tag is specified, or IfNotPresent
+                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      type: string
+                                    lifecycle:
+                                      description: Lifecycle is not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies an
+                                                action involving a TCP port. TCP hooks
+                                                not yet supported TODO: implement
+                                                a realistic TCP lifecycle hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The reason for termination is
+                                            passed to the handler. The Pod''s termination
+                                            grace period countdown begins before the
+                                            PreStop hooked is executed. Regardless
+                                            of the outcome of the handler, the container
+                                            will eventually terminate within the Pod''s
+                                            termination grace period. Other management
+                                            of the container blocks until the hook
+                                            completes or until the termination grace
+                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies an
+                                                action involving a TCP port. TCP hooks
+                                                not yet supported TODO: implement
+                                                a realistic TCP lifecycle hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Name of the ephemeral container
+                                        specified as a DNS_LABEL. This name must be
+                                        unique among all containers, init containers
+                                        and ephemeral containers.
+                                      type: string
+                                    ports:
+                                      description: Ports are not allowed for ephemeral
+                                        containers.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: Protocol for port. Must be
+                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                    readinessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: Resources are not allowed for ephemeral
+                                        containers. Ephemeral containers use spare
+                                        resources already allocated to the pod.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: SecurityContext is not allowed
+                                        for ephemeral containers.
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Whether this container should allocate
+                                        a buffer for stdin in the container runtime.
+                                        If this is not set, reads from stdin in the
+                                        container will always result in EOF. Default
+                                        is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Whether the container runtime should
+                                        close the stdin channel after it has been
+                                        opened by a single attach. When stdin is true
+                                        the stdin stream will remain open across multiple
+                                        attach sessions. If stdinOnce is set to true,
+                                        stdin is opened on container start, is empty
+                                        until the first client attaches to stdin,
+                                        and then remains open and accepts data until
+                                        the client disconnects, at which time stdin
+                                        is closed and remains closed until the container
+                                        is restarted. If this flag is false, a container
+                                        processes that reads from stdin will never
+                                        receive an EOF. Default is false
+                                      type: boolean
+                                    targetContainerName:
+                                      description: If set, the name of the container
+                                        from PodSpec that this ephemeral container
+                                        targets. The ephemeral container will be run
+                                        in the namespaces (IPC, PID, etc) of this
+                                        container. If not set then the ephemeral container
+                                        is run in whatever namespaces are shared for
+                                        the pod. Note that the container runtime must
+                                        support this feature.
+                                      type: string
+                                    terminationMessagePath:
+                                      description: 'Optional: Path at which the file
+                                        to which the container''s termination message
+                                        will be written is mounted into the container''s
+                                        filesystem. Message written is intended to
+                                        be brief final status, such as an assertion
+                                        failure message. Will be truncated by the
+                                        node if greater than 4096 bytes. The total
+                                        message length across all containers will
+                                        be limited to 12kb. Defaults to /dev/termination-log.
+                                        Cannot be updated.'
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: Indicate how the termination message
+                                        should be populated. File will use the contents
+                                        of terminationMessagePath to populate the
+                                        container status message on both success and
+                                        failure. FallbackToLogsOnError will use the
+                                        last chunk of container log output if the
+                                        termination message file is empty and the
+                                        container exited with an error. The log output
+                                        is limited to 2048 bytes or 80 lines, whichever
+                                        is smaller. Defaults to File. Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: Whether this container should allocate
+                                        a TTY for itself, also requires 'stdin' to
+                                        be true. Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      description: Pod volumes to mount into the container's
+                                        filesystem. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      description: Container's working directory.
+                                        If not specified, the container runtime's
+                                        default will be used, which might be configured
+                                        in the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              hostAliases:
+                                description: HostAliases is an optional list of hosts
+                                  and IPs that will be injected into the pod's hosts
+                                  file if specified. This is only valid for non-hostNetwork
+                                  pods.
+                                items:
+                                  description: HostAlias holds the mapping between
+                                    IP and hostnames that will be injected as an entry
+                                    in the pod's hosts file.
+                                  properties:
+                                    hostnames:
+                                      description: Hostnames for the above IP address.
+                                      items:
+                                        type: string
+                                      type: array
+                                    ip:
+                                      description: IP address of the host file entry.
+                                      type: string
+                                  type: object
+                                type: array
+                              hostIPC:
+                                description: 'Use the host''s ipc namespace. Optional:
+                                  Default to false.'
+                                type: boolean
+                              hostNetwork:
+                                description: Host networking requested for this pod.
+                                  Use the host's network namespace. If this option
+                                  is set, the ports that will be used must be specified.
+                                  Default to false.
+                                type: boolean
+                              hostPID:
+                                description: 'Use the host''s pid namespace. Optional:
+                                  Default to false.'
+                                type: boolean
+                              hostname:
+                                description: Specifies the hostname of the Pod If
+                                  not specified, the pod's hostname will be set to
+                                  a system-defined value.
+                                type: string
+                              imagePullSecrets:
+                                description: 'ImagePullSecrets is an optional list
+                                  of references to secrets in the same namespace to
+                                  use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual
+                                  puller implementations for them to use. For example,
+                                  in the case of docker, only DockerConfig type secrets
+                                  are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                items:
+                                  description: LocalObjectReference contains enough
+                                    information to let you locate the referenced object
+                                    inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                type: array
+                              initContainers:
+                                description: 'List of initialization containers belonging
+                                  to the pod. Init containers are executed in order
+                                  prior to containers being started. If any init container
+                                  fails, the pod is considered to have failed and
+                                  is handled according to its restartPolicy. The name
+                                  for an init container or normal container must be
+                                  unique among all containers. Init containers may
+                                  not have Lifecycle actions, Readiness probes, Liveness
+                                  probes, or Startup probes. The resourceRequirements
+                                  of an init container are taken into account during
+                                  scheduling by finding the highest request/limit
+                                  for each resource type, and then using the max of
+                                  of that value or the sum of the normal containers.
+                                  Limits are applied to init containers in a similar
+                                  fashion. Init containers cannot currently be added
+                                  or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        docker image''s CMD is used if this is not
+                                        provided. Variable references $(VAR_NAME)
+                                        are expanded using the container''s environment.
+                                        If a variable cannot be resolved, the reference
+                                        in the input string will be unchanged. The
+                                        $(VAR_NAME) syntax can be escaped with a double
+                                        $$, ie: $$(VAR_NAME). Escaped references will
+                                        never be expanded, regardless of whether the
+                                        variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The docker image''s ENTRYPOINT
+                                        is used if this is not provided. Variable
+                                        references $(VAR_NAME) are expanded using
+                                        the container''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. The $(VAR_NAME)
+                                        syntax can be escaped with a double $$, ie:
+                                        $$(VAR_NAME). Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previous defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. The $(VAR_NAME) syntax can
+                                              be escaped with a double $$, ie: $$(VAR_NAME).
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the container. The keys defined
+                                        within a source must be a C_IDENTIFIER. All
+                                        invalid keys will be reported as an event
+                                        when the container is starting. When a key
+                                        exists in multiple sources, the value associated
+                                        with the last source will take precedence.
+                                        Values defined by an Env with a duplicate
+                                        key will take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                    image:
+                                      description: 'Docker image name. More info:
+                                        https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level
+                                        config management to default or override container
+                                        images in workload controllers like Deployments
+                                        and StatefulSets.'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: 'Image pull policy. One of Always,
+                                        Never, IfNotPresent. Defaults to Always if
+                                        :latest tag is specified, or IfNotPresent
+                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      type: string
+                                    lifecycle:
+                                      description: Actions that the management system
+                                        should take in response to container lifecycle
+                                        events. Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies an
+                                                action involving a TCP port. TCP hooks
+                                                not yet supported TODO: implement
+                                                a realistic TCP lifecycle hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The reason for termination is
+                                            passed to the handler. The Pod''s termination
+                                            grace period countdown begins before the
+                                            PreStop hooked is executed. Regardless
+                                            of the outcome of the handler, the container
+                                            will eventually terminate within the Pod''s
+                                            termination grace period. Other management
+                                            of the container blocks until the hook
+                                            completes or until the termination grace
+                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: One and only one of the
+                                                following should be specified. Exec
+                                                specifies the action to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: 'TCPSocket specifies an
+                                                action involving a TCP port. TCP hooks
+                                                not yet supported TODO: implement
+                                                a realistic TCP lifecycle hook'
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: 'Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Name of the container specified
+                                        as a DNS_LABEL. Each container in a pod must
+                                        have a unique name (DNS_LABEL). Cannot be
+                                        updated.
+                                      type: string
+                                    ports:
+                                      description: List of ports to expose from the
+                                        container. Exposing a port here gives the
+                                        system additional information about the network
+                                        connections a container uses, but is primarily
+                                        informational. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed.
+                                        Any port which is listening on the default
+                                        "0.0.0.0" address inside a container will
+                                        be accessible from the network. Cannot be
+                                        updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: Protocol for port. Must be
+                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: 'Periodic probe of container service
+                                        readiness. Container will be removed from
+                                        service endpoints if the probe fails. Cannot
+                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: 'Compute Resources required by
+                                        this container. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: 'Security options the pod should
+                                        run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: 'StartupProbe indicates that the
+                                        Pod has successfully initialized. If specified,
+                                        no other probes are executed until this completes
+                                        successfully. If this probe fails, the Pod
+                                        will be restarted, just as if the livenessProbe
+                                        failed. This can be used to provide different
+                                        probe parameters at the beginning of a Pod''s
+                                        lifecycle, when it might take a long time
+                                        to load data or warm a cache, than during
+                                        steady-state operation. This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: 'TCPSocket specifies an action
+                                            involving a TCP port. TCP hooks not yet
+                                            supported TODO: implement a realistic
+                                            TCP lifecycle hook'
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is an alpha field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Whether this container should allocate
+                                        a buffer for stdin in the container runtime.
+                                        If this is not set, reads from stdin in the
+                                        container will always result in EOF. Default
+                                        is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Whether the container runtime should
+                                        close the stdin channel after it has been
+                                        opened by a single attach. When stdin is true
+                                        the stdin stream will remain open across multiple
+                                        attach sessions. If stdinOnce is set to true,
+                                        stdin is opened on container start, is empty
+                                        until the first client attaches to stdin,
+                                        and then remains open and accepts data until
+                                        the client disconnects, at which time stdin
+                                        is closed and remains closed until the container
+                                        is restarted. If this flag is false, a container
+                                        processes that reads from stdin will never
+                                        receive an EOF. Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: 'Optional: Path at which the file
+                                        to which the container''s termination message
+                                        will be written is mounted into the container''s
+                                        filesystem. Message written is intended to
+                                        be brief final status, such as an assertion
+                                        failure message. Will be truncated by the
+                                        node if greater than 4096 bytes. The total
+                                        message length across all containers will
+                                        be limited to 12kb. Defaults to /dev/termination-log.
+                                        Cannot be updated.'
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: Indicate how the termination message
+                                        should be populated. File will use the contents
+                                        of terminationMessagePath to populate the
+                                        container status message on both success and
+                                        failure. FallbackToLogsOnError will use the
+                                        last chunk of container log output if the
+                                        termination message file is empty and the
+                                        container exited with an error. The log output
+                                        is limited to 2048 bytes or 80 lines, whichever
+                                        is smaller. Defaults to File. Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: Whether this container should allocate
+                                        a TTY for itself, also requires 'stdin' to
+                                        be true. Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      description: Pod volumes to mount into the container's
+                                        filesystem. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      description: Container's working directory.
+                                        If not specified, the container runtime's
+                                        default will be used, which might be configured
+                                        in the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeName:
+                                description: NodeName is a request to schedule this
+                                  pod onto a specific node. If it is non-empty, the
+                                  scheduler simply schedules this pod onto that node,
+                                  assuming that it fits resource requirements.
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is a selector which must
+                                  be true for the pod to fit on a node. Selector which
+                                  must match a node''s labels for the pod to be scheduled
+                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Overhead represents the resource overhead
+                                  associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time
+                                  by the RuntimeClass admission controller. If the
+                                  RuntimeClass admission controller is enabled, overhead
+                                  must not be set in Pod create requests. The RuntimeClass
+                                  admission controller will reject Pod create requests
+                                  which have the overhead already set. If RuntimeClass
+                                  is configured and selected in the PodSpec, Overhead
+                                  will be set to the value defined in the corresponding
+                                  RuntimeClass, otherwise it will remain unset and
+                                  treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                                  This field is alpha-level as of Kubernetes v1.16,
+                                  and is only honored by servers that enable the PodOverhead
+                                  feature.'
+                                type: object
+                              preemptionPolicy:
+                                description: PreemptionPolicy is the Policy for preempting
+                                  pods with lower priority. One of Never, PreemptLowerPriority.
+                                  Defaults to PreemptLowerPriority if unset. This
+                                  field is beta-level, gated by the NonPreemptingPriority
+                                  feature-gate.
+                                type: string
+                              priority:
+                                description: The priority value. Various system components
+                                  use this field to find the priority of the pod.
+                                  When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission
+                                  controller populates this field from PriorityClassName.
+                                  The higher the value, the higher the priority.
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                description: If specified, indicates the pod's priority.
+                                  "system-node-critical" and "system-cluster-critical"
+                                  are two special keywords which indicate the highest
+                                  priorities with the former being the highest priority.
+                                  Any other name must be defined by creating a PriorityClass
+                                  object with that name. If not specified, the pod
+                                  priority will be default or zero if there is no
+                                  default.
+                                type: string
+                              readinessGates:
+                                description: 'If specified, all readiness gates will
+                                  be evaluated for pod readiness. A pod is ready when
+                                  all its containers are ready AND all conditions
+                                  specified in the readiness gates have status equal
+                                  to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                items:
+                                  description: PodReadinessGate contains the reference
+                                    to a pod condition
+                                  properties:
+                                    conditionType:
+                                      description: ConditionType refers to a condition
+                                        in the pod's condition list with matching
+                                        type.
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                              restartPolicy:
+                                description: 'Restart policy for all containers within
+                                  the pod. One of Always, OnFailure, Never. Default
+                                  to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                                type: string
+                              runtimeClassName:
+                                description: 'RuntimeClassName refers to a RuntimeClass
+                                  object in the node.k8s.io group, which should be
+                                  used to run this pod.  If no RuntimeClass resource
+                                  matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will
+                                  be used, which is an implicit class with an empty
+                                  definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                                  This is a beta feature as of Kubernetes v1.14.'
+                                type: string
+                              schedulerName:
+                                description: If specified, the pod will be dispatched
+                                  by specified scheduler. If not specified, the pod
+                                  will be dispatched by default scheduler.
+                                type: string
+                              securityContext:
+                                description: 'SecurityContext holds pod-level security
+                                  attributes and common container settings. Optional:
+                                  Defaults to empty.  See type description for default
+                                  values of each field.'
+                                properties:
+                                  fsGroup:
+                                    description: "A special supplemental group that
+                                      applies to all containers in a pod. Some volume
+                                      types allow the Kubelet to change the ownership
+                                      of that volume to be owned by the pod: \n 1.
+                                      The owning GID will be the FSGroup 2. The setgid
+                                      bit is set (new files created in the volume
+                                      will be owned by FSGroup) 3. The permission
+                                      bits are OR'd with rw-rw---- \n If unset, the
+                                      Kubelet will not modify the ownership and permissions
+                                      of any volume."
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    description: 'fsGroupChangePolicy defines behavior
+                                      of changing ownership and permission of the
+                                      volume before being exposed inside Pod. This
+                                      field will only apply to volume types which
+                                      support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types
+                                      such as: secret, configmaps and emptydir. Valid
+                                      values are "OnRootMismatch" and "Always". If
+                                      not specified, "Always" is used.'
+                                    type: string
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of
+                                      the container process. Uses runtime default
+                                      if unset. May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence for that container.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must
+                                      run as a non-root user. If true, the Kubelet
+                                      will validate the image at runtime to ensure
+                                      that it does not run as UID 0 (root) and fail
+                                      to start the container if it does. If unset
+                                      or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of
+                                      the container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in SecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified
+                                      in SecurityContext takes precedence for that
+                                      container.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied
+                                      to all containers. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence for that container.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by the
+                                      containers in this pod.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a
+                                          profile defined in a file on the node should
+                                          be used. The profile must be preconfigured
+                                          on the node to work. Must be a descending
+                                          path, relative to the kubelet's configured
+                                          seccomp profile location. Must only be set
+                                          if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of
+                                          seccomp profile will be applied. Valid options
+                                          are: \n Localhost - a profile defined in
+                                          a file on the node should be used. RuntimeDefault
+                                          - the container runtime default profile
+                                          should be used. Unconfined - no profile
+                                          should be applied."
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    description: A list of groups applied to the first
+                                      process run in each container, in addition to
+                                      the container's primary GID.  If unspecified,
+                                      no groups will be added to any container.
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                  sysctls:
+                                    description: Sysctls hold a list of namespaced
+                                      sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail
+                                      to launch.
+                                    items:
+                                      description: Sysctl defines a kernel parameter
+                                        to be set
+                                      properties:
+                                        name:
+                                          description: Name of a property to set
+                                          type: string
+                                        value:
+                                          description: Value of a property to set
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      within a container's SecurityContext will be
+                                      used. If set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName
+                                          field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process.
+                                          Defaults to the user specified in image
+                                          metadata if unspecified. May also be set
+                                          in PodSecurityContext. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                description: 'DeprecatedServiceAccount is a depreciated
+                                  alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                  instead.'
+                                type: string
+                              serviceAccountName:
+                                description: 'ServiceAccountName is the name of the
+                                  ServiceAccount to use to run this pod. More info:
+                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                                type: string
+                              setHostnameAsFQDN:
+                                description: If true the pod's hostname will be configured
+                                  as the pod's FQDN, rather than the leaf name (the
+                                  default). In Linux containers, this means setting
+                                  the FQDN in the hostname field of the kernel (the
+                                  nodename field of struct utsname). In Windows containers,
+                                  this means setting the registry value of hostname
+                                  for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
+                                  to FQDN. If a pod does not have FQDN, this has no
+                                  effect. Default to false.
+                                type: boolean
+                              shareProcessNamespace:
+                                description: 'Share a single process namespace between
+                                  all of the containers in a pod. When this is set
+                                  containers will be able to view and signal processes
+                                  from other containers in the same pod, and the first
+                                  process in each container will not be assigned PID
+                                  1. HostPID and ShareProcessNamespace cannot both
+                                  be set. Optional: Default to false.'
+                                type: boolean
+                              subdomain:
+                                description: If specified, the fully qualified Pod
+                                  hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                  domain>". If not specified, the pod will not have
+                                  a domainname at all.
+                                type: string
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully. May be decreased
+                                  in delete request. Value must be non-negative integer.
+                                  The value zero indicates stop immediately via the
+                                  kill signal (no opportunity to shut down). If this
+                                  value is nil, the default grace period will be used
+                                  instead. The grace period is the duration in seconds
+                                  after the processes running in the pod are sent
+                                  a termination signal and the time when the processes
+                                  are forcibly halted with a kill signal. Set this
+                                  value longer than the expected cleanup time for
+                                  your process. Defaults to 30 seconds.
+                                format: int64
+                                type: integer
+                              tolerations:
+                                description: If specified, the pod's tolerations.
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                              topologySpreadConstraints:
+                                description: TopologySpreadConstraints describes how
+                                  a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which
+                                  abides by the constraints. All topologySpreadConstraints
+                                  are ANDed.
+                                items:
+                                  description: TopologySpreadConstraint specifies
+                                    how to spread matching pods among the given topology.
+                                  properties:
+                                    labelSelector:
+                                      description: LabelSelector is used to find matching
+                                        pods. Pods that match this label selector
+                                        are counted to determine the number of pods
+                                        in their corresponding topology domain.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    maxSkew:
+                                      description: 'MaxSkew describes the degree to
+                                        which pods may be unevenly distributed. When
+                                        `whenUnsatisfiable=DoNotSchedule`, it is the
+                                        maximum permitted difference between the number
+                                        of matching pods in the target topology and
+                                        the global minimum. For example, in a 3-zone
+                                        cluster, MaxSkew is set to 1, and pods with
+                                        the same labelSelector spread as 1/1/0: |
+                                        zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                        - if MaxSkew is 1, incoming pod can only be
+                                        scheduled to zone3 to become 1/1/1; scheduling
+                                        it onto zone1(zone2) would make the ActualSkew(2-0)
+                                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew
+                                        is 2, incoming pod can be scheduled onto any
+                                        zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                        it is used to give higher precedence to topologies
+                                        that satisfy it. It''s a required field. Default
+                                        value is 1 and 0 is not allowed.'
+                                      format: int32
+                                      type: integer
+                                    topologyKey:
+                                      description: TopologyKey is the key of node
+                                        labels. Nodes that have a label with this
+                                        key and identical values are considered to
+                                        be in the same topology. We consider each
+                                        <key, value> as a "bucket", and try to put
+                                        balanced number of pods into each bucket.
+                                        It's a required field.
+                                      type: string
+                                    whenUnsatisfiable:
+                                      description: 'WhenUnsatisfiable indicates how
+                                        to deal with a pod if it doesn''t satisfy
+                                        the spread constraint. - DoNotSchedule (default)
+                                        tells the scheduler not to schedule it. -
+                                        ScheduleAnyway tells the scheduler to schedule
+                                        the pod in any location,   but giving higher
+                                        precedence to topologies that would help reduce
+                                        the   skew. A constraint is considered "Unsatisfiable"
+                                        for an incoming pod if and only if every possible
+                                        node assigment for that pod would violate
+                                        "MaxSkew" on some topology. For example, in
+                                        a 3-zone cluster, MaxSkew is set to 1, and
+                                        pods with the same labelSelector spread as
+                                        3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule,
+                                        incoming pod can only be scheduled to zone2(zone3)
+                                        to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                        on zone2(zone3) satisfies MaxSkew(1). In other
+                                        words, the cluster can still be imbalanced,
+                                        but scheduler won''t make it *more* imbalanced.
+                                        It''s a required field.'
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                description: 'List of volumes that can be mounted
+                                  by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                                items:
+                                  description: Volume represents a named volume in
+                                    a pod that may be accessed by any container in
+                                    the pod.
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: 'AWSElasticBlockStore represents
+                                        an AWS Disk resource that is attached to a
+                                        kubelet''s host machine and then exposed to
+                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      properties:
+                                        fsType:
+                                          description: 'Filesystem type of the volume
+                                            that you want to mount. Tip: Ensure that
+                                            the filesystem type is supported by the
+                                            host operating system. Examples: "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'The partition in the volume
+                                            that you want to mount. If omitted, the
+                                            default is to mount by volume name. Examples:
+                                            For volume /dev/sda1, you specify the
+                                            partition as "1". Similarly, the volume
+                                            partition for /dev/sda is "0" (or you
+                                            can leave the property empty).'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'Specify "true" to force and
+                                            set the ReadOnly property in VolumeMounts
+                                            to "true". If omitted, the default is
+                                            "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: boolean
+                                        volumeID:
+                                          description: 'Unique ID of the persistent
+                                            disk resource in AWS (Amazon EBS volume).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: AzureDisk represents an Azure Data
+                                        Disk mount on the host and bind mount to the
+                                        pod.
+                                      properties:
+                                        cachingMode:
+                                          description: 'Host Caching mode: None, Read
+                                            Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: The Name of the data disk in
+                                            the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: The URI the data disk in the
+                                            blob storage
+                                          type: string
+                                        fsType:
+                                          description: Filesystem type to mount. Must
+                                            be a filesystem type supported by the
+                                            host operating system. Ex. "ext4", "xfs",
+                                            "ntfs". Implicitly inferred to be "ext4"
+                                            if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'Expected values Shared: multiple
+                                            blob disks per storage account  Dedicated:
+                                            single blob disk per storage account  Managed:
+                                            azure managed data disk (only in managed
+                                            availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          description: Defaults to false (read/write).
+                                            ReadOnly here will force the ReadOnly
+                                            setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: AzureFile represents an Azure File
+                                        Service mount on the host and bind mount to
+                                        the pod.
+                                      properties:
+                                        readOnly:
+                                          description: Defaults to false (read/write).
+                                            ReadOnly here will force the ReadOnly
+                                            setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: the name of secret that contains
+                                            Azure Storage Account Name and Key
+                                          type: string
+                                        shareName:
+                                          description: Share Name
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      description: CephFS represents a Ceph FS mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        monitors:
+                                          description: 'Required: Monitors is a collection
+                                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          description: 'Optional: Used as the mounted
+                                            root, rather than the full Ceph tree,
+                                            default is /'
+                                          type: string
+                                        readOnly:
+                                          description: 'Optional: Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretFile:
+                                          description: 'Optional: SecretFile is the
+                                            path to key ring for User, default is
+                                            /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                        secretRef:
+                                          description: 'Optional: SecretRef is reference
+                                            to the authentication secret for User,
+                                            default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'Optional: User is the rados
+                                            user name, default is admin More info:
+                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      description: 'Cinder represents a cinder volume
+                                        attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'Filesystem type to mount.
+                                            Must be a filesystem type supported by
+                                            the host operating system. Examples: "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                        readOnly:
+                                          description: 'Optional: Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'Optional: points to a secret
+                                            object containing parameters used to connect
+                                            to OpenStack.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        volumeID:
+                                          description: 'volume id used to identify
+                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      description: ConfigMap represents a configMap
+                                        that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on created files by default.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. Defaults to 0644. Directories
+                                            within the path are not affected by this
+                                            setting. This might be in conflict with
+                                            other options that affect the file mode,
+                                            like fsGroup, and the result can be other
+                                            mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed
+                                            keys will be projected into the specified
+                                            paths, and unlisted keys will not be present.
+                                            If a key is specified which is not present
+                                            in the ConfigMap, the volume setup will
+                                            error unless it is marked optional. Paths
+                                            must be relative and may not contain the
+                                            '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file. Must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of
+                                                  the file to map the key to. May
+                                                  not be an absolute path. May not
+                                                  contain the path element '..'. May
+                                                  not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    csi:
+                                      description: CSI (Container Storage Interface)
+                                        represents ephemeral storage that is handled
+                                        by certain external CSI drivers (Beta feature).
+                                      properties:
+                                        driver:
+                                          description: Driver is the name of the CSI
+                                            driver that handles this volume. Consult
+                                            with your admin for the correct name as
+                                            registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: Filesystem type to mount. Ex.
+                                            "ext4", "xfs", "ntfs". If not provided,
+                                            the empty value is passed to the associated
+                                            CSI driver which will determine the default
+                                            filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: NodePublishSecretRef is a reference
+                                            to the secret object containing sensitive
+                                            information to pass to the CSI driver
+                                            to complete the CSI NodePublishVolume
+                                            and NodeUnpublishVolume calls. This field
+                                            is optional, and  may be empty if no secret
+                                            is required. If the secret object contains
+                                            more than one secret, all secret references
+                                            are passed.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        readOnly:
+                                          description: Specifies a read-only configuration
+                                            for the volume. Defaults to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: VolumeAttributes stores driver-specific
+                                            properties that are passed to the CSI
+                                            driver. Consult your driver's documentation
+                                            for supported values.
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: DownwardAPI represents downward
+                                        API about the pod that should populate this
+                                        volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits to use
+                                            on created files by default. Must be a
+                                            Optional: mode bits used to set permissions
+                                            on created files by default. Must be an
+                                            octal value between 0000 and 0777 or a
+                                            decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. Defaults to 0644. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward
+                                            API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      description: 'EmptyDir represents a temporary
+                                        directory that shares a pod''s lifetime. More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      properties:
+                                        medium:
+                                          description: 'What type of storage medium
+                                            should back this directory. The default
+                                            is "" which means to use the node''s default
+                                            medium. Must be an empty string (default)
+                                            or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'Total amount of local storage
+                                            required for this EmptyDir volume. The
+                                            size limit is also applicable for memory
+                                            medium. The maximum usage on memory medium
+                                            EmptyDir would be the minimum value between
+                                            the SizeLimit specified here and the sum
+                                            of memory limits of all containers in
+                                            a pod. The default is nil which means
+                                            that the limit is undefined. More info:
+                                            http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: "Ephemeral represents a volume
+                                        that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod
+                                        that defines it - it will be created before
+                                        the pod starts, and deleted when the pod is
+                                        removed. \n Use this if: a) the volume is
+                                        only needed while the pod runs, b) features
+                                        of normal volumes like restoring from snapshot
+                                        or capacity    tracking are needed, c) the
+                                        storage driver is specified through a storage
+                                        class, and d) the storage driver supports
+                                        dynamic volume provisioning through    a PersistentVolumeClaim
+                                        (see EphemeralVolumeSource for more    information
+                                        on the connection between this volume type
+                                        \   and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                                        or one of the vendor-specific APIs for volumes
+                                        that persist for longer than the lifecycle
+                                        of an individual pod. \n Use CSI for light-weight
+                                        local ephemeral volumes if the CSI driver
+                                        is meant to be used that way - see the documentation
+                                        of the driver for more information. \n A pod
+                                        can use both types of ephemeral volumes and
+                                        persistent volumes at the same time. \n This
+                                        is a beta feature and only available when
+                                        the GenericEphemeralVolume feature gate is
+                                        enabled."
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: "Will be used to create a stand-alone
+                                            PVC to provision the volume. The pod in
+                                            which this EphemeralVolumeSource is embedded
+                                            will be the owner of the PVC, i.e. the
+                                            PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod
+                                            name>-<volume name>` where `<volume name>`
+                                            is the name from the `PodSpec.Volumes`
+                                            array entry. Pod validation will reject
+                                            the pod if the concatenated name is not
+                                            valid for a PVC (for example, too long).
+                                            \n An existing PVC with that name that
+                                            is not owned by the pod will *not* be
+                                            used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is
+                                            then blocked until the unrelated PVC is
+                                            removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has
+                                            to updated with an owner reference to
+                                            the pod once the pod exists. Normally
+                                            this should not be necessary, but it may
+                                            be useful when manually reconstructing
+                                            a broken cluster. \n This field is read-only
+                                            and no changes will be made by Kubernetes
+                                            to the PVC after it has been created.
+                                            \n Required, must not be nil."
+                                          properties:
+                                            metadata:
+                                              description: May contain labels and
+                                                annotations that will be copied into
+                                                the PVC when creating it. No other
+                                                fields are allowed and will be rejected
+                                                during validation.
+                                              type: object
+                                            spec:
+                                              description: The specification for the
+                                                PersistentVolumeClaim. The entire
+                                                content is copied unchanged into the
+                                                PVC that gets created from this template.
+                                                The same fields as in a PersistentVolumeClaim
+                                                are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: 'AccessModes contains
+                                                    the desired access modes the volume
+                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  description: 'This field can be
+                                                    used to specify either: * An existing
+                                                    VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    * An existing custom resource
+                                                    that implements data population
+                                                    (Alpha) In order to use custom
+                                                    resource types that implement
+                                                    data population, the AnyVolumeDataSource
+                                                    feature gate must be enabled.
+                                                    If the provisioner or an external
+                                                    controller can support the specified
+                                                    data source, it will create a
+                                                    new volume based on the contents
+                                                    of the specified data source.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  description: 'Resources represents
+                                                    the minimum resources the volume
+                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes
+                                                        the maximum amount of compute
+                                                        resources allowed. More info:
+                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Requests describes
+                                                        the minimum amount of compute
+                                                        resources required. If Requests
+                                                        is omitted for a container,
+                                                        it defaults to Limits if that
+                                                        is explicitly specified, otherwise
+                                                        to an implementation-defined
+                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: A label query over
+                                                    volumes to consider for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                storageClassName:
+                                                  description: 'Name of the StorageClass
+                                                    required by the claim. More info:
+                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeMode:
+                                                  description: volumeMode defines
+                                                    what type of volume is required
+                                                    by the claim. Value of Filesystem
+                                                    is implied when not included in
+                                                    claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: VolumeName is the binding
+                                                    reference to the PersistentVolume
+                                                    backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: FC represents a Fibre Channel resource
+                                        that is attached to a kubelet's host machine
+                                        and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: 'Filesystem type to mount.
+                                            Must be a filesystem type supported by
+                                            the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. TODO: how do
+                                            we prevent errors in the filesystem from
+                                            compromising the machine'
+                                          type: string
+                                        lun:
+                                          description: 'Optional: FC target lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'Optional: Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'Optional: FC target worldwide
+                                            names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          description: 'Optional: FC volume world
+                                            wide identifiers (wwids) Either wwids
+                                            or combination of targetWWNs and lun must
+                                            be set, but not both simultaneously.'
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      description: FlexVolume represents a generic
+                                        volume resource that is provisioned/attached
+                                        using an exec based plugin.
+                                      properties:
+                                        driver:
+                                          description: Driver is the name of the driver
+                                            to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: Filesystem type to mount. Must
+                                            be a filesystem type supported by the
+                                            host operating system. Ex. "ext4", "xfs",
+                                            "ntfs". The default filesystem depends
+                                            on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'Optional: Extra command options
+                                            if any.'
+                                          type: object
+                                        readOnly:
+                                          description: 'Optional: Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'Optional: SecretRef is reference
+                                            to the secret object containing sensitive
+                                            information to pass to the plugin scripts.
+                                            This may be empty if no secret object
+                                            is specified. If the secret object contains
+                                            more than one secret, all secrets are
+                                            passed to the plugin scripts.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      description: Flocker represents a Flocker volume
+                                        attached to a kubelet's host machine. This
+                                        depends on the Flocker control service being
+                                        running
+                                      properties:
+                                        datasetName:
+                                          description: Name of the dataset stored
+                                            as metadata -> name on the dataset for
+                                            Flocker should be considered as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: UUID of the dataset. This is
+                                            unique identifier of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: 'GCEPersistentDisk represents a
+                                        GCE Disk resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      properties:
+                                        fsType:
+                                          description: 'Filesystem type of the volume
+                                            that you want to mount. Tip: Ensure that
+                                            the filesystem type is supported by the
+                                            host operating system. Examples: "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        partition:
+                                          description: 'The partition in the volume
+                                            that you want to mount. If omitted, the
+                                            default is to mount by volume name. Examples:
+                                            For volume /dev/sda1, you specify the
+                                            partition as "1". Similarly, the volume
+                                            partition for /dev/sda is "0" (or you
+                                            can leave the property empty). More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: 'Unique name of the PD resource
+                                            in GCE. Used to identify the disk in GCE.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        readOnly:
+                                          description: 'ReadOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: 'GitRepo represents a git repository
+                                        at a particular revision. DEPRECATED: GitRepo
+                                        is deprecated. To provision a container with
+                                        a git repo, mount an EmptyDir into an InitContainer
+                                        that clones the repo using git, then mount
+                                        the EmptyDir into the Pod''s container.'
+                                      properties:
+                                        directory:
+                                          description: Target directory name. Must
+                                            not contain or start with '..'.  If '.'
+                                            is supplied, the volume directory will
+                                            be the git repository.  Otherwise, if
+                                            specified, the volume will contain the
+                                            git repository in the subdirectory with
+                                            the given name.
+                                          type: string
+                                        repository:
+                                          description: Repository URL
+                                          type: string
+                                        revision:
+                                          description: Commit hash for the specified
+                                            revision.
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      description: 'Glusterfs represents a Glusterfs
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      properties:
+                                        endpoints:
+                                          description: 'EndpointsName is the endpoint
+                                            name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        path:
+                                          description: 'Path is the Glusterfs volume
+                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        readOnly:
+                                          description: 'ReadOnly here will force the
+                                            Glusterfs volume to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      description: 'HostPath represents a pre-existing
+                                        file or directory on the host machine that
+                                        is directly exposed to the container. This
+                                        is generally used for system agents or other
+                                        privileged things that are allowed to see
+                                        the host machine. Most containers will NOT
+                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        --- TODO(jonesdl) We need to restrict who
+                                        can use host directory mounts and who can/can
+                                        not mount host directories as read/write.'
+                                      properties:
+                                        path:
+                                          description: 'Path of the directory on the
+                                            host. If the path is a symlink, it will
+                                            follow the link to the real path. More
+                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                        type:
+                                          description: 'Type for HostPath Volume Defaults
+                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    iscsi:
+                                      description: 'ISCSI represents an ISCSI Disk
+                                        resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: whether support iSCSI Discovery
+                                            CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: whether support iSCSI Session
+                                            CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: 'Filesystem type of the volume
+                                            that you want to mount. Tip: Ensure that
+                                            the filesystem type is supported by the
+                                            host operating system. Examples: "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        initiatorName:
+                                          description: Custom iSCSI Initiator Name.
+                                            If initiatorName is specified with iscsiInterface
+                                            simultaneously, new iSCSI interface <target
+                                            portal>:<volume name> will be created
+                                            for the connection.
+                                          type: string
+                                        iqn:
+                                          description: Target iSCSI Qualified Name.
+                                          type: string
+                                        iscsiInterface:
+                                          description: iSCSI Interface Name that uses
+                                            an iSCSI transport. Defaults to 'default'
+                                            (tcp).
+                                          type: string
+                                        lun:
+                                          description: iSCSI Target Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: iSCSI Target Portal List. The
+                                            portal is either an IP or ip_addr:port
+                                            if the port is other than default (typically
+                                            TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          description: ReadOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: CHAP Secret for iSCSI target
+                                            and initiator authentication
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        targetPortal:
+                                          description: iSCSI Target Portal. The Portal
+                                            is either an IP or ip_addr:port if the
+                                            port is other than default (typically
+                                            TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      description: 'Volume''s name. Must be a DNS_LABEL
+                                        and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    nfs:
+                                      description: 'NFS represents an NFS mount on
+                                        the host that shares a pod''s lifetime More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      properties:
+                                        path:
+                                          description: 'Path that is exported by the
+                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                        readOnly:
+                                          description: 'ReadOnly here will force the
+                                            NFS export to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: boolean
+                                        server:
+                                          description: 'Server is the hostname or
+                                            IP address of the NFS server. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: 'PersistentVolumeClaimVolumeSource
+                                        represents a reference to a PersistentVolumeClaim
+                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      properties:
+                                        claimName:
+                                          description: 'ClaimName is the name of a
+                                            PersistentVolumeClaim in the same namespace
+                                            as the pod using this volume. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          type: string
+                                        readOnly:
+                                          description: Will force the ReadOnly setting
+                                            in VolumeMounts. Default false.
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: PhotonPersistentDisk represents
+                                        a PhotonController persistent disk attached
+                                        and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: Filesystem type to mount. Must
+                                            be a filesystem type supported by the
+                                            host operating system. Ex. "ext4", "xfs",
+                                            "ntfs". Implicitly inferred to be "ext4"
+                                            if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: ID that identifies Photon Controller
+                                            persistent disk
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: PortworxVolume represents a portworx
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: FSType represents the filesystem
+                                            type to mount Must be a filesystem type
+                                            supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred
+                                            to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: Defaults to false (read/write).
+                                            ReadOnly here will force the ReadOnly
+                                            setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: VolumeID uniquely identifies
+                                            a Portworx volume
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      description: Items for all in one resources
+                                        secrets, configmaps, and downward API
+                                      properties:
+                                        defaultMode:
+                                          description: Mode bits used to set permissions
+                                            on created files by default. Must be an
+                                            octal value between 0000 and 0777 or a
+                                            decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. Directories within the path are
+                                            not affected by this setting. This might
+                                            be in conflict with other options that
+                                            affect the file mode, like fsGroup, and
+                                            the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: list of volume projections
+                                          items:
+                                            description: Projection that may be projected
+                                              along with other supported volume types
+                                            properties:
+                                              configMap:
+                                                description: information about the
+                                                  configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: If unspecified, each
+                                                      key-value pair in the Data field
+                                                      of the referenced ConfigMap
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the ConfigMap, the volume
+                                                      setup will error unless it is
+                                                      marked optional. Paths must
+                                                      be relative and may not contain
+                                                      the '..' path or start with
+                                                      '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: The key to
+                                                            project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: The relative
+                                                            path of the file to map
+                                                            the key to. May not be
+                                                            an absolute path. May
+                                                            not contain the path element
+                                                            '..'. May not start with
+                                                            the string '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its keys must be
+                                                      defined
+                                                    type: boolean
+                                                type: object
+                                              downwardAPI:
+                                                description: information about the
+                                                  downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of
+                                                      DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required:
+                                                            Selects a field of the
+                                                            pod: only annotations,
+                                                            labels, name and namespace
+                                                            are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version
+                                                                of the schema the
+                                                                FieldPath is written
+                                                                in terms of, defaults
+                                                                to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of
+                                                                the field to select
+                                                                in the specified API
+                                                                version.
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        mode:
+                                                          description: 'Optional:
+                                                            mode bits used to set
+                                                            permissions on this file,
+                                                            must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required:
+                                                            Path is  the relative
+                                                            path name of the file
+                                                            to be created. Must not
+                                                            be absolute or contain
+                                                            the ''..'' path. Must
+                                                            be utf-8 encoded. The
+                                                            first item of the relative
+                                                            path must not start with
+                                                            ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: 'Selects a
+                                                            resource of the container:
+                                                            only resources limits
+                                                            and requests (limits.cpu,
+                                                            limits.memory, requests.cpu
+                                                            and requests.memory) are
+                                                            currently supported.'
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container
+                                                                name: required for
+                                                                volumes, optional
+                                                                for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              description: Specifies
+                                                                the output format
+                                                                of the exposed resources,
+                                                                defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required:
+                                                                resource to select'
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                description: information about the
+                                                  secret data to project
+                                                properties:
+                                                  items:
+                                                    description: If unspecified, each
+                                                      key-value pair in the Data field
+                                                      of the referenced Secret will
+                                                      be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the Secret, the volume setup
+                                                      will error unless it is marked
+                                                      optional. Paths must be relative
+                                                      and may not contain the '..'
+                                                      path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: The key to
+                                                            project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: The relative
+                                                            path of the file to map
+                                                            the key to. May not be
+                                                            an absolute path. May
+                                                            not contain the path element
+                                                            '..'. May not start with
+                                                            the string '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                type: object
+                                              serviceAccountToken:
+                                                description: information about the
+                                                  serviceAccountToken data to project
+                                                properties:
+                                                  audience:
+                                                    description: Audience is the intended
+                                                      audience of the token. A recipient
+                                                      of a token must identify itself
+                                                      with an identifier specified
+                                                      in the audience of the token,
+                                                      and otherwise should reject
+                                                      the token. The audience defaults
+                                                      to the identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: ExpirationSeconds
+                                                      is the requested duration of
+                                                      validity of the service account
+                                                      token. As the token approaches
+                                                      expiration, the kubelet volume
+                                                      plugin will proactively rotate
+                                                      the service account token. The
+                                                      kubelet will start trying to
+                                                      rotate the token if the token
+                                                      is older than 80 percent of
+                                                      its time to live or if the token
+                                                      is older than 24 hours.Defaults
+                                                      to 1 hour and must be at least
+                                                      10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: Path is the path
+                                                      relative to the mount point
+                                                      of the file to project the token
+                                                      into.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      description: Quobyte represents a Quobyte mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        group:
+                                          description: Group to map volume access
+                                            to Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly here will force the
+                                            Quobyte volume to be mounted with read-only
+                                            permissions. Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: Registry represents a single
+                                            or multiple Quobyte Registry services
+                                            specified as a string as host:port pair
+                                            (multiple entries are separated with commas)
+                                            which acts as the central registry for
+                                            volumes
+                                          type: string
+                                        tenant:
+                                          description: Tenant owning the given Quobyte
+                                            volume in the Backend Used with dynamically
+                                            provisioned Quobyte volumes, value is
+                                            set by the plugin
+                                          type: string
+                                        user:
+                                          description: User to map volume access to
+                                            Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: Volume is a string that references
+                                            an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      description: 'RBD represents a Rados Block Device
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'Filesystem type of the volume
+                                            that you want to mount. Tip: Ensure that
+                                            the filesystem type is supported by the
+                                            host operating system. Examples: "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                            TODO: how do we prevent errors in the
+                                            filesystem from compromising the machine'
+                                          type: string
+                                        image:
+                                          description: 'The rados image name. More
+                                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        keyring:
+                                          description: 'Keyring is the path to key
+                                            ring for RBDUser. Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        monitors:
+                                          description: 'A collection of Ceph monitors.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          description: 'The rados pool name. Default
+                                            is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        readOnly:
+                                          description: 'ReadOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'SecretRef is name of the authentication
+                                            secret for RBDUser. If provided overrides
+                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'The rados user name. Default
+                                            is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: ScaleIO represents a ScaleIO persistent
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: Filesystem type to mount. Must
+                                            be a filesystem type supported by the
+                                            host operating system. Ex. "ext4", "xfs",
+                                            "ntfs". Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: The host address of the ScaleIO
+                                            API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: The name of the ScaleIO Protection
+                                            Domain for the configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: Defaults to false (read/write).
+                                            ReadOnly here will force the ReadOnly
+                                            setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: SecretRef references to the
+                                            secret for ScaleIO user and other sensitive
+                                            information. If this is not provided,
+                                            Login operation will fail.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        sslEnabled:
+                                          description: Flag to enable/disable SSL
+                                            communication with Gateway, default false
+                                          type: boolean
+                                        storageMode:
+                                          description: Indicates whether the storage
+                                            for a volume should be ThickProvisioned
+                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: The ScaleIO Storage Pool associated
+                                            with the protection domain.
+                                          type: string
+                                        system:
+                                          description: The name of the storage system
+                                            as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: The name of a volume already
+                                            created in the ScaleIO system that is
+                                            associated with this volume source.
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      description: 'Secret represents a secret that
+                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on created files by default.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. Defaults to 0644. Directories
+                                            within the path are not affected by this
+                                            setting. This might be in conflict with
+                                            other options that affect the file mode,
+                                            like fsGroup, and the result can be other
+                                            mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            Secret will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed
+                                            keys will be projected into the specified
+                                            paths, and unlisted keys will not be present.
+                                            If a key is specified which is not present
+                                            in the Secret, the volume setup will error
+                                            unless it is marked optional. Paths must
+                                            be relative and may not contain the '..'
+                                            path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file. Must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of
+                                                  the file to map the key to. May
+                                                  not be an absolute path. May not
+                                                  contain the path element '..'. May
+                                                  not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'Name of the secret in the
+                                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: StorageOS represents a StorageOS
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: Filesystem type to mount. Must
+                                            be a filesystem type supported by the
+                                            host operating system. Ex. "ext4", "xfs",
+                                            "ntfs". Implicitly inferred to be "ext4"
+                                            if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: Defaults to false (read/write).
+                                            ReadOnly here will force the ReadOnly
+                                            setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: SecretRef specifies the secret
+                                            to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default
+                                            values will be attempted.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                          type: object
+                                        volumeName:
+                                          description: VolumeName is the human-readable
+                                            name of the StorageOS volume.  Volume
+                                            names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: VolumeNamespace specifies the
+                                            scope of the volume within StorageOS.  If
+                                            no namespace is specified then the Pod's
+                                            namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored
+                                            within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override
+                                            the default behaviour. Set to "default"
+                                            if you are not using namespaces within
+                                            StorageOS. Namespaces that do not pre-exist
+                                            within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: VsphereVolume represents a vSphere
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: Filesystem type to mount. Must
+                                            be a filesystem type supported by the
+                                            host operating system. Ex. "ext4", "xfs",
+                                            "ntfs". Implicitly inferred to be "ext4"
+                                            if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: Storage Policy Based Management
+                                            (SPBM) profile ID associated with the
+                                            StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: Storage Policy Based Management
+                                            (SPBM) profile name.
+                                          type: string
+                                        volumePath:
+                                          description: Path that identifies vSphere
+                                            volume vmdk
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      type: array
+                    engineResources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    explainer:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        containerSpec:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is an alpha field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        endpoint:
+                          properties:
+                            grpcPort:
+                              format: int32
+                              type: integer
+                            httpPort:
+                              format: int32
+                              type: integer
+                            service_host:
+                              type: string
+                            service_port:
+                              format: int32
+                              type: integer
+                            type:
+                              type: string
+                          type: object
+                        envSecretRefName:
+                          type: string
+                        initParameters:
+                          type: string
+                        modelUri:
+                          type: string
+                        replicas:
+                          format: int32
+                          type: integer
+                        serviceAccountName:
+                          type: string
+                        storageInitializerImage:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    graph:
+                      properties:
+                        children:
+                          items:
+                            properties:
+                              children:
+                                items:
+                                  properties:
+                                    children:
+                                      items:
+                                        properties:
+                                          children:
+                                            items:
+                                              properties:
+                                                children:
+                                                  items:
+                                                    properties:
+                                                      children:
+                                                        items:
+                                                          properties:
+                                                            children:
+                                                              items:
+                                                                properties:
+                                                                  children:
+                                                                    items:
+                                                                      properties:
+                                                                        children:
+                                                                          items:
+                                                                            properties:
+                                                                              children:
+                                                                                items:
+                                                                                  properties:
+                                                                                    endpoint:
+                                                                                      properties:
+                                                                                        grpcPort:
+                                                                                          format: int32
+                                                                                          type: integer
+                                                                                        httpPort:
+                                                                                          format: int32
+                                                                                          type: integer
+                                                                                        service_host:
+                                                                                          type: string
+                                                                                        service_port:
+                                                                                          format: int32
+                                                                                          type: integer
+                                                                                        type:
+                                                                                          type: string
+                                                                                      type: object
+                                                                                    envSecretRefName:
+                                                                                      type: string
+                                                                                    implementation:
+                                                                                      type: string
+                                                                                    logger:
+                                                                                      description: Request/response  payload
+                                                                                        logging.
+                                                                                        v2alpha1
+                                                                                        feature
+                                                                                        that
+                                                                                        is
+                                                                                        added
+                                                                                        to
+                                                                                        v1
+                                                                                        for
+                                                                                        backwards
+                                                                                        compatibility
+                                                                                        while
+                                                                                        v1
+                                                                                        is
+                                                                                        the
+                                                                                        storage
+                                                                                        version.
+                                                                                      properties:
+                                                                                        mode:
+                                                                                          description: What
+                                                                                            payloads
+                                                                                            to
+                                                                                            log
+                                                                                          type: string
+                                                                                        url:
+                                                                                          description: URL
+                                                                                            to
+                                                                                            send
+                                                                                            request
+                                                                                            logging
+                                                                                            CloudEvents
+                                                                                          type: string
+                                                                                      type: object
+                                                                                    methods:
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                    modelUri:
+                                                                                      type: string
+                                                                                    name:
+                                                                                      type: string
+                                                                                    parameters:
+                                                                                      items:
+                                                                                        properties:
+                                                                                          name:
+                                                                                            type: string
+                                                                                          type:
+                                                                                            type: string
+                                                                                          value:
+                                                                                            type: string
+                                                                                        required:
+                                                                                        - name
+                                                                                        - type
+                                                                                        - value
+                                                                                        type: object
+                                                                                      type: array
+                                                                                    serviceAccountName:
+                                                                                      type: string
+                                                                                    storageInitializerImage:
+                                                                                      type: string
+                                                                                    type:
+                                                                                      type: string
+                                                                                  required:
+                                                                                  - name
+                                                                                  type: object
+                                                                                type: array
+                                                                              endpoint:
+                                                                                properties:
+                                                                                  grpcPort:
+                                                                                    format: int32
+                                                                                    type: integer
+                                                                                  httpPort:
+                                                                                    format: int32
+                                                                                    type: integer
+                                                                                  service_host:
+                                                                                    type: string
+                                                                                  service_port:
+                                                                                    format: int32
+                                                                                    type: integer
+                                                                                  type:
+                                                                                    type: string
+                                                                                type: object
+                                                                              envSecretRefName:
+                                                                                type: string
+                                                                              implementation:
+                                                                                type: string
+                                                                              logger:
+                                                                                description: Request/response  payload
+                                                                                  logging.
+                                                                                  v2alpha1
+                                                                                  feature
+                                                                                  that
+                                                                                  is
+                                                                                  added
+                                                                                  to
+                                                                                  v1
+                                                                                  for
+                                                                                  backwards
+                                                                                  compatibility
+                                                                                  while
+                                                                                  v1
+                                                                                  is
+                                                                                  the
+                                                                                  storage
+                                                                                  version.
+                                                                                properties:
+                                                                                  mode:
+                                                                                    description: What
+                                                                                      payloads
+                                                                                      to
+                                                                                      log
+                                                                                    type: string
+                                                                                  url:
+                                                                                    description: URL
+                                                                                      to
+                                                                                      send
+                                                                                      request
+                                                                                      logging
+                                                                                      CloudEvents
+                                                                                    type: string
+                                                                                type: object
+                                                                              methods:
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                              modelUri:
+                                                                                type: string
+                                                                              name:
+                                                                                type: string
+                                                                              parameters:
+                                                                                items:
+                                                                                  properties:
+                                                                                    name:
+                                                                                      type: string
+                                                                                    type:
+                                                                                      type: string
+                                                                                    value:
+                                                                                      type: string
+                                                                                  required:
+                                                                                  - name
+                                                                                  - type
+                                                                                  - value
+                                                                                  type: object
+                                                                                type: array
+                                                                              serviceAccountName:
+                                                                                type: string
+                                                                              storageInitializerImage:
+                                                                                type: string
+                                                                              type:
+                                                                                type: string
+                                                                            required:
+                                                                            - name
+                                                                            type: object
+                                                                          type: array
+                                                                        endpoint:
+                                                                          properties:
+                                                                            grpcPort:
+                                                                              format: int32
+                                                                              type: integer
+                                                                            httpPort:
+                                                                              format: int32
+                                                                              type: integer
+                                                                            service_host:
+                                                                              type: string
+                                                                            service_port:
+                                                                              format: int32
+                                                                              type: integer
+                                                                            type:
+                                                                              type: string
+                                                                          type: object
+                                                                        envSecretRefName:
+                                                                          type: string
+                                                                        implementation:
+                                                                          type: string
+                                                                        logger:
+                                                                          description: Request/response  payload
+                                                                            logging.
+                                                                            v2alpha1
+                                                                            feature
+                                                                            that is
+                                                                            added
+                                                                            to v1
+                                                                            for backwards
+                                                                            compatibility
+                                                                            while
+                                                                            v1 is
+                                                                            the storage
+                                                                            version.
+                                                                          properties:
+                                                                            mode:
+                                                                              description: What
+                                                                                payloads
+                                                                                to
+                                                                                log
+                                                                              type: string
+                                                                            url:
+                                                                              description: URL
+                                                                                to
+                                                                                send
+                                                                                request
+                                                                                logging
+                                                                                CloudEvents
+                                                                              type: string
+                                                                          type: object
+                                                                        methods:
+                                                                          items:
+                                                                            type: string
+                                                                          type: array
+                                                                        modelUri:
+                                                                          type: string
+                                                                        name:
+                                                                          type: string
+                                                                        parameters:
+                                                                          items:
+                                                                            properties:
+                                                                              name:
+                                                                                type: string
+                                                                              type:
+                                                                                type: string
+                                                                              value:
+                                                                                type: string
+                                                                            required:
+                                                                            - name
+                                                                            - type
+                                                                            - value
+                                                                            type: object
+                                                                          type: array
+                                                                        serviceAccountName:
+                                                                          type: string
+                                                                        storageInitializerImage:
+                                                                          type: string
+                                                                        type:
+                                                                          type: string
+                                                                      required:
+                                                                      - name
+                                                                      type: object
+                                                                    type: array
+                                                                  endpoint:
+                                                                    properties:
+                                                                      grpcPort:
+                                                                        format: int32
+                                                                        type: integer
+                                                                      httpPort:
+                                                                        format: int32
+                                                                        type: integer
+                                                                      service_host:
+                                                                        type: string
+                                                                      service_port:
+                                                                        format: int32
+                                                                        type: integer
+                                                                      type:
+                                                                        type: string
+                                                                    type: object
+                                                                  envSecretRefName:
+                                                                    type: string
+                                                                  implementation:
+                                                                    type: string
+                                                                  logger:
+                                                                    description: Request/response  payload
+                                                                      logging. v2alpha1
+                                                                      feature that
+                                                                      is added to
+                                                                      v1 for backwards
+                                                                      compatibility
+                                                                      while v1 is
+                                                                      the storage
+                                                                      version.
+                                                                    properties:
+                                                                      mode:
+                                                                        description: What
+                                                                          payloads
+                                                                          to log
+                                                                        type: string
+                                                                      url:
+                                                                        description: URL
+                                                                          to send
+                                                                          request
+                                                                          logging
+                                                                          CloudEvents
+                                                                        type: string
+                                                                    type: object
+                                                                  methods:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                  modelUri:
+                                                                    type: string
+                                                                  name:
+                                                                    type: string
+                                                                  parameters:
+                                                                    items:
+                                                                      properties:
+                                                                        name:
+                                                                          type: string
+                                                                        type:
+                                                                          type: string
+                                                                        value:
+                                                                          type: string
+                                                                      required:
+                                                                      - name
+                                                                      - type
+                                                                      - value
+                                                                      type: object
+                                                                    type: array
+                                                                  serviceAccountName:
+                                                                    type: string
+                                                                  storageInitializerImage:
+                                                                    type: string
+                                                                  type:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                type: object
+                                                              type: array
+                                                            endpoint:
+                                                              properties:
+                                                                grpcPort:
+                                                                  format: int32
+                                                                  type: integer
+                                                                httpPort:
+                                                                  format: int32
+                                                                  type: integer
+                                                                service_host:
+                                                                  type: string
+                                                                service_port:
+                                                                  format: int32
+                                                                  type: integer
+                                                                type:
+                                                                  type: string
+                                                              type: object
+                                                            envSecretRefName:
+                                                              type: string
+                                                            implementation:
+                                                              type: string
+                                                            logger:
+                                                              description: Request/response  payload
+                                                                logging. v2alpha1
+                                                                feature that is added
+                                                                to v1 for backwards
+                                                                compatibility while
+                                                                v1 is the storage
+                                                                version.
+                                                              properties:
+                                                                mode:
+                                                                  description: What
+                                                                    payloads to log
+                                                                  type: string
+                                                                url:
+                                                                  description: URL
+                                                                    to send request
+                                                                    logging CloudEvents
+                                                                  type: string
+                                                              type: object
+                                                            methods:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            modelUri:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            parameters:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  type:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - type
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            serviceAccountName:
+                                                              type: string
+                                                            storageInitializerImage:
+                                                              type: string
+                                                            type:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          type: object
+                                                        type: array
+                                                      endpoint:
+                                                        properties:
+                                                          grpcPort:
+                                                            format: int32
+                                                            type: integer
+                                                          httpPort:
+                                                            format: int32
+                                                            type: integer
+                                                          service_host:
+                                                            type: string
+                                                          service_port:
+                                                            format: int32
+                                                            type: integer
+                                                          type:
+                                                            type: string
+                                                        type: object
+                                                      envSecretRefName:
+                                                        type: string
+                                                      implementation:
+                                                        type: string
+                                                      logger:
+                                                        description: Request/response  payload
+                                                          logging. v2alpha1 feature
+                                                          that is added to v1 for
+                                                          backwards compatibility
+                                                          while v1 is the storage
+                                                          version.
+                                                        properties:
+                                                          mode:
+                                                            description: What payloads
+                                                              to log
+                                                            type: string
+                                                          url:
+                                                            description: URL to send
+                                                              request logging CloudEvents
+                                                            type: string
+                                                        type: object
+                                                      methods:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      modelUri:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      parameters:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            type:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - type
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      serviceAccountName:
+                                                        type: string
+                                                      storageInitializerImage:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                endpoint:
+                                                  properties:
+                                                    grpcPort:
+                                                      format: int32
+                                                      type: integer
+                                                    httpPort:
+                                                      format: int32
+                                                      type: integer
+                                                    service_host:
+                                                      type: string
+                                                    service_port:
+                                                      format: int32
+                                                      type: integer
+                                                    type:
+                                                      type: string
+                                                  type: object
+                                                envSecretRefName:
+                                                  type: string
+                                                implementation:
+                                                  type: string
+                                                logger:
+                                                  description: Request/response  payload
+                                                    logging. v2alpha1 feature that
+                                                    is added to v1 for backwards compatibility
+                                                    while v1 is the storage version.
+                                                  properties:
+                                                    mode:
+                                                      description: What payloads to
+                                                        log
+                                                      type: string
+                                                    url:
+                                                      description: URL to send request
+                                                        logging CloudEvents
+                                                      type: string
+                                                  type: object
+                                                methods:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                modelUri:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                parameters:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - type
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                serviceAccountName:
+                                                  type: string
+                                                storageInitializerImage:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          endpoint:
+                                            properties:
+                                              grpcPort:
+                                                format: int32
+                                                type: integer
+                                              httpPort:
+                                                format: int32
+                                                type: integer
+                                              service_host:
+                                                type: string
+                                              service_port:
+                                                format: int32
+                                                type: integer
+                                              type:
+                                                type: string
+                                            type: object
+                                          envSecretRefName:
+                                            type: string
+                                          implementation:
+                                            type: string
+                                          logger:
+                                            description: Request/response  payload
+                                              logging. v2alpha1 feature that is added
+                                              to v1 for backwards compatibility while
+                                              v1 is the storage version.
+                                            properties:
+                                              mode:
+                                                description: What payloads to log
+                                                type: string
+                                              url:
+                                                description: URL to send request logging
+                                                  CloudEvents
+                                                type: string
+                                            type: object
+                                          methods:
+                                            items:
+                                              type: string
+                                            type: array
+                                          modelUri:
+                                            type: string
+                                          name:
+                                            type: string
+                                          parameters:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - type
+                                              - value
+                                              type: object
+                                            type: array
+                                          serviceAccountName:
+                                            type: string
+                                          storageInitializerImage:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    endpoint:
+                                      properties:
+                                        grpcPort:
+                                          format: int32
+                                          type: integer
+                                        httpPort:
+                                          format: int32
+                                          type: integer
+                                        service_host:
+                                          type: string
+                                        service_port:
+                                          format: int32
+                                          type: integer
+                                        type:
+                                          type: string
+                                      type: object
+                                    envSecretRefName:
+                                      type: string
+                                    implementation:
+                                      type: string
+                                    logger:
+                                      description: Request/response  payload logging.
+                                        v2alpha1 feature that is added to v1 for backwards
+                                        compatibility while v1 is the storage version.
+                                      properties:
+                                        mode:
+                                          description: What payloads to log
+                                          type: string
+                                        url:
+                                          description: URL to send request logging
+                                            CloudEvents
+                                          type: string
+                                      type: object
+                                    methods:
+                                      items:
+                                        type: string
+                                      type: array
+                                    modelUri:
+                                      type: string
+                                    name:
+                                      type: string
+                                    parameters:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          type:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - type
+                                        - value
+                                        type: object
+                                      type: array
+                                    serviceAccountName:
+                                      type: string
+                                    storageInitializerImage:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              endpoint:
+                                properties:
+                                  grpcPort:
+                                    format: int32
+                                    type: integer
+                                  httpPort:
+                                    format: int32
+                                    type: integer
+                                  service_host:
+                                    type: string
+                                  service_port:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                type: object
+                              envSecretRefName:
+                                type: string
+                              implementation:
+                                type: string
+                              logger:
+                                description: Request/response  payload logging. v2alpha1
+                                  feature that is added to v1 for backwards compatibility
+                                  while v1 is the storage version.
+                                properties:
+                                  mode:
+                                    description: What payloads to log
+                                    type: string
+                                  url:
+                                    description: URL to send request logging CloudEvents
+                                    type: string
+                                type: object
+                              methods:
+                                items:
+                                  type: string
+                                type: array
+                              modelUri:
+                                type: string
+                              name:
+                                type: string
+                              parameters:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    type:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                              serviceAccountName:
+                                type: string
+                              storageInitializerImage:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        endpoint:
+                          properties:
+                            grpcPort:
+                              format: int32
+                              type: integer
+                            httpPort:
+                              format: int32
+                              type: integer
+                            service_host:
+                              type: string
+                            service_port:
+                              format: int32
+                              type: integer
+                            type:
+                              type: string
+                          type: object
+                        envSecretRefName:
+                          type: string
+                        implementation:
+                          type: string
+                        logger:
+                          description: Request/response  payload logging. v2alpha1
+                            feature that is added to v1 for backwards compatibility
+                            while v1 is the storage version.
+                          properties:
+                            mode:
+                              description: What payloads to log
+                              type: string
+                            url:
+                              description: URL to send request logging CloudEvents
+                              type: string
+                          type: object
+                        methods:
+                          items:
+                            type: string
+                          type: array
+                        modelUri:
+                          type: string
+                        name:
+                          type: string
+                        parameters:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              type:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        serviceAccountName:
+                          type: string
+                        storageInitializerImage:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    replicas:
+                      format: int32
+                      type: integer
+                    shadow:
+                      type: boolean
+                    ssl:
+                      properties:
+                        certSecretName:
+                          type: string
+                      type: object
+                    svcOrchSpec:
+                      properties:
+                        env:
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    traffic:
+                      format: int32
+                      type: integer
+                  required:
+                  - graph
+                  - name
+                  type: object
+                type: array
+              protocol:
+                type: string
+              replicas:
+                format: int32
+                type: integer
+              serverType:
+                type: string
+              transport:
+                type: string
+            required:
+            - predictors
+            type: object
+          status:
+            description: SeldonDeploymentStatus defines the observed state of SeldonDeployment
+            properties:
+              address:
+                description: 'Addressable placeholder until duckv1 issue is fixed:    https://github.com/kubernetes-sigs/controller-tools/issues/391'
+                properties:
+                  url:
+                    type: string
+                type: object
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: 'Conditions defines a readiness condition for a Knative
+                    resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: Severity with which to treat failures of this type
+                        of condition. When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              deploymentStatus:
+                additionalProperties:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    description:
+                      type: string
+                    explainerFor:
+                      type: string
+                    name:
+                      type: string
+                    replicas:
+                      format: int32
+                      type: integer
+                    status:
+                      type: string
+                  type: object
+                type: object
+              description:
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the 'Generation' of the Service
+                  that was last processed by the controller.
+                format: int64
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              serviceStatus:
+                additionalProperties:
+                  properties:
+                    explainerFor:
+                      type: string
+                    grpcEndpoint:
+                      type: string
+                    httpEndpoint:
+                      type: string
+                    svcName:
+                      type: string
+                  type: object
+                type: object
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/seldon-operator-certified/1.12.0/manifests/seldon-operator-certified.clusterserviceversion.yaml
+++ b/operators/seldon-operator-certified/1.12.0/manifests/seldon-operator-certified.clusterserviceversion.yaml
@@ -1,0 +1,665 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "machinelearning.seldon.io/v1",
+          "kind": "SeldonDeployment",
+          "metadata": {
+            "labels": {
+              "app": "seldon",
+              "app.kubernetes.io/instance": "seldon1",
+              "app.kubernetes.io/name": "seldon",
+              "app.kubernetes.io/version": "v0.5"
+            },
+            "name": "seldon-model"
+          },
+          "spec": {
+            "name": "test-deployment",
+            "predictors": [
+              {
+                "componentSpecs": [
+                  {
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "seldonio/mock_classifier:1.6.0",
+                          "name": "classifier"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "graph": {
+                  "children": [],
+                  "name": "classifier",
+                  "type": "MODEL"
+                },
+                "name": "example",
+                "replicas": 1
+              }
+            ]
+          },
+          "status": {}
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: AI/Machine Learning
+    certified: 'false'
+    containerImage: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:dbea873072acda45863dabc94555d39b9f48670ac04fec3e835c90531f1a2eda
+    createdAt: '2019-05-21 15:00:00'
+    description: The Seldon operator for management, monitoring and operations of machine learning systems through the Seldon Engine. Once installed, the Seldon Operator provides multiple functions which
+      facilitate the productisation, monitoring and maintenance of machine learning systems at scale.
+    olm.skipRange: <1.12.0
+    operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    repository: https://github.com/SeldonIO/seldon-core
+    support: Clive Cox
+  name: seldon-operator.v1.12.0
+  namespace: seldon-operator-system
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: A seldon engine deployment
+      displayName: Seldon Delpoyment
+      kind: SeldonDeployment
+      name: seldondeployments.machinelearning.seldon.io
+      resources:
+      - kind: SeldonDeployment
+        name: ''
+        version: v1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: Namespace
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: Event
+        name: ''
+        version: v1
+      - kind: HorizontalPodAutoscaler
+        name: ''
+        version: v2beta1
+      - kind: ValidatingWebhookConfiguration
+        name: ''
+        version: v1beta1
+      - kind: customresourcedefinitions
+        name: ''
+        version: v1beta1
+      specDescriptors:
+      - description: Name of the seldon deployment
+        displayName: name
+        path: name
+      - description: List of predictors
+        displayName: predictors
+        path: predictors
+      statusDescriptors:
+      - description: State of the SeldonDeployment
+        displayName: state
+        path: state
+      - description: Description of the state
+        displayName: description
+        path: description
+      - description: State of the services created from the SeldonDeployment
+        displayName: serviceStatus
+        path: serviceStatus
+      - description: State of the deployments created from the SeldonDeployment
+        displayName: deploymentStatus
+        path: deploymentStatus
+      - description: The number of default replicas for predictors who do not override the value
+        displayName: replicas
+        path: replicas
+      - description: The URL of the main default predictor service
+        displayName: address
+        path: address
+      version: v1
+  description: "The Seldon operator enables for native operation of production machine learning workloads, including monitoring and operations of language-agnostic models with the benefits of real-time\
+    \ metrics and log analysis.\n   \n## Overview\nSeldon Core is an open source platform for deploying machine learning models on a Kubernetes cluster.\n\n* Deploy machine learning models in the cloud\
+    \ or on-premise.\n* Get metrics and ensure proper governance and compliance for your running machine learning models.\n* Create powerful inference graphs made up of multiple components.\n* Provide a\
+    \ consistent serving layer for models built using heterogeneous ML toolkits.\n\nYou can get started by following the guides in our documentation at https://docs.seldon.io/projects/seldon-core/en/latest/workflow/README.html\n"
+  displayName: Seldon Operator
+  icon:
+  - base64data: /9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAChAegDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD9U6KKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiio7i4is7eWeeVIYIlLySSMFVFAySSegA70CbUVdklFeKeKv2o9E0i9Nvo+nTa2qMQ9w0vkRHgfcJVi3ORyB04yDWZp/7WlpJdot94bmtrU53SW92JXHHGFKKDz/tCvSjl2KlHmUPy/Lc+Bq8fcNUazw8sYuZO2ik1/4EouNvO9j36isnwx4q0vxjpKajpF2l5asxQsoIZGHVWU8qenB7EHoRV+9vbfTbOe7u54rW0t42lmnmcJHGijLMzHgAAEknpivPcZKXK1qfc0a1LEU41qMlKMldNO6a7plfXNcsPDOj3eq6pdx2On2kZlmuJjhUUd//AK3Uk4FfKXjH/goFZWmoXNt4Z8LtqFqjbYr+/uTF5mDyfKCk4PbLA+oHSvJv2n/2kpvi9qx0XQ5JIPCFnJmPIKNfSD/lq4PIX+6p57nBOF7j4A/sX2/jDwzF4g8cTX9it2BJZadaOsb+URw8pZSfmyCFGCAMk84H7DgeHMsyXALMOIk+aW0NdPkmm331slvqcM69SrPkofeei/C/9uTw14x1iPTPEemN4UlmZUgu2uRPbMx4/eNtUx84wSCvXLDHP0xX5j/tK/Bqy+Cfj6DSNMvbi+027skvIWu9plTLMjIxUANyhIO0cMBzgk/cn7L/AIrvfGXwN8MX+pTNcXyRSWskzZy4ileNCSep2KuT3OTXk8UZFl+HwVDNsquqVR2s76XTaavr0d7t67GuHrTlN06m6PVKKKK/MjvCiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAr56/am8bTQ/YPC1uzJHKgvLplON43ERpwemVLEEdQhHSvoWvkf9paxls/idLLI+5Lq0hmjH91QCmPzRj+NexlMIzxK5ump+U+JmMr4Th2aoac8oxk/7ru399kvmWvg/8Bf+E+0z+2dWu5bLSndkgjtgPNmxkFtxBCqG46EnDdOCeu8Xfss2UWizS+G7+8l1KMblt750KTAfwhgq7W9CcjPBxnI9C+Bms2msfDHRvsoVDaxm1mjU/dkU8592BDf8CrvqvEZhiYYiVnZJ7HFkfAvD2KyOhz0lOVSCbnd815K912s9lbpqnrf4t+Dfjm48CeOLNmmMWm3ki219HI+yPYTgO2RxsJ3Z64DDIDGug/bAsfiz418zSNE8MXp8EWzIZGsJI5ptRk4IZokYyeWp6Lt6jccnbtxfjx4ZPhn4l6mFBEF+RfxZYEnzCd/0/eB8D0Ar6f8AhV4qPjHwDo+pSSGS6MPk3BYgsZU+VicdNxG7Howr6GOPWW4ijmtKlGb/AL19H0as1qtVd3t2vY8Dw6r1sHicbwzipu9KTcfRPllbyfuyS82+5+V15p+q+ENaSK/sLjTNStXWT7Pf2xV1IORujccj2Iwa9s8O/twfE7RI5lvLjS9fMhBVtRsgpjxnhfIMY5/2s9K/QjUtLs9asZrLULSC+s5htkt7mNZI3Gc4ZWBB/GvNte/Ze+FniS8F1d+DbKGUIE22Dy2ceB/sQsi5564zX10uN8pzOKjm2B5rdVaX3X5Wr+v3n7b9UqU/4cz8+vFfizxb8fviFFc3Ubaprl8y21rZ2keEjTJKxxrnhFyxyT6lj1NfpJ8Gfh+fhb8MdA8MvMLi4soCZ5FOVMzu0km04GVDuwXIBwBnmneAfg/4N+F4mPhjQLXTJptwe4y0s7KduU82Qs+zKKduduRnGa7KvlOJeJqeb0qeCwVL2dCnqlpdu1lotFZX0u9zow+HdJuc3dsKKKK+AO0KK/Pz/gqB+3h4g/Z5Gm/Dj4fSDT/GGr2a6he66yrI2n2hkZESFSCvmyGN8sw+RBlQWdXj/JybVPiv8XrmXWJbvxl41uEIhk1B5Lu/dSBkIZMsRwehPegD+maiv5l/+FffFX/oWvGH/gBd/wDxNH/Cvvir/wBC14w/8ALv/wCJoA/poor+Zf8A4V98Vf8AoWvGH/gBd/8AxNfpL/wR/wBF+N2i+KfFcXiy18TWHwx/soG1t/EEU0cBvzcDY1qJhn7gufM8rjJj35OzAB+odFfOf/BQ7x54h+Gf7HHxG8Q+FtWudC1y3hs4INQs22TQrNe28MhRuqMY5HAYYZScqQQCPwI0eTxj4y1KaLSm1zXL8q1xLHZma4l27gGdguTjLDJPcj1oA/qDor+Zf/hX3xV/6Frxh/4AXf8A8TR/wr74q/8AQteMP/AC7/8AiaAP6aKK/mX/AOFffFX/AKFrxh/4AXf/AMTX63/8EjdP+Mml/DXxjb/EqHxFa+GUuLMeGrfxIjpKn7uQ3HkiUeYICptdv/LPO/Zz5lAH3zRXj37YHjrV/hr+zD8S/Emg3Bs9ZsdFnNpdKSGgkYbBIpHRl3bh7gda/Ln/AIJO/HTx1eftWf8ACO6p4n1bW9I8RWN9Ne2up381whuFRZvtIVmI84mLaXOSVZhQB+09FFFABRRRQAUV8s/8FMviJ4g+Gf7IPirVPDGqXWiatNc2Vmmo2M7Q3ECPcJvMbqQVJUFcjsxr8G/DXhfxP481Ce28P6Rq/iK+RDPLDpttLdSKuQC7BASBkgZPcigD+oqiv5mf+FC/Ff8A6J14y/8ABHd//G6nsfiL8YPgizaRZ+J/G/gFm+ZrGC/vNNJ9ygZfbtQB/S/RX4yfs6f8FiviD4L1OOw+LVnH4+0CRyW1Kyt4rTU7UHYBtCBIZkUK52MqMWfJlwAtfr18P/iD4d+Kng3SvFnhPVrfXPD2qQie0vrYna65IIIIDKysCrIwDKylWAIIoA6GiivAf2uv2yvBv7IfhCC/1xJNY8RagrjSvD9pIEmuio5d3IPlRAkAuQTzwrHigD36sfUPGXh/SL5LO+1zTbK8Y4W3uLuOOQ/RSc1/Pd8d/wBt74z/ALTOoS2mv+Jrq20e7/cp4Y8P77WwYMVxG0SsWnyygjzWkIJOCBxWJZfsZ/HfULOW5i+D/jRY4vvLNolxE5+iOoZvwBoA/pCVlkUMpDKwyGByCKdX81Xh7xl8Y/2T/FwTT7zxX8MddYw3cun3Mc9ibhVJMZmtpAFmTO7AkVlOWGDk1+p37CP/AAVCsfjfqmk/Dz4nR22h+OZ0W3sNbjIjs9Zn6CNkwBBO4xhR8kjbguwlI2AP0Hoor8qv+C0Xxg8W+HfEngHwXo+t3uj6Fc6fNqN5DYXMkP2yQzKqCbawDqnlZUEcFmPPGAD9VaK+Uf8AgmL8TPEfxS/ZI0DUvFOqXWt6taX15YnUb6Z5rieNJSyGR2JLEB9uT2Va+rqACivz4/4Kn/twaz8C9Lsfhl4Bvjpvi/XLQ3Wo6xA5WfTLNiURYSB8s0pV/nB3RqmQAzo6fkTa+HPHN9pF58RbbS/ENxpdnfg3PiyK3naCC8LIw33YG1Zd0kbctuy6nuKAP6faK/OP/glN+234o+NF1q/wv+IGpXGva7pliNR0rWrooZZrWMxxSQTPkNJIpdHVyGZgZS7fKM/o5QAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAV5v8AG/4YP8RvDsTWIQazYlnt97YEqkfNHnOAThSCe644BJr0iitqNWVGaqQ3R5mZ5bh83wdTA4uN4TVn+aa809V5o+FtL13xP8MNauI7We70S/XCzW8i4DcHG9GBVuGJBIPXIr1vwv8AtWXEbJF4h0dJkzzc6cdrAY/55scE577h16V71r/hfSPFNr9n1fTbbUIwrKvnxhmTcMEo3VT7qQeBXk/ij9lvQtSZ5dEvrjR5Cc+TIPPhAC4wMkMMnnJZu/FfQfXcHi/95hZ9/wDhtT8K/wBUOK+GG3w/i/aUr35HZf8Aksrw9WnFve3bkfjv4s8M/EfwzpmraNqKPqFhL5ctpKBFL5cgyflbBfayqPk3AbmPvV/9lLxOVm1nw9ISVYC/hG0YBGEkyeuTmPA9jXn/AIm+AvjLwzlv7MOqwcDztMJm5PbZgPx67ce9cv4R8UXngfxLaaxZxxvd2pYCO4UlTuUoQQCD0Y969L6vSq4SVCjLmXTy6n59LPsyyziijnObYd0ZuymrNKStytpO9/ds9G02rn3nRXi/hn9qLw9qhEes2dzokhJ/eL/pEIAHGSoDZPptx716voviHS/EdqbjS9QttQhGAzW8qvtJGcNg8HHY818hVw1ah/Ei1/Xc/qnK+IMqzpXwGIjN9r2l/wCAu0l9xo0UUVzH0AUUUUAfh1/wWA+GmreEv2rpvFNyskmj+LNNtriyuNjCNXgiS3lgDHgsvlxyEDoJ09a92/YV/wCCovw48A/C/wAM/DT4haMfBKaHafZLfXdKtWmsbkAuxkmhjUyRyuSCzKsgd2d2KZxX6NfF74MeC/j14Lm8KePNBt/EOhySpcCCZnjeKVM7ZI5EKvG4BZdysCVZlOVZgfy4+P8A/wAEXvE+gPc6l8IfEkXijT1Uuuh6+6W1+MBAFScAQyknecuIQoAHzHmgD9YfB/jbw98QtCh1rwtrum+I9HmZljv9Ju47mBmU4ZQ6EjIPBGcg1t1/NXLb/GH9j/4hhmTxN8MfFMeVVx5lr9qiSUZAI+S5gLxjpvjfb/EK+zPgJ/wWe8aeGfsmm/Ffw7b+M7AMqya3pASy1BVLsXdogBBKQpVVVRCPl5Ykk0AfsRRXhvwD/bU+EH7SEdrB4Q8W2y67MgJ8Pap/omoq2wuyLEx/elVVizQl1GD81e5UAfKv/BUf/kxP4m/9wz/06WlfAH/BFT/k6bxT/wBiZdf+l1jX3/8A8FR/+TE/ib/3DP8A06WlfhD4J+IXir4a6rLqfhHxLrHhXUpoTbSXmiX8tnM8RZWMZeNlJUsiHbnGVB7CgD+oiiv5rP8AhrH43/8ARZPiB/4VF9/8do/4ax+N/wD0WT4gf+FRff8Ax2gD+lOivzD/AOCQHxu+M3xO8SeNtM8W6zq/i7wHa2guV1jXriS7mttRLxKkEc8jFyrxeYzR/MFMakbC58z9PKAPn79v7/kzX4sf9gZv/Q0r8nP+CTP/ACet4X/7B+of+kz1+sf7f3/JmvxY/wCwM3/oaV+Tn/BJn/k9bwv/ANg/UP8A0megD95KKKKACiiigD40/wCCtv8AyZb4g/7Cen/+jxXxf/wRP/5OL8af9ipJ/wClltX2h/wVt/5Mt8Qf9hPT/wD0eK+L/wDgif8A8nF+NP8AsVJP/Sy2oA/ZuqmraRY+INLu9M1Syt9S028iaC5s7uJZYZo2GGR0YEMpBIIIwc1booA/Lb/goh/wTL8P6d4P1f4pfCDTbfQZNJhn1DXvDMcmy2mt13SyXNqGOImjXcTCuEKKPLCsmyXwr/gk3+09efCX452/w71W+YeDvG0otkhmmIitdT24glRcH5pSqwEDbuLxFjiMCv2+r+ZzxFI3wJ/aH1STwpepeP4N8UytpN64Eiym0uz5EhHRgfLU++aAP6UvEXiDTvCfh/U9c1e7jsNJ0y1lvby6lzshhjQvI7eyqpJ+lfzl/GL4neM/2zv2i5tWMM97rnibUo9N0PR5LlStpE8uy1s0dtiKq7wCxCgszu2CzGv26/4KH+LNQ8F/sW/FXUNNjEtxNpiaa6suf3N1PFazH8I5nPtivyv/AOCR/h2z1r9s7RLy5uhbzaPpWoXtrGT/AK+RofIKD/gE8jf8AoA/Uv8AY9/Yf8D/ALJ/he2ktLG31bx5cWypqniWdd8rNjLx2+4fuockjCgFgql9xAx9IUUUAcj8UvhL4O+NXhKfwz448PWXiTRZjv8As94mTE+1lEkTjDRSBWYB0IYbjgjNfgT+2t+yrqX7IPxol0CG5vL/AMNXqfb9A1idNsksO7BjdlAUzRN8rbcZGx9qCQKP6JK/Ov8A4LaeGdOuvgB4G8QywBtWsPE4sLefPKQz2k7yrj/aa1hP/AKAPor9gf8AaNuf2nP2b9E8T6tKs3iewlk0fW5Ei8tZLuIKfMAAC5kikhkOwBQ0jKANuK+Af+C3H/JZvh5/2AJP/Sh673/ghrql3Npnxl057iRrG3m0i4ity3yJJIt4sjgdiwijBP8AsD0rgv8Agtx/yWb4ef8AYAk/9KHoA+sf+CQn/Jm9h/2G7/8A9CWvsrW9asPDei3+r6reQ6fpen28l3d3lw4SKCFFLPI7HgKqgkk9AK+Nf+CQn/Jm9h/2G7//ANCWof8AgrZ8eG+FP7NLeFdOuzb6945uDpiiN2SRbFAHu3BAwQQYoWUkZW5PXBoA/I74p+NfEX7XX7TGq61bW5m13xrrsdppllM8aGNZHSCzt2cBV+SMQx7zjO3cxySa/an48/CDQ/g3/wAE7PGngDS4I59L0HwfPAjvCq+dMiGRrhl6B3m3SnHRmJFfn1/wRy+Bv/CefHzVfiDfwh9L8FWf+j5bG6/uQ8cfylSGVYhcMeQVYxGv0+/bZ/5NG+L3/YtXv/oo0Afjz/wSpleP9uLwIqsyq8GpKwB+8PsE5wfxAP4V++VfgX/wSt/5Pk8Af9cdS/8ATfcV++lABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFfK/7UHhn+y/Glrq8YxFqkHzZbJMsWFbjsNhj/HNfVFea/tBeF28SfDW9kiVnuNNYXyBSoyqgiTJPYIztgckqPofSy6t7HExb2en3n59x5lP9r5BXpxV50/fj6x3+bjzL5nz34G+Dt/8AETw3c6jo+oWpvLWdopbC4yjbdoZWVhn7xJAyAMqeaxtW8J+K/hzfJc3dlf6NPEwEd7CSFDMp4WVDtzjPAPrXb/szeKDo3jx9Lkci31WEx44x5qAuhJPt5g47sK+ryAwIIyK9zF4+rhK7pzSlF7H4zwzwRlnFGTU8bhqsqOIg3GTXvLmWqdnZ3acXpJK99D5L8H/tI+J/D8kcWqMmvWKhUKz4SZQAQMSAcnoSXDE46jOa+m/CPi7TPG+hwarpU3m28nDK3DxOOqOOzDI/MEZBBPlHxz+C+kS+GbrXdDsI9Ov7BPNlgtUVIpoh97K8BSoy2R1wQQSRjiP2YPFEmm+NJ9FeRvsupQMVjxkedGNwPt8gk6dePSuavRw+Mw8sTQXK47r+vzPo8lzTO+Fc9pZDnVX21Ktbkk23q9FZvXf3XF7aNab/AFRRRRXzR/QgUV8X/ty/8FGof2P/ABtonhCy8Ev4q1nUNMGqy3Fxfi0t4IWmeKNVwjtIxMM2QdgUBMFtxC/Mv/D8XXf+iSaf/wCDyT/4xQB+qfirwhoXjrQ59F8S6Lp3iHR7gqZtP1W0jubeQqwZd0bgqcMARkcEA18KfHL/AII3/C7xxG158OtUvvhzqYUD7IxfUdPkxvJJSV/NRmJUbhIVULxHk14v/wAPxdd/6JJp/wD4PJP/AIxR/wAPxdd/6JJp/wD4PJP/AIxQB8eftG/sR/Fv9lmRbzxboa3OgNII4fEmiym5sWfCHBbCvCcvtHmohYq23cBmv0K/4JR/tseLvjLqetfC/wCIOqT+INV07TxqWka1d7TO8EbRxSwTSZDSuDJG6sQzkeaXY4WvmL9pr/gqz4o/aI+EWsfD+LwJpHhzT9YEaXt21095L5aSpKBECqKjbkHzENwTjBww7P8A4It/B/VtY+MHib4kS2jx+HdF0yTSobpgyrLfTNG2xDt2vsiVy4zlfNhOMNQB9x/8FR/+TE/ib/3DP/TpaV8Af8EVP+TpvFP/AGJl1/6XWNff/wDwVH/5MT+Jv/cM/wDTpaV+PH7G/wC1Vd/sg/E7U/GNn4dh8TS32jy6QbSe6NuqB5oJd+4K2SPIAxj+LrxQB/RjRX5Kf8Pxdd/6JJp3/g8k/wDjFH/D8XXf+iSad/4PJP8A4xQB+tdFfkp/w/F13/okmnf+DyT/AOMV7d+yD/wVST9pT40aT8OdX+HreHbzV4rlrLUbLU/tMYkhhaYpJG0aFVMcUvzqzHdsG3BLKAe+ft/f8ma/Fj/sDN/6Glfk5/wSZ/5PW8L/APYP1D/0mev1k/b8Ut+xr8WABk/2M5/8fSvwy/ZY/aDuP2YPjJpnj+10WLxBNZQXEAsZrgwK/mxlCd4VsYznpQB/SbRX5Kf8Pxdd/wCiSad/4PJP/jFH/D8XXf8Aokmnf+DyT/4xQB+tdFfkp/w/F13/AKJJp3/g8k/+MV7f+yB/wVST9pT4zaV8OdX+HzeHL3Vorl7LUbLU/tUfmRQtMUkjaNCqmOOX5wzfMEG3BLAA7H/grb/yZb4g/wCwnp//AKPFfF//AARP/wCTi/Gn/YqSf+lltX2j/wAFbFZv2LfEJAJC6np5OB0/fqP61+Tv7G/7WV9+x/8AEDWPFNh4ct/EsupaW2mG2uLpoFQGWOTfkK2T+7Ax70Af0WUV+Rbf8FwfFPG34WaOPrqsp/8AadcX40/4LQ/GPXLO8tdA8O+FfDInjKR3gt5rq6t2PR0LyeWSP9qNh6g0Afpl+2L+1V4e/ZP+Ed/4g1C7t5PE97DLb+HdHkUyPfXgX5SyBlPkRlkaV9y4UgA73RW/E/8AYN+EuofGv9rLwBpkEH2q00/Uotd1SSaEzRLa2rrM4l9BIypCC3G6ZQetcxZ2Pxi/bU+K7+WNb+JHjO6VneSR9y20JkLckkRW0CvKcD5I1LgADIFftn+wz+xPov7H/gGaOW4i1rx5rKRvresR58obclba3DAEQoSfmIDSMSzADYkYB7L8bPh83xY+DvjfwWksME2v6LeabDPcIXjhllhZI5GA5IVircc/LxX89/7NvxWv/wBlP9pjwz4s1fSrmObw3qUtprGlzQEXMcTK9vdx+WzJiZEeTarkASKu7gEV/SLX5h/8FMv+CduqeONau/i18KdF+3avcKZPEPh6wQma7kA/4+4Ix9+QgYeNRlyAwDOz5AP0o8LeKNJ8beG9M1/Qr+HVNG1K3S6tLy3OUmicBlYfUHvyO9alfzvfsv8A7dfxR/ZTeWy8N38OseGZjul8O62HmtFbcSZIdrK0LnLZKEKxILK21cfblj/wXI0uSzla8+D95BdD/VxweIEkRvqxt1I/BTQB+otfjJ/wWE/aWsPiV8TdH+GPh68F3png55ZNVnt5w8UuoyAKYsDjdAilSc5DyyoQChzgftBf8FePin8WdJn0XwZp1v8ADDSrhAs1xYXTXWpt8rB1W6KoI1O5SDHGsilBiTBIPn/7EH7BHiv9qrxVZapqdrd6B8MbaTzL/XZIyhvFViDb2eRiSRirKXGVjwxbLBY3AP0F/wCCOvwbl8A/s46l4yv7QW+o+NNSM8L7m3PY24MUG5SBtPmm6YYzlXQ55r5s/wCC3H/JZvh5/wBgCT/0oev190nSbHw/pNlpemWdvp2m2UCW1rZ2kSxQwRIoVI0RQAqqoACgYAAFfmH/AMFtPhLqeoab8PviPYWM9zp2ni40fVbhDuS23sj2xK9QGbz1L9M+WvBYZAPcP+CQn/Jm9h/2G7//ANCWvzl/4KhfHRvjP+1Zr9laz+ZoXg8f8I9ZqodQZYmJunKsSNxnaRNygBkii64yZv2cP+Cjnir9mr9nfxD8NdB0CC61W8ubi50rxHNdAf2WZURWxb+URMVKs6lnA3PyGUbTyn7AP7M9z+0z+0LomnXdg9x4O0WRNU8QTNGWh+zo2Ut2ORzO6iPAO7aZGAIQ0AfsF/wTx+BMnwA/ZX8KaRf2bWXiHWA2vaxG4lV1uLgKVR0k5jeOBYImUADdEx6kk9R+2z/yaN8Xv+xavf8A0Ua9srxT9tgFv2R/i9gZ/wCKZvv/AEU1AH47f8Erf+T5PAH/AFx1L/033FfvpX4F/wDBKsE/tx+AcDOIdSJ/8ALiv30oAKKKKACiiigAooooAKKKKACiiigAooooAKq6rqltoml3mo3svkWdpC9xPKQTsjRSzNgcnAB6Varyv9qJmX4FeJypIOLYcen2mLP6UpOybPRy3CrHY2hhZOyqTjG/bmaX6nzH8U/2oPFXjbVp00S/uvDmhI4+zw2knlXDgZw8ki/Nk55UHaOByRuPJaP8cvH+hXn2m28XarJJtK7by4N0nP8AsS7lz74zXXfsl2eiXvxegGsxwSyx2skunLcdPtSshUgdCwTzCM9CMjkA19R/Hjxl4R8F+FFu/E2l6frl0Sw07TbyBJWllxyQGB2qMjc3YYHJIB44pyXO5H9C4/MMvyPG0shw2WqqpJdtb+qfNtq211vsfO3hv9tDxhpn2ePVtP03WoUz5kmxreeT/gSkoPwSvZfhl+0xpfxa1KPw+fC2pLfXSuJ44/LuLWOHGGeR2KkLzg/JySAMkgV8d+H/AA3qnxL8YJp+kWUIvtQnZxDAnlwQqSSxwPuoo/IDHNffvwl+E+k/CTwyunWCie9m2ve37Lh7mQD9FGSFXsCepLE3SlOT30PC42wPDmWYflWHSxE1ootpLzaWluytrstL2+S9b0+8+G/j2e3jJ+1aTeh4JJUHzhWDRuRnow2tj3r7N8G+NdK8daPFqGl3KyqygywkjzIGP8Lr2PB9jjIyOa434xfBeH4kJDf2M6WOtwL5Yklz5U0eSQr4BIIJOGAPUgg8EfNmpfCnxjpd49tN4a1KSRcEtbW7TpyM8OmVP4GvtZewzSlFynyzR/nXR/tjw3zHERoYV18JVd42vpvbVKVmk7NNe9a62PpD4+fEaw8L+Eb/AEeOeOXWNSha3W2HzFI2GHdwD8o2khc9SRwQGx4/+zP4fl1T4iDUQGWDTLd5GcLlS7qY1QnsSGc/8ANYHhj4I+MPE155S6PPpkSnD3GpI0CLwezDc3THyg9RnFfVPw7+H2n/AA58Ppp1kWmlc+Zc3TjDTSYwTj+EDoFHQepJJzrTo4HDSoU5c0pb/wBeh6GVYbNuNeIaOdY/Dujh6FnFO+rTurXScnzat2SsrbnU0UUV8wf0WeBftPfsRfDH9rJtMuvGVnfWWt6cnkW+t6LOsF2INxbyGLo6Om4lgGUlSzbSu5s+A/8ADln4Hf8AQyePf/BjZ/8AyJX33RQB8Cf8OWfgd/0Mnj3/AMGNn/8AIlH/AA5Z+B3/AEMnj3/wY2f/AMiV990UAfD3hP8A4I7/AAA8OaqLvUP+Ep8U2+0r9h1bVlSEn+9m2ihfI/38e1fZPhHwfoXgHw7Z6B4a0ex0DRLNWW30/TbdIIIgzFm2ooABLMzE9yxJ5JrYooA5z4ifDvw78WPBWreEvFulQ614d1WLybuxnJCyKGDKQVIZWVlVlZSCrKCCCAa+KZv+CLnwMkmd18QeO4lZiRGmpWm1fYZtScD3Jr75ooA+BP8Ahyz8Dv8AoZPHv/gxs/8A5Eo/4cs/A7/oZPHv/gxs/wD5Er77ooA+BP8Ahyz8Dv8AoZPHv/gxs/8A5Er1/wDZt/4J3/CP9l/xdJ4p8OW+q634kEbRWupeILmOeSyVlKyCFY441UspKlypbaWUEBmB+nKKAM3xJ4d03xh4d1XQdZtEv9I1S0lsby1kJCzQSoUkQ4IOCrEcHvXxBqn/AARl+BGoaldXUGreNdMgmlaRLK11O3aKBSchEMls7lR0G5mPHJPWvvGigD4E/wCHLPwO/wChk8e/+DGz/wDkSj/hyz8Dv+hk8e/+DGz/APkSvvuigD4E/wCHLPwO/wChk8e/+DGz/wDkSvYf2a/+CePwj/Ze8VS+J/Ddrqmt+JPLaK21TxDcR3Etkjja4gCRxohYZUvtL7WZQwVmB+mqKAOW+J3wx8NfGTwLqvg7xfpq6v4d1RES6s2leLfsdZEIZCGUh0VgQRyor4w/4cufAzzGb/hIPHWCeF/tK0wPp/oua++KKAPg2P8A4Ix/AlMZ1fxs/H8Wp239Laux8M/8Enf2b9BtfKvfCeo+Ipc5+0anrV0r/TEDxL/47X2DRQBgeCvh/wCF/hro7aT4S8OaT4X0tpTO1lo1jFaQtIQAXKRqAWIVQWIydo9K36KKACiiigD57+P37BvwY/aOuLnUfE3hZbDxHOpDeIdDk+x3pY7fncgGOZsKFBmR8DgYr5r1D/giV8MJL5WsfHni62s8/NFcC1mkP0cRIB/3ya/RiigD41+FX/BJv4BfDTVV1K+0zVvHV1HJFLCnii8WWCFkJP8AqYUiSRWOMpKJFIAGOufsDS9Ls9D02007TrSDT9Ps4Ut7a0tYljihiRQqIiKAFVQAAAMAACrVFABWd4i8OaV4u0O90bXNNtNY0i9jMNzY30KzQzIequjAhh9a0aKAPhHxF/wRp+A+ta1d31nqPjPQLaZtyabp2pwPBAMAbUM9vJIRxn5nY89e1fVXwL+APgf9nLwRB4W8C6NHpdgpD3E7HzLm8lxgyzyHl3P4BRwoVQAPRKKACqGv6Dp/inQdS0XVrSLUNK1K2ks7u0mGUnhkUo6MO4ZSQfrV+igD59/Z7/YU+En7MvjDV/FHgvSb5Na1BZYEuNQvnuPsdtIyMbeFTgbAY1wzhpOoLkEivoKiigAooooAKKKKACiiigAooooAKKKKACiiigAqnq+lWuvaTe6bfRedZXkL288e4rvjdSrDIIIyCeRzVyigqMpQkpRdmj4E+Jn7Nfi7wNrDpp+m3XiHSZGJt7rT4WmcLzxIiglWAxzjaex6gcz4f+EfjjxrqEMdp4e1OVpjt+13ULxwjaOd0rgKMAdM54wATxX6Q0Vz+xVz9eo+JeY06ChUoxlUStza/e0v0aPM/gf8E9P+EOg7SY73XrpQb2+Ucevlx55CD82PJxwB6ZRRW6SSsj8sxuNxGYYieKxMuact3/XRdF0CiiimcQUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAf/9k=
+    mediatype: image/jpeg
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - keda.sh
+          resources:
+          - scaledobjects
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - keda.sh
+          resources:
+          - scaledobjects/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - keda.sh
+          resources:
+          - scaledobjects/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - machinelearning.seldon.io
+          resources:
+          - seldondeployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - machinelearning.seldon.io
+          resources:
+          - seldondeployments/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - machinelearning.seldon.io
+          resources:
+          - seldondeployments/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - destinationrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - destinationrules/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - virtualservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - virtualservices/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - v1
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - v1
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - v1
+          resources:
+          - services/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+          - list
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        serviceAccountName: seldon-manager
+      deployments:
+      - name: seldon-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: seldon
+              app.kubernetes.io/instance: seldon1
+              app.kubernetes.io/name: seldon
+              app.kubernetes.io/version: v0.5
+              control-plane: seldon-controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                sidecar.istio.io/inject: 'false'
+              labels:
+                app: seldon
+                app.kubernetes.io/instance: seldon1
+                app.kubernetes.io/name: seldon
+                app.kubernetes.io/version: v0.5
+                control-plane: seldon-controller-manager
+            spec:
+              containers:
+              - args:
+                - --enable-leader-election
+                - --webhook-port=8443
+                - --create-resources=$(MANAGER_CREATE_RESOURCES)
+                command:
+                - /manager
+                env:
+                - name: MANAGER_LEADER_ELECTION_ID
+                  value: a33bd623.machinelearning.seldon.io
+                - name: MANAGER_LOG_LEVEL
+                  value: INFO
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: RELATED_IMAGE_EXECUTOR
+                  value: registry.connect.redhat.com/seldonio/seldon-core-executor@sha256:4aab0706cef5ae37e3d62ba3cc4f92bc5d0b0e18d0d953143d25d745696ecc54
+                - name: RELATED_IMAGE_ENGINE
+                  value: registry.connect.redhat.com/seldonio/seldon-engine@sha256:0abffc5f882b16a7ffa9ecfb7d1b362d8e8017b47e94b4b72b10dce74daeec65
+                - name: RELATED_IMAGE_STORAGE_INITIALIZER
+                  value: registry.connect.redhat.com/seldonio/storage-initializer@sha256:554547229653bf1ebedb88c8eec40e63c8282146e0a0ea14f2d47f000004439f
+                - name: RELATED_IMAGE_SKLEARNSERVER
+                  value: registry.connect.redhat.com/seldonio/sklearnserver@sha256:0a68b243b28d2dc273a3278393e9f986b6ed5fc29aea7b9f3f343bf9efc5ac8e
+                - name: RELATED_IMAGE_XGBOOSTSERVER
+                  value: registry.connect.redhat.com/seldonio/xgboostserver@sha256:0ee0001730d21ca636417824655d74d423d4492d7fed28befc74c23caf0cc4c8
+                - name: RELATED_IMAGE_MLFLOWSERVER
+                  value: registry.connect.redhat.com/seldonio/mlflowserver@sha256:3381cad85a16434f48cd65afbcfc65f2693bee46a149aa143a4088c9f9d899a2
+                - name: RELATED_IMAGE_TFPROXY
+                  value: registry.connect.redhat.com/seldonio/tfproxy@sha256:407932f2d8e670bb4d3b9f6670a687039fae8d79312269d4da2677b73dc3e301
+                - name: RELATED_IMAGE_TENSORFLOW
+                  value: registry.connect.redhat.com/seldonio/tensorflow-serving@sha256:04d1eee0208ca0e64ae277197cb1ddff4c0ee143a712a7f7a30faec397239dfc
+                - name: RELATED_IMAGE_EXPLAINER
+                  value: registry.connect.redhat.com/seldonio/alibiexplainer@sha256:6ec697ad5187639712701454198a5f6afa1f662d3c127641c06b4322f391d6dd
+                - name: RELATED_IMAGE_MOCK_CLASSIFIER
+                  value: registry.connect.redhat.com/seldonio/mock-classifier@sha256:ea78453871e656b71ec9ce4660623a58938d0492fb8b660cc36a1943c768ce4d
+                - name: MANAGER_CREATE_RESOURCES
+                  value: 'true'
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: CONTROLLER_ID
+                - name: AMBASSADOR_ENABLED
+                  value: 'true'
+                - name: AMBASSADOR_SINGLE_NAMESPACE
+                  value: 'false'
+                - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
+                  value: docker.io/seldonio/engine:1.12.0
+                - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
+                  value: IfNotPresent
+                - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
+                  value: default
+                - name: ENGINE_CONTAINER_USER
+                - name: ENGINE_LOG_MESSAGES_EXTERNALLY
+                  value: 'false'
+                - name: PREDICTIVE_UNIT_HTTP_SERVICE_PORT
+                  value: '9000'
+                - name: PREDICTIVE_UNIT_GRPC_SERVICE_PORT
+                  value: '9500'
+                - name: PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME
+                - name: PREDICTIVE_UNIT_METRICS_PORT_NAME
+                  value: metrics
+                - name: ENGINE_SERVER_GRPC_PORT
+                  value: '5001'
+                - name: ENGINE_SERVER_PORT
+                  value: '8000'
+                - name: ENGINE_PROMETHEUS_PATH
+                  value: /prometheus
+                - name: ISTIO_ENABLED
+                  value: 'false'
+                - name: KEDA_ENABLED
+                  value: 'false'
+                - name: ISTIO_GATEWAY
+                  value: istio-system/seldon-gateway
+                - name: ISTIO_TLS_MODE
+                - name: USE_EXECUTOR
+                  value: 'true'
+                - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
+                  value: seldonio/seldon-core-executor:1.12.0
+                - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
+                  value: IfNotPresent
+                - name: EXECUTOR_PROMETHEUS_PATH
+                  value: /prometheus
+                - name: EXECUTOR_SERVER_PORT
+                  value: '8000'
+                - name: EXECUTOR_CONTAINER_USER
+                - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
+                  value: default
+                - name: EXECUTOR_SERVER_METRICS_PORT_NAME
+                  value: metrics
+                - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT
+                  value: http://default-broker
+                - name: EXECUTOR_REQUEST_LOGGER_WORK_QUEUE_SIZE
+                  value: '10000'
+                - name: EXECUTOR_REQUEST_LOGGER_WRITE_TIMEOUT_MS
+                  value: '2000'
+                - name: DEFAULT_USER_ID
+                - name: EXECUTOR_DEFAULT_CPU_REQUEST
+                  value: '0.5'
+                - name: EXECUTOR_DEFAULT_MEMORY_REQUEST
+                  value: 512Mi
+                - name: EXECUTOR_DEFAULT_CPU_LIMIT
+                  value: '0.5'
+                - name: EXECUTOR_DEFAULT_MEMORY_LIMIT
+                  value: 512Mi
+                - name: ENGINE_DEFAULT_CPU_REQUEST
+                  value: '0.5'
+                - name: ENGINE_DEFAULT_MEMORY_REQUEST
+                  value: 512Mi
+                - name: ENGINE_DEFAULT_CPU_LIMIT
+                  value: '0.5'
+                - name: ENGINE_DEFAULT_MEMORY_LIMIT
+                  value: 512Mi
+                - name: DEPLOYMENT_NAME_AS_PREFIX
+                  value: 'false'
+                image: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:dbea873072acda45863dabc94555d39b9f48670ac04fec3e835c90531f1a2eda
+                name: manager
+                ports:
+                - containerPort: 8443
+                  name: webhook-server
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 300Mi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              serviceAccountName: seldon-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ''
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: seldon-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - mlops
+  - aiops
+  - production
+  - monitoring
+  labels:
+    name: seldon-operator
+  links:
+  - name: Website
+    url: https://www.seldon.io/
+  - name: Documentation
+    url: https://docs.seldon.io/projects/seldon-core/en/latest/
+  maintainers:
+  - email: hello@seldon.io
+    name: Seldon Technologies
+  maturity: stable
+  minKubeVersion: 1.16.0
+  provider:
+    name: Seldon Technologies
+  selector:
+    matchLabels:
+      name: seldon-operator
+  version: 1.12.0
+  relatedImages:
+  - name: seldon-core-operator-dbea873072acda45863dabc94555d39b9f48670ac04fec3e835c90531f1a2eda-annotation
+    image: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:dbea873072acda45863dabc94555d39b9f48670ac04fec3e835c90531f1a2eda
+  - name: manager
+    image: registry.connect.redhat.com/seldonio/seldon-core-operator@sha256:dbea873072acda45863dabc94555d39b9f48670ac04fec3e835c90531f1a2eda
+  - name: executor
+    image: registry.connect.redhat.com/seldonio/seldon-core-executor@sha256:4aab0706cef5ae37e3d62ba3cc4f92bc5d0b0e18d0d953143d25d745696ecc54
+  - name: engine
+    image: registry.connect.redhat.com/seldonio/seldon-engine@sha256:0abffc5f882b16a7ffa9ecfb7d1b362d8e8017b47e94b4b72b10dce74daeec65
+  - name: storage_initializer
+    image: registry.connect.redhat.com/seldonio/storage-initializer@sha256:554547229653bf1ebedb88c8eec40e63c8282146e0a0ea14f2d47f000004439f
+  - name: sklearnserver
+    image: registry.connect.redhat.com/seldonio/sklearnserver@sha256:0a68b243b28d2dc273a3278393e9f986b6ed5fc29aea7b9f3f343bf9efc5ac8e
+  - name: xgboostserver
+    image: registry.connect.redhat.com/seldonio/xgboostserver@sha256:0ee0001730d21ca636417824655d74d423d4492d7fed28befc74c23caf0cc4c8
+  - name: mlflowserver
+    image: registry.connect.redhat.com/seldonio/mlflowserver@sha256:3381cad85a16434f48cd65afbcfc65f2693bee46a149aa143a4088c9f9d899a2
+  - name: tfproxy
+    image: registry.connect.redhat.com/seldonio/tfproxy@sha256:407932f2d8e670bb4d3b9f6670a687039fae8d79312269d4da2677b73dc3e301
+  - name: tensorflow
+    image: registry.connect.redhat.com/seldonio/tensorflow-serving@sha256:04d1eee0208ca0e64ae277197cb1ddff4c0ee143a712a7f7a30faec397239dfc
+  - name: explainer
+    image: registry.connect.redhat.com/seldonio/alibiexplainer@sha256:6ec697ad5187639712701454198a5f6afa1f662d3c127641c06b4322f391d6dd
+  - name: mock_classifier
+    image: registry.connect.redhat.com/seldonio/mock-classifier@sha256:ea78453871e656b71ec9ce4660623a58938d0492fb8b660cc36a1943c768ce4d

--- a/operators/seldon-operator-certified/1.12.0/metadata/annotations.yaml
+++ b/operators/seldon-operator-certified/1.12.0/metadata/annotations.yaml
@@ -1,0 +1,12 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: seldon-operator-certified
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0+git
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
+  com.redhat.openshift.versions: "v4.8"


### PR DESCRIPTION
Re-add files missing from [operators/seldon-operator-certified](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/seldon-operator-certified) folder merged in https://github.com/redhat-openshift-ecosystem/certified-operators/pull/405 (see https://github.com/redhat-openshift-ecosystem/certified-operators/issues/576).

Signed-off-by: Rafal Skolasinski <r.j.skolasinski@gmail.com>