### PR TITLE
operator pachyderm-operator (v0.1.2)

### DIFF
--- a/operators/pachyderm-operator/v0.1.2/manifests/aiml.pachyderm.com_pachydermexports.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/aiml.pachyderm.com_pachydermexports.yaml
@@ -1,0 +1,124 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: pachydermexports.aiml.pachyderm.com
+spec:
+  group: aiml.pachyderm.com
+  names:
+    kind: PachydermExport
+    listKind: PachydermExportList
+    plural: pachydermexports
+    singular: pachydermexport
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: PachydermExport is the Schema for the pachydermexports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PachydermExportSpec defines the desired state of PachydermExport
+            properties:
+              backup:
+                description: Backup options allow the user to provide options when
+                  performing a backup
+                properties:
+                  target:
+                    description: Name of Pachyderm instance to backup.
+                    type: string
+                required:
+                - target
+                type: object
+              restore:
+                description: Restore allows a user to restore a backup to a new Pachyderm
+                  cluster
+                properties:
+                  backup:
+                    description: Name of backup resource in S3 to restore
+                    type: string
+                  destination:
+                    description: Name of the pachyderm instance to restore the backup
+                      to
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              storageSecret:
+                description: Storage Secret containing credentials to upload the backup
+                  to an S3-compatible object store
+                type: string
+            type: object
+          status:
+            description: PachydermExportStatus defines the observed state of PachydermExport
+            properties:
+              backup:
+                description: Backup represents the backup status
+                properties:
+                  completedAt:
+                    description: Time the backup process completed
+                    type: string
+                  id:
+                    description: Unique ID of the backup
+                    type: string
+                  location:
+                    description: Location of pachyderm backup on the S3 bucket
+                    type: string
+                  name:
+                    description: Name of backup resource created
+                    type: string
+                  startedAt:
+                    description: Time the backup process commenced
+                    type: string
+                  status:
+                    description: Status reports the state of the restore request
+                    type: string
+                type: object
+              phase:
+                description: Phase of the export status
+                type: string
+              restore:
+                description: Restore represents the restore status
+                properties:
+                  completedAt:
+                    description: Time the restore process completed
+                    type: string
+                  id:
+                    description: Unique ID of the backup
+                    type: string
+                  startedAt:
+                    description: Time the restore process commenced
+                    type: string
+                  status:
+                    description: Status reports the state of the restore request
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/pachyderm-operator/v0.1.2/manifests/aiml.pachyderm.com_pachyderms.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/aiml.pachyderm.com_pachyderms.yaml
@@ -1,0 +1,574 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: pachyderms.aiml.pachyderm.com
+spec:
+  group: aiml.pachyderm.com
+  names:
+    kind: Pachyderm
+    listKind: PachydermList
+    plural: pachyderms
+    singular: pachyderm
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Pachyderm is the Schema for the pachyderms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PachydermSpec defines the desired state of Pachyderm
+            properties:
+              console:
+                description: Allows the user to customize the console instance(s)
+                properties:
+                  disable:
+                    description: If true, this option disables the Pachyderm dashboard.
+                    type: boolean
+                  image:
+                    description: Optional image overrides. Used to specify alternative
+                      images to use to deploy console
+                    properties:
+                      pullPolicy:
+                        description: Determines when images should be pulled. It accepts,
+                          "IfNotPresent","Never" or "Always"
+                        enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                        type: string
+                      repository:
+                        description: This option dictates the particular image to
+                          pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+                        type: string
+                      tag:
+                        description: Used with the image registry to choose a specific
+                          image in a cointainer registry to pull e.g. latest
+                        type: string
+                    type: object
+                  resources:
+                    description: Optional resource requirements required to run the
+                      dash pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  service:
+                    description: Service overrides
+                    properties:
+                      annotations:
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  url:
+                    description: The address to use as the host in the dash ingress.
+                      Used as the host of a rule
+                    type: string
+                type: object
+              etcd:
+                description: Allows the user to customize the etcd key-value store
+                properties:
+                  dynamicNodes:
+                    description: Optional parameter to set the number of nodes in
+                      the Etcd statefulset. Analogous --dynamic-etcd-nodes argument
+                      to 'pachctl deploy'
+                    format: int32
+                    type: integer
+                  image:
+                    description: Optional image overrides. Used to specify alternative
+                      images to use to deploy dash
+                    properties:
+                      pullPolicy:
+                        description: Determines when images should be pulled. It accepts,
+                          "IfNotPresent","Never" or "Always"
+                        enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                        type: string
+                      repository:
+                        description: This option dictates the particular image to
+                          pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+                        type: string
+                      tag:
+                        description: Used with the image registry to choose a specific
+                          image in a cointainer registry to pull e.g. latest
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requests and limits for Etcd
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  service:
+                    description: Service overrides
+                    properties:
+                      annotations:
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  storageClass:
+                    description: If specified, etcd would use an existing storage
+                      class for its storage Name of existing storage class to use
+                      for the Etcd persistent volume.
+                    type: string
+                  storageSize:
+                    default: 10Gi
+                    description: 'The size of the storage to use for etcd. For example:
+                      "100Gi"'
+                    type: string
+                type: object
+              imagePullSecret:
+                description: Allow user to provide an image pull secret
+                type: string
+              license:
+                description: License for pachyderm enterprise. Takes the name of the
+                  secret containing the 'license' string
+                type: string
+              pachd:
+                description: Allows the user to customize the pachd instance(s)
+                properties:
+                  clusterDeploymentID:
+                    description: Set an ID for the cluster deployment. Defaults to
+                      a random value if none is provided
+                    type: string
+                  disable:
+                    description: Disable pachd
+                    type: boolean
+                  image:
+                    description: Optional image overrides. Used to specify alternative
+                      images to use to deploy dash
+                    properties:
+                      pullPolicy:
+                        description: Determines when images should be pulled. It accepts,
+                          "IfNotPresent","Never" or "Always"
+                        enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                        type: string
+                      repository:
+                        description: This option dictates the particular image to
+                          pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+                        type: string
+                      tag:
+                        description: Used with the image registry to choose a specific
+                          image in a cointainer registry to pull e.g. latest
+                        type: string
+                    type: object
+                  logLevel:
+                    default: info
+                    description: The log level option determines the severity of logs
+                      that are of interest to the user
+                    type: string
+                  lokiLogging:
+                    description: 'Optional value to determine the format of the logs
+                      Default: false'
+                    type: boolean
+                  metrics:
+                    description: Allows user to customize metrics options
+                    properties:
+                      disable:
+                        description: If true, this option allows user to disable metrics
+                          endpoint.
+                        type: boolean
+                      endpoint:
+                        description: Option to customize pachd metrics endpoint. When
+                          not set, defaults to /metrics
+                        type: string
+                    type: object
+                  postgresql:
+                    description: Postgresql server connection credentials
+                    properties:
+                      database:
+                        default: pachyderm
+                        description: Name of the database into which the table schemas
+                          will live
+                        type: string
+                      host:
+                        default: postgres
+                        description: Hostname opr address  of the postgresql host
+                        type: string
+                      passwordSecret:
+                        description: Name of the kubernetes secret containing the
+                          database password. Password should have the key postgres-password
+                        type: string
+                      port:
+                        default: 5432
+                        description: Postgresql port number. Defaults to 5432 when
+                          not set
+                        format: int32
+                        type: integer
+                      ssl:
+                        default: disable
+                        type: string
+                      user:
+                        default: pachyderm
+                        description: Username to use to connect to the database. Defaults
+                          to pachyderm
+                        type: string
+                    type: object
+                  ppsWorkerGRPCPort:
+                    default: 1080
+                    description: Pachyderm Pipeline System(PPS) worker GRPC port.
+                      Defaults to port 1080
+                    format: int32
+                    type: integer
+                  requireCriticalServersOnly:
+                    description: Require only critical Pachd servers to startup and
+                      run without errors.
+                    type: boolean
+                  resources:
+                    description: Resource requests and limits for Pachd
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  service:
+                    description: Service overrides for pachd
+                    properties:
+                      annotations:
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  serviceAccountName:
+                    description: Service Account Name to use for the pachd pod
+                    type: string
+                  storage:
+                    description: Object storage options for Pachd
+                    properties:
+                      amazon:
+                        description: Configures the Amazon storage backend
+                        properties:
+                          cloudFrontDistribution:
+                            description: CloudFrontDistribution sets the CloudFront
+                              distribution in the storage secrets. It is analogous
+                              to the --cloudfront-distribution argument to pachctl
+                              deploy.
+                            type: string
+                          credentialSecretName:
+                            description: The name of the secret containing the credentials
+                              to the S3 storage
+                            type: string
+                          disableSSL:
+                            description: DisableSSL disables SSL.  It is analogous
+                              to the --disable-ssl
+                            type: boolean
+                          iamRole:
+                            description: IAM identity with the desired permissions
+                            type: string
+                          logOptions:
+                            description: LogOptions sets various log options in Pachyderm’s
+                              internal S3 client.
+                            type: string
+                          maxUploadParts:
+                            description: 'Set a custom maximum number of upload parts.
+                              Default: 10000'
+                            type: integer
+                          partSize:
+                            description: 'Set a custom part size for object storage
+                              uploads. Default: 5242880'
+                            format: int64
+                            type: integer
+                          retries:
+                            description: 'Set a custom number of retries for object
+                              storage requests. Default: 10'
+                            type: integer
+                          reverse:
+                            description: Reverse object storage paths.
+                            type: boolean
+                          timeout:
+                            description: 'Set a custom timeout for object storage
+                              requests. Default: 5m'
+                            type: string
+                          uploadACL:
+                            description: 'Sets a custom upload ACL for object store
+                              uploads. Default: "bucket-owner-full-control"'
+                            type: string
+                          vault:
+                            description: Container for storing archives
+                            properties:
+                              address:
+                                type: string
+                              role:
+                                type: string
+                              token:
+                                type: string
+                            type: object
+                          verifySSL:
+                            description: Skip SSL certificate verification. Typically
+                              used for enabling self-signed certificates
+                            type: boolean
+                        type: object
+                      backend:
+                        description: Sets the type of storage backend. Should be one
+                          of "GOOGLE", "AMAZON", "MINIO" or "MICROSOFT"
+                        enum:
+                        - AMAZON
+                        - MINIO
+                        - MICROSOFT
+                        - GOOGLE
+                        type: string
+                      google:
+                        description: Configures the Google storage backend
+                        properties:
+                          bucket:
+                            description: Name of GCS bucket to hold objects
+                            type: string
+                          credentialSecret:
+                            description: Credentials json file
+                            type: string
+                          serviceAccountName:
+                            description: ServiceAccount used for Google container
+                              storage
+                            type: string
+                        type: object
+                      microsoft:
+                        description: Configures Microsoft storage backend
+                        properties:
+                          container:
+                            type: string
+                          id:
+                            type: string
+                          secret:
+                            type: string
+                        type: object
+                      minio:
+                        description: Configures Minio object store
+                        properties:
+                          bucket:
+                            description: Name of minio bucket to store pachd objects
+                            type: string
+                          endpoint:
+                            description: 'The hostname and port that are used to access
+                              the minio object store Example: "minio-server:9000"'
+                            type: string
+                          id:
+                            description: The user access ID that is used to access
+                              minio object store.
+                            type: string
+                          secret:
+                            description: The associated password that is used with
+                              the user access ID
+                            type: string
+                          secure:
+                            type: string
+                          signature:
+                            type: string
+                        type: object
+                      putFileConcurrencyLimit:
+                        default: 100
+                        description: 'The maximum number of files to upload or fetch
+                          from remote sources (HTTP, blob storage) using PutFile concurrently.
+                          Default: 100'
+                        format: int32
+                        type: integer
+                      uploadFileConcurrencyLimit:
+                        default: 100
+                        description: 'The maximum number of concurrent object storage
+                          uploads per Pachd instance. Default: 100'
+                        format: int32
+                        type: integer
+                    required:
+                    - backend
+                    type: object
+                type: object
+              postgresql:
+                description: Allows user to customize Postgresql database
+                properties:
+                  disable:
+                    description: Set disabled to true if you choose to provide an
+                      external postgresql database
+                    type: boolean
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  service:
+                    description: Service overrides
+                    properties:
+                      annotations:
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  storageClass:
+                    description: Storage class for the postgresql persistent storage
+                    type: string
+                type: object
+              version:
+                description: Allows user to change version of Pachyderm to deploy
+                type: string
+              worker:
+                description: Allows user to customize worker instance(s)
+                properties:
+                  image:
+                    description: Optional image overrides. Used to specify alternative
+                      images to use to deploy dash
+                    properties:
+                      pullPolicy:
+                        description: Determines when images should be pulled. It accepts,
+                          "IfNotPresent","Never" or "Always"
+                        enum:
+                        - IfNotPresent
+                        - Always
+                        - Never
+                        type: string
+                      repository:
+                        description: This option dictates the particular image to
+                          pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+                        type: string
+                      tag:
+                        description: Used with the image registry to choose a specific
+                          image in a cointainer registry to pull e.g. latest
+                        type: string
+                    type: object
+                  serviceAccountName:
+                    default: pachyderm-worker
+                    description: Name of worker service account. Defaults to pachyderm-worker
+                      service account
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PachydermStatus defines the observed state of Pachyderm
+            properties:
+              currentVersion:
+                description: Version of the deployed pachyderm cluster
+                type: string
+              pachdAddress:
+                description: Address of the pachyderm cluster
+                type: string
+              phase:
+                description: Deployment phase of the pachyderm cluster
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-backup-manager_v1_service.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-backup-manager_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: backup-manager
+  name: pachyderm-operator-backup-manager
+spec:
+  ports:
+  - name: api
+    port: 8890
+    protocol: TCP
+    targetPort: 8890
+  selector:
+    app: pachyderm-backup-manager
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: pachyderm-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-manager-config_v1_configmap.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-manager-config_v1_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: e34953c9.pachyderm.com
+kind: ConfigMap
+metadata:
+  name: pachyderm-operator-manager-config

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: pachyderm-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-pachyderm-backup-manager_v1_service.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-pachyderm-backup-manager_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: pachyderm-backup-manager
+  name: pachyderm-operator-pachyderm-backup-manager
+spec:
+  ports:
+  - name: api
+    port: 8890
+    protocol: TCP
+    targetPort: 8890
+  selector:
+    app: pachyderm-backup-manager
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-webhook-service_v1_service.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: pachyderm-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator.clusterserviceversion.yaml
+++ b/operators/pachyderm-operator/v0.1.2/manifests/pachyderm-operator.clusterserviceversion.yaml
@@ -1,0 +1,1087 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "aiml.pachyderm.com/v1beta1",
+          "kind": "Pachyderm",
+          "metadata": {
+            "name": "pachyderm-sample"
+          },
+          "spec": {
+            "console": {
+              "disable": true
+            },
+            "pachd": {
+              "metrics": {
+                "disable": false
+              },
+              "storage": {
+                "amazon": {
+                  "credentialSecretName": "pachyderm-aws-secret"
+                },
+                "backend": "AMAZON"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "aiml.pachyderm.com/v1beta1",
+          "kind": "PachydermExport",
+          "metadata": {
+            "name": "pachydermexport-sample"
+          },
+          "spec": {
+            "backup": {
+              "target": "pachyderm-sample"
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: AI/Machine Learning
+    certified: "true"
+    containerImage: registry.connect.redhat.com/pachyderm/pachyderm-operator@sha256:b3ec850de86c044a070330154975e3a392cd0e711f6d50213ec198e4f3350191
+    createdAt: "2021-05-20T08:05:00Z"
+    description: Pachyderm provides the data layer that allows data science teams
+      to productionize and scale their machine learning lifecycle with data driven
+      automation, petabyte scalability and end-to-end reproducibility.
+    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/pachyderm/openshift-operator
+    support: Pachyderm, Inc.
+  name: pachyderm-operator.v0.1.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: PachydermExport is the Schema for the pachydermexports API
+      displayName: Pachyderm Export
+      kind: PachydermExport
+      name: pachydermexports.aiml.pachyderm.com
+      specDescriptors:
+      - description: Name of backup resource in S3 to restore
+        displayName: Backup Name
+        path: restore.backup
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Name of the pachyderm instance to restore the backup to
+        displayName: Restore Destination
+        path: restore.destination
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Restore Target
+        path: restore.destination.name
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Pachyderm Namespace
+        path: restore.destination.namespace
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Storage Secret containing credentials to upload the backup to
+          an S3-compatible object store
+        displayName: S3 Upload Secret
+        path: storageSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      version: v1beta1
+    - description: Pachyderm is the Schema for the pachyderms API
+      displayName: Pachyderm
+      kind: Pachyderm
+      name: pachyderms.aiml.pachyderm.com
+      specDescriptors:
+      - description: If true, this option disables the Pachyderm dashboard.
+        displayName: Disable
+        path: console.disable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: Determines when images should be pulled. It accepts, "IfNotPresent","Never"
+          or "Always"
+        displayName: Pull Policy
+        path: console.image.pullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: This option dictates the particular image to pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+        displayName: Image Repo
+        path: console.image.repository
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Used with the image registry to choose a specific image in a
+          cointainer registry to pull e.g. latest
+        displayName: Tag
+        path: console.image.tag
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Optional resource requirements required to run the dash pods.
+        displayName: Resources
+        path: console.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Annotations
+        path: console.service.annotations
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Type
+        path: console.service.type
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: The address to use as the host in the dash ingress. Used as the
+          host of a rule
+        displayName: URL
+        path: console.url
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Optional parameter to set the number of nodes in the Etcd statefulset.
+          Analogous --dynamic-etcd-nodes argument to 'pachctl deploy'
+        displayName: Dynamic Nodes
+        path: etcd.dynamicNodes
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Determines when images should be pulled. It accepts, "IfNotPresent","Never"
+          or "Always"
+        displayName: Pull Policy
+        path: etcd.image.pullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: This option dictates the particular image to pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+        displayName: Image Repo
+        path: etcd.image.repository
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Used with the image registry to choose a specific image in a
+          cointainer registry to pull e.g. latest
+        displayName: Tag
+        path: etcd.image.tag
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Resource requests and limits for Etcd
+        displayName: Resources
+        path: etcd.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Annotations
+        path: etcd.service.annotations
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Type
+        path: etcd.service.type
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: If specified, etcd would use an existing storage class for its
+          storage Name of existing storage class to use for the Etcd persistent volume.
+        displayName: Storage Class
+        path: etcd.storageClass
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: 'The size of the storage to use for etcd. For example: "100Gi"'
+        displayName: Storage Size
+        path: etcd.storageSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: License for pachyderm enterprise. Takes the name of the secret
+          containing the 'license' string
+        displayName: Enterprise License Secret
+        path: license
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Set an ID for the cluster deployment. Defaults to a random value
+          if none is provided
+        displayName: Cluster ID
+        path: pachd.clusterDeploymentID
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Disable pachd
+        displayName: Disable
+        path: pachd.disable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: Determines when images should be pulled. It accepts, "IfNotPresent","Never"
+          or "Always"
+        displayName: Pull Policy
+        path: pachd.image.pullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: This option dictates the particular image to pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+        displayName: Image Repo
+        path: pachd.image.repository
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Used with the image registry to choose a specific image in a
+          cointainer registry to pull e.g. latest
+        displayName: Tag
+        path: pachd.image.tag
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: The log level option determines the severity of logs that are
+          of interest to the user
+        displayName: Log Level
+        path: pachd.logLevel
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: 'Optional value to determine the format of the logs Default:
+          false'
+        displayName: Loki Logging
+        path: pachd.lokiLogging
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: If true, this option allows user to disable metrics endpoint.
+        displayName: Disable
+        path: pachd.metrics.disable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: Option to customize pachd metrics endpoint. When not set, defaults
+          to /metrics
+        displayName: Endpoint
+        path: pachd.metrics.endpoint
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Name of the database into which the table schemas will live
+        displayName: Database
+        path: pachd.postgresql.database
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Hostname opr address  of the postgresql host
+        displayName: Host
+        path: pachd.postgresql.host
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Name of the kubernetes secret containing the database password.
+          Password should have the key postgres-password
+        displayName: Password Secret
+        path: pachd.postgresql.passwordSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Postgresql port number. Defaults to 5432 when not set
+        displayName: Port
+        path: pachd.postgresql.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - displayName: SSL
+        path: pachd.postgresql.ssl
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Username to use to connect to the database. Defaults to pachyderm
+        displayName: User
+        path: pachd.postgresql.user
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Pachyderm Pipeline System(PPS) worker GRPC port. Defaults to
+          port 1080
+        displayName: PPS Worker GRPC Port
+        path: pachd.ppsWorkerGRPCPort
+        x-descriptors:
+        - urn:alm:descriptor:number
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Require only critical Pachd servers to startup and run without
+          errors.
+        displayName: Require Critical Servers Only
+        path: pachd.requireCriticalServersOnly
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: Resource requests and limits for Pachd
+        displayName: Resources
+        path: pachd.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Annotations
+        path: pachd.service.annotations
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Type
+        path: pachd.service.type
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Service Account Name to use for the pachd pod
+        displayName: Service Account Name
+        path: pachd.serviceAccountName
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: CloudFrontDistribution sets the CloudFront distribution in the
+          storage secrets. It is analogous to the --cloudfront-distribution argument
+          to pachctl deploy.
+        displayName: CloudFront Distribution
+        path: pachd.storage.amazon.cloudFrontDistribution
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: The name of the secret containing the credentials to the S3 storage
+        displayName: S3 Credentials Secret
+        path: pachd.storage.amazon.credentialSecretName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: DisableSSL disables SSL.  It is analogous to the --disable-ssl
+        displayName: Disable SSL
+        path: pachd.storage.amazon.disableSSL
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: IAM identity with the desired permissions
+        displayName: IAM Role
+        path: pachd.storage.amazon.iamRole
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: LogOptions sets various log options in Pachyderm’s internal S3
+          client.
+        displayName: Log Options
+        path: pachd.storage.amazon.logOptions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: 'Set a custom maximum number of upload parts. Default: 10000'
+        displayName: Max Upload Parts
+        path: pachd.storage.amazon.maxUploadParts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: 'Set a custom part size for object storage uploads. Default:
+          5242880'
+        displayName: Part Size
+        path: pachd.storage.amazon.partSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: 'Set a custom number of retries for object storage requests.
+          Default: 10'
+        displayName: Retries
+        path: pachd.storage.amazon.retries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Reverse object storage paths.
+        displayName: Reverse
+        path: pachd.storage.amazon.reverse
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: 'Set a custom timeout for object storage requests. Default: 5m'
+        displayName: Timeout
+        path: pachd.storage.amazon.timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: 'Sets a custom upload ACL for object store uploads. Default:
+          "bucket-owner-full-control"'
+        displayName: Upload ACL
+        path: pachd.storage.amazon.uploadACL
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Address
+        path: pachd.storage.amazon.vault.address
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Role
+        path: pachd.storage.amazon.vault.role
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Token
+        path: pachd.storage.amazon.vault.token
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Skip SSL certificate verification. Typically used for enabling
+          self-signed certificates
+        displayName: Verify SSL
+        path: pachd.storage.amazon.verifySSL
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - description: Sets the type of storage backend. Should be one of "GOOGLE",
+          "AMAZON", "MINIO" or "MICROSOFT"
+        displayName: Backend
+        path: pachd.storage.backend
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Name of GCS bucket to hold objects
+        displayName: Bucket
+        path: pachd.storage.google.bucket
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Credentials json file
+        displayName: Credential Secret
+        path: pachd.storage.google.credentialSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: ServiceAccount used for Google container storage
+        displayName: Service Account Name
+        path: pachd.storage.google.serviceAccountName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Container
+        path: pachd.storage.microsoft.container
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: ID
+        path: pachd.storage.microsoft.id
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Secret
+        path: pachd.storage.microsoft.secret
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Name of minio bucket to store pachd objects
+        displayName: Bucket
+        path: pachd.storage.minio.bucket
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: 'The hostname and port that are used to access the minio object
+          store Example: "minio-server:9000"'
+        displayName: Endpoint
+        path: pachd.storage.minio.endpoint
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: The user access ID that is used to access minio object store.
+        displayName: ID
+        path: pachd.storage.minio.id
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: The associated password that is used with the user access ID
+        displayName: Secret
+        path: pachd.storage.minio.secret
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Secure
+        path: pachd.storage.minio.secure
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Signature
+        path: pachd.storage.minio.signature
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: 'The maximum number of files to upload or fetch from remote sources
+          (HTTP, blob storage) using PutFile concurrently. Default: 100'
+        displayName: Put File Concurrency Limit
+        path: pachd.storage.putFileConcurrencyLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: 'The maximum number of concurrent object storage uploads per
+          Pachd instance. Default: 100'
+        displayName: Upload File Concurrency Limit
+        path: pachd.storage.uploadFileConcurrencyLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Set disabled to true if you choose to provide an external postgresql
+          database
+        displayName: Disable
+        path: postgresql.disable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:custom
+      - displayName: Resources
+        path: postgresql.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - displayName: Annotations
+        path: postgresql.service.annotations
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - displayName: Type
+        path: postgresql.service.type
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Storage class for the postgresql persistent storage
+        displayName: Storage Class
+        path: postgresql.storageClass
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Allows user to change version of Pachyderm to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      - description: Determines when images should be pulled. It accepts, "IfNotPresent","Never"
+          or "Always"
+        displayName: Pull Policy
+        path: worker.image.pullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: This option dictates the particular image to pull e.g. quay.io/app-sre/ubi8-ubi-minimal
+        displayName: Image Repo
+        path: worker.image.repository
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Used with the image registry to choose a specific image in a
+          cointainer registry to pull e.g. latest
+        displayName: Tag
+        path: worker.image.tag
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:custom
+      - description: Name of worker service account. Defaults to pachyderm-worker
+          service account
+        displayName: Service Account Name
+        path: worker.serviceAccountName
+        x-descriptors:
+        - urn:alm:descriptor:text
+        - urn:alm:descriptor:io.kubernetes:advanced
+      statusDescriptors:
+      - description: Version of the deployed pachyderm cluster
+        displayName: Version
+        path: currentVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:version
+      - description: Address of the pachyderm cluster
+        displayName: Pachd Address
+        path: pachdAddress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:pachdAddress
+      - description: Deployment phase of the pachyderm cluster
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:phase
+      version: v1beta1
+  description: "The Pachyderm operator aims to make deploying and managing Pachyderm
+    instances on Openshift container platform easier.\n\nPachyderm is the data foundation
+    for machine learning.  Pachyderm provides industry leading data versioning, pipelines
+    and lineage that allow data science teams to automate the machine learning lifecycle
+    and optimize their machine learning operations (MLOps). \n\n## Getting started\n\n1.
+    Pachyderm uses an object store to store your data. Set the pachd storage backend
+    at `pachyderm.spec.pachd.storage.backend` to `AMAZON`, `MICROSOFT`, `GOOGLE` or
+    `MINIO` depending on your storage provider. Additionally, create a user with read/write
+    access to the object store.\n\n2. Setup the user credentials in the section, `pachyderm.spec.pachd.storage`.
+    Required fields depend on the backend type set in step 1 above.\n\n3. Finally,
+    deploy the pachyderm cluster in its own namespace.\n\nFor more information on
+    getting started, reference the documentation.\n"
+  displayName: Pachyderm
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAlgAAACBCAYAAAAcyMQSAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAACWKADAAQAAAABAAAAgQAAAABmsT67AABAAElEQVR4Ae1dB2AcxdWe2b2qaslFxt00gx1aTEnAgAHTi4HQ+RNqaCEQEnqL6D2QQIDQe3PAYDoY4oBNNwSwAYOpLliWLFn1Tne3O//39u7kk3xlb+8k3Vlv7NPuTp9vZ2e/ffPmjRBF5D4/7bQ9Qrdf9IB66R/eIqo2V5URYAQYAUaAEWAEBhgCWrG0d8Hpp++ghPl3l1seI5atfEnde115sdSd68kIMAKMACPACDACAwuBoiBY/zvllK0ikciLPr+7gW6PEmJXoVrfVI/VDhlYt4tbywgwAowAI8AIMALFgEDBE6xPTz11gpDyVYBZWVrhMeOgKiW2Fu3G2+q+K0fH/fjICDACjAAjwAgwAoxAISBQ0ATriz/8YaxQajZ+Q1eFSub9d1HphKZW7bs4cEqoTYQZnKfur90k7sdHRoARYAQYAUaAEWAE+huBgiVYn595Zk3IMF7HdOCo5rD//bpA+XaQWtW8+qEYsqJJ+yIOHPxGiwgkWffWbh334yMjwAgwAowAI8AIMAL9iYDsz8JTlf3ZqadWgVjNUUpt3hLxfrK0vXIirrtWDqLSgV9PMheNrRFbxvOQUrQKqU2XJ1z+n7gfHxkBRoARYAQYAUaAEegPBAqOYH169tmlor19NsjVrzpM74IfWgeNw1RgWU9wpJCRrTY0P5kwRm0TD0NjOoXXNUb+rnZl3I+PjAAjwAgwAowAI8AI9DUChTdF2NFxDJGrTsP99XdtlaOSkSsCCf6uTxbLrT/5Rr4bB82SclWJtvg1HxkBRoARYAQYAUaAEegPBAqPYJnmlE7T9ePitqpBUolB6UABoZJfLZG/fmehNo/iSSlb5P61HenScBgjwAgwAowAI8AIMAK9jUDBEaywcm38bVu1joYPs9v4H+vEDm9+or0DsdYyu2k4HiPACDACjAAjwAgwAr2FQEERrHmnnD3sm9bqKqwMHJVtg+uaxPYvfSDfyjYdx2cEGAFGgBFgBBgBRiDfCBQUwdrhzhtXmkK7GcrqmP3LzkHp/bPV7f4LskvFsRkBRoARYAQYAUaAEcg/AgW3ipCa+PjRtUeZynwANMttp8kw0fCNKPHueNQ9F9XZic9xGAFGgBFgBBgBRoAR6E0ECpJgUYMfPap2H6nMf0OU5U8HABqwxOXWphz2UO1P6eJxGCPACDACjAAjwAgwAn2FQMESLALgyaMv3yGijBewVU7S1YSofL1Ld+942COXLOorwLgcRoARYAQYAUaAEWAEMiFQUDpYPSt7+KOXzpMuuTP0q1b0DAO5anZJbQ8mVz2R4WtGgBFgBBgBRoAR6G8EClqCFQfniWOu2MAIR16DJGt9y0/KDpfU9yACFo/DR0aAEWAEGAFGgBFgBAoFgaIgWATW0/931XpBs/NVqeQETZP7H/Fo7WuFAiLXgxFgBBgBRoARYAQYgaJF4NGjrqmC8vu0om0AV5wRYAQYAUaAEWAEBgQCrmJq5aPDPUNLf7XBf8RjxVRrrisjwAgwAowAI8AIDDQEClrJPfFm7H/2DePLNx23SG/V5h/61FO0lQ47RoARYAQYAUaAEWAEChKBoiFY4fagJ7SkXri83i0C7y4dXpBocqUYAUaAEWAEGAFGgBEAAkVDsExluM36ZtpDR43YpHQl3z1GgBFgBBgBRoARYAQKFYHiIVgRUQYzDUIYZsddJ58cLlRAuV6MACPACDACjAAjwAgUDcGSytAVBG7SND182xgBRoARYAQYAUaAEShkBIqGYGlSaBISLMMU7r3/ePXQQgaV68YIMAKMACPACDACAxuBoiFYShMhEQoLozMszBL3tgP7tnHrGQFGgBFgBBgBRqCQESgeguXRl6hASBiBoCgZNvjoQgaV68YIMAKMACPACDACAxuBoiFYr99Wu1wJc0mkoVX4KqsO3ePMq7cb2LeOW88IMAKMACPACDAChYpA0RAsAjDsVzNV/WrRubrVVf2LjZ7a84+Xb1GowHK9GAFGgBFgBBgBRmDgIlA0mz3TLdr1lCtHljaFvtZGDy7Ra6qEu8IXCDQ03NZZ3/TEKzdf+ImUEnYc2DECjAAjwAgwAowAI9C/CBQVwSKopp146fTSVvW0GF6ly5pBQndpwlXqF9IlV3a2trwcrGt8bLvSjtm1tbVm/0LLpTMCjAAjwAgwAozAQEWg6AgW3ahpJ1481R/Q7tbcng3F6CFC+t1CSCmkrgtvRYkQLrV49eIfz33l2nNmDtQby+1mBBgBRoARYAQYgf5DoCgJFsFFGz43v/zJQXpAHu8dMngPud4gXYFkkdMg1fIMKhOdLasf3KJt6YmQZkWsAP7DCDACjAAjwAgwAoxAHyBQtAQrEZu9jj1/nBHWzivZYPRx0uvxUpjUNOholcBuVuDpp/987CGJ8fmcEWAEGAFGgBFgBBiB3kRgnSBYcYCmgmj5S8pn+EYO39qaMoREy1XuE+0//3zsi1f9+cF4PD4yAowAI8AIMAKMACPQmwisUwSLgJp6Wm1ZSaec4xk/cjLkWFB+14RvSEVdpMIYOeOww4zeBJPzZgQYAUaAEWAEGAFGgBAoKjtYdm7ZnNtr29qMtiPNH+siAnsXqoghjGC4pu3Db3ezk57jMAKMACPACDACjAAjkCsC6xzBIkDeeuCGb0KtrS+pH1dChiWE0dEpvEOrf5MrWJyeEWAEGAFGgBFgBBgBOwiskwSLGq4G+xaolg5hLm+0Noh2+0s3swMIx2EEGAFGgBFgBBgBRiBXBNZZguWqLPOLEq9QDS1CtAXIRtbGuYLF6RkBRoARYAQYAUaAEbCDwDpLsLxDqrfQRg0WQteEWrka84RGRU9Amuo/mdq66uOJPf35mhFgBBgBRoARYAQYgVwQWCcJ1m4nXljjK6vYUbh0IYcNEqojJCLNQbdSqmvVZEvLl4OFYT4U0eTyXADktIwAI8AIMAKMACPACPREYJ0kWKWjR5wTbgti/xwYahhUKoTXJUJ1jfWJm0GbgcCduF5QVbUVxFvsGAFGgBFgBBgBRoARyB8C6xzB2uXUSyZXjB5xRqi5DZruBJQCySoTkY6OxXHYVtfNP9k0zUM6Otpmxf34yAgwAowAI8AIMAKMQL4QWKcI1u5nXnHA8Mmbv9C+bJVbErmCHSyLZEHZ3QyHviXQmlZ+siX8bulobV203jjjnnwByfkwAowAI8AIMAKMACMQR8AVPynm4x6n1W5fOXHDGz2lZb8OLGsQKkR7O0vwKEivaANo8CzDjHzdsHz+psI0XgmFQ65gOHSPlHvyJtDFfOO57owAI8AIMAKMQIEiUJAEq7a2Vnu3XttUL/dt4/KX/EJ6XRWa1MrBlrz4QVNdmqBPUmlamae8ZBPN5R0bbmoT7XXLhTJBrYhUEbmy/oJdBUPi4F0nfSmU8WYkYtY0N7Us3HCzPW8q0HvC1WIE+gwBj6d084gyd3JaIB61ZUYoMNNpek5X/Ai43f7tsAfZNk5bomna4khn+ytO03M6RqBQESg4grXfX647etGYDa4cur57nIHVfyoMIROm+kwQJyJNWAlI4igQKSXcHo+ItHQKo5X01GGOwYhKrKw48CGiJRF/9y2HrDpk2sYPRiKRkpaWltVlZe59EYaM2DECAxsBkKud8VD9wzEKSsxBWiZYjgEs/oRKyv0wQF/stCXKNJ9CWiZYTgHkdAWLQEERrP0uuPHcyokbXxf8qR5mFdotgmSRJZJIkTgKDpSp6zzcFL0mpiRlbB9nECqKQ9ODG4woFwdtM1ysP8Q3OBIOi7bW1k6v7jl4xPq7/WhlFvvz3uznagwZKNthtyMsPa3EMD5nBBgBRoARYAQYAUYgWwQKhmDtc/a1Jw+aOOG69q+WCDMUJsaED2uIrVqDwuwM4VIT0u0SCiYXhM9jkawokbLmBEnI1UXINhpTLvbcYpiYMAQzipomwiBXgUBH0O/37Dd2wrT/xEEiu1hz33jy950icIHu9e8Q9+cjI8AIMAKMACPACDACuSDQ7wRr2knnVZaMGX195frjTmr/einIVJRc0QSeagkK1dQq/vfhi2JwZbUYs/GvQZhAq4ZWCkXb4OBf3Llgsf2XE6rETpsMEiNKdYF5fUwjmiLYGYARd3PFoNKSaetttOvCePy333xii7feePJWlLOdJuW+U6ZM7zWDo253yVaGMJ+Il90HxzBQagfrbAfthChQ/Qwu+S046mIg8/WFF56zEHpu1qRrH9SFi2AEGAFGgBFgBAYcAv1GsEh6tO+frzl20BabXKu73MMC3/4MXapg7AYQdYIEC5Irchtvsr2QZT4h16sWwgMpFk0XksgKcVylXrHh2Epx8MQSUeXVLckWTSuGQp2QXBkqGDGf2/pXBx5E+ZCbO/e5EUYwcJFpiJNxGQFhO2TH3Q6fbQX20h/Ux4esN+6l7JNmu4Z8ElOlKPABpYoIQ1x+5XXNusv/Nrz/69Y9Mzs7m3lqNCmK7MkIMAKMACPACDhDoF8I1p4nXLTtYbc9emv1VpO2Ddc3i44Vq6GgDh0q0rUiFyMEMc12UTp0mLXlTTQ8qsguPW6heTFViMj7re8WFWiJQXngOmQq1dwWWhQ0tL2GDzd+fmv2U9hv0NwcROcgWHA/EHE8KGkl9ik8eMddD59HRQ4spyoB8X5o835ho/MG3e1/G4sE7l+vpuqJpUuXBgYWFtxaRoARYAQYAUYg/wj0KcHa84Szqn3jJ9xYNnq9Y4NLG2Tb97BZBbEKrQgUqzGbBSfL/djaxtrlJqpzFcSUYew6KrUCPUJ8FQgJE2EKU4qlrmoRMSCbgf83XzaYb7/1fWjMhMHDtpk86r2G5WIoUkC0FXVR2Zh81aVpJ2y/62HL4v4D+QjiuSPo6Y7LV6y6SnOXXLHV5pveM3/+fADPjhFgBBgBRoARYAScINBnBGvP0y/7TfWWE/8ZaWiraftkMeoak1aRKYVAp0WYVDt0rhrbhKz0Czm4QqjKEiFJoZ0U24mEIQmZXqApQBGMCNXaIQRMOTw3E9OBWHX46dwfhXDrmizx+r5fGfFpZX4xeWNMK8YcSvoeGVy607TDH4n78TERAbUewL39k88W/sXl8p0QiQT/mxjK54wAI8AIMAKMACNgD4FeJ1iHHnqWP7LFxneU1Aw7pn3RUsvKOhGkuDFQ65wkVEScOjqtWqu2gJAgTiTNUn6sBCTFdyJYEZCqECRe1jUUiuCl2gPi488g/YKSuz5hFAiWCxaxhNhy8hCx1YZVlG8EiuxvQG/r4ZJBGz619dZbs2QmU9+AhQug+6bLU3LNlO23rZ0zZ04kUxIOZwQYAUaAEWAEGIE1CPQqwdr/pNoSOXH8y163d6fWBT9YRj+paEiSrKlBOlpqV7QycDAMtcOoqOqAonvIwOpBbNYMIiVLfcSjkjuSaEFKpSLQvcKUISRh5qBKbcFOO459aaOxgxa6lL5wPX3wl+N32SWuPZ88H/ZNhoCGDbEvenvue9uOGDHiwOXLl0NcyI4RYAQYAUaAEWAE7CDQqwRLGzHkb7rPv1P7Fz9hcxvQJJJS4R94UdThxJJgEeFywc7VkAohV+s4h8oUrQhc1WaRJ0nXyRxJsCDtMkOh9k535OZIietfzz1w9dIHH0gWmf2cIACId6+rb3p56NCh+9bX14P1smMEGAFGgBFgBBiBTAjQbFqvuD2Pv2SL8nEjTw58tcwiV6Q2RcrpXRvUWB4xskVThqiFpW9F0ixIpDQXVgmOr8HithRVRBwTNrKMznBLe7kxZfYrd1wy55lbl/ZKYwZ4piDBOzU2tc6kPSIHOBTcfEaAEWAEGAFGwBYCeZdg7X10bYWhh3bwbTjiLx0gV5ZVdlTFmgokCVaMTFm1wznxLHI0XWhN9cXMX6qWDoFNnoWoKhUCiu+kY9XlIqYwaSsdbFEYKDGOnPPs7f/rCuOTXkEAt2nalVdf/1dkTj92jAAjwAgwAowAI5AGgZwJ1kkn/ctd72+dqkr9+5p+z06GrjYPt7fq0pTCaImaXiD6RMSKlKmIaHVNC1LFcE3ThyoIBfd2UnJHJHIUvzUgNKwktNJGfS1/k/JFmqDHvOU/L/zzpXgQH3sXAehkXYzVhW/y6sLexZlzZwQYAUaAESh+BBwTrP3/cO0kffCgs+qryw4VRkkFrQBUAehDtWOHlvZWEdaDQpc6CBXIlTCjR0tiBeJk4AcplIBSOwxYwchoTGzVA0+ydWVNG8Kf4lh5kWkGnJvS/FEO81/aIwlf9i4CminlzSC8k3EvYky4dwvk3BkBRoARYAQYgWJEIGHezV71Dz35xokHXn7Pi66NxiwQfu8Jqq6pwlwGg6GNzVA4D2IloCk0pYlIOLpwLy65IiIlMO0nVkH6BKOipJxOqwSJLKVzClIsQSsJG1uF2dhimXmg+EGfuuC1h2+Mi8jSZcFh+URAqa1cXv9R+cwyU15YxVgCN8LrrdgIx/VGjRoFa7TrjsMzImtqakrhhlMbfT7f2MrKyqpDDz00xeqO4m07tbWioqIa7dyQ2jt58uSoVeHibdI6UfNx48b5cD9q6L7QszZp0iTaJmOddtQXhwwZUu73+0d6veUb4ziqurq6YqDomsafxbKysqGFcqMHwXm9lRuUl5cPofr1Zb2qqqoqqWzgMSxfY6/tBhz61FN6ZP7Ki+SIqovNtqBbQQfKIk0xBOIW2U1YVI+EYfgzGBQl3jKhQYpF04AWmbKmALOHTGK/QeOnBkwLRskYpiH/+9Lrt+5SLFIUl8u/Pax3zcu+5WtSoK0fQmT0yBqfFGdK+DRNVuJ+4KGRW6GTbo6Y+R0spVhghoObpahB1t40oF199U0bGyLyS3SVLbEYYis8WmOw6eQgyC5hzEwkewljo0rZDEW81VLJrzDJ/KGm6x/6PdqHra2tq7KuRB8loME8FNH2kNGtmzZVUm6KOXAYcLPMtyWrRSvu/VfA4TMsBfkMMuG54XDHx8kiOvHT3P4zUP7fnaSlNLhfc4xIcJdk6Yk0rlrdtiNWt+wK4fVU/MaiHYMRtwdxtO7jSuhhvg8Y3vC4zDcCgcCSZHna8aPBuSNodO0/aidNzzguTX+rs7N1UU//XK+nTp3qenveB8c5zceluf7T2dmy2Gl6SkcEtz0Q2h93bztcbokxgp7lMgrr4WD1WayQQnsHg++bHpek+7K0RxwBe3lXkkmXnv52r9G/nzLCgcPtxncSj17crR2de6K/Tsb48gs8d7+IPXfwWsvhUZNLpVILUbeFGIveryj1vdbU1NS8Vsw8eWBcGB2KyL2cZlc9qPTxdKu8fb7K8SEjvCfatIeSaiOMrXg/qCEoT8ck0wNGOJi0T+Ld9WsLKycVw9hshAIzkiUl8uTxlE42lLk3MN4DY8M41GcY4ia+q2CnSaL/iZ8R9gUWvD09fvSI1xcvXhw1mJksYxt+9FH36YKvdlUmjRFyEt4dMLAtRiBp4oc7XreyCe8XKn8u6jG7xOt6M9t3C9JmdoeedO2YyJihj8KUwhSFlXsiTHv+dXcADBhgMhC7KJNie6QzIMLYcFnHe8NfAvMLtBoQU35k4ypOlLrnkOYKPQCkDlbbg8LQzEWR0tJdX591/fI0KQoqKD8ES3vICHcck23D6CXX0Nh6BO7Mn9CJfpFt+lTxMf27ZTjc/mmq8Ez+Pt+gcaFI56G4tQeg7/wS8UsypbEdLsUitPVBv1e/r729vc52ul6K6PGUb2KKyHFQG9wbz0juxFSKH2DU5BkQkkdzJVu9QbDc7pJf4oPifNxX7PuZlBxnRlrK/6FvXHPJhef9GwQ8vZi7R25EYt6a+/4PGJBG9giyfQls/21EAofaTmAzou7xH4IXfNKXjo0swujTY9CnV9iI2y0KfZE/89wLh0F39XiM1FMR6Eg9BC+MN4BNbSQSmBsvAATrCtLPjF9ne+wtgkXSqcbm9mNAKg5Gm3d02uZYeyKo5zwwryeGVpc/XFdXBwlD/pzuLdkbajCO9Yk9Lt/4YHD1D4k1IiLdEQyfi615D8J4uHFiWOJ5WoLl9v8d6c9IjG/7HOMwPsQ3SYxPRLeto/M8yEqOjxGqxGA75y24D8/jnt4FXeC37CSIxyGM0f+PBE3Bx4XCx3vWjkRqs9H/L0P/tyUwAetJ76affuOekY1G/s/sDE1RK1cnJVeUg8XUQhHLAruGbWz0iBRuEx+q0LNqW1UnWuqXi9a2VaJdtYmgK4RfRIRkWIQ0DMV+POtlPkwFesFfcY473s0BEd3nNkNa5OXAMN+UYiJX3drRDxc0EICY3bvV5pN+qWnalfmqgpLm0dnmRaRKc/nPwebSH4Qiwe/Rya/HS3gK8skfuaJKKTEBf68OdBpLUNaTUMynwbVPHdol8UAfoLt8r0XM8Jemqc7NC7miVuBrD4Pen/H1Nx/5v+R2+3/Vp41LURjqsR3q8yrVC+0ncpJM8pgidQ9vpUiS+eTlV127AKQkK6IT3XlA/atHjlld4qt2Ok2ZZZXITmRTnWwnWrI4eLE8ky25ImKlu0t+//Szzy8Cno+BaExD3hhknTmk3w0j9tvUryEVWd9ZLr2biqRBLo//hsbV7UvwzN2KOu+CEh23OVZbF/r0zpDG3lG/qmUp5U9T3L3bEme5j8N0L8bZc9s6wt9i3DkvHblyVkL2qUitg8b+lrbO71Cn8zGIkbTKiavAfTgaX1z/1d2+u2laL1Mm9IGL/vo6EVik/S3KdkKuqBhSPN4d/X8u9X/6kMxUdlqCNf1PN58oRw95waxrrBLYJzClI6lUG6R2nSBYqAFJq3TdJVxuL7YG9AqXC0fNA1kWjIgibiQQFOGONhHoaBUdjfVi9XfficbPPxerFiwUq5f/JMLgWYL2IEx0mqZEhTp2zuM3Ya6QXbYI0ObNkVDHJbg7F2SbNll8SGNooLblMOCNwSD/AEjVt+jcRKq2sZUw90hulHUYHsa36GGkL9rcs8ycA4jGtviqfxcP9HP0QGZO4TwG8t/bUOpd3eWfSboDDnJCFrk5YCxpQEc95iKzPXLLrUdqJTYFMXgK9++uDTfckEYGWw6SnrsQESJzx84Ngn6849RJEpJ+E/DZLUmQLS98td9uK2IsksdTNumZZ194B+oCd+Elu0E2aTPFRTt2D0VCH+DjZadMcfsqnPTGNJfvos6wWoSX+NkYazK+fJ3VTQ2i/NE/FkECfBZJTJ3lk/9U9LH107K6RWj7dTkQibxWjNQilteteo/Gfvyq8pU55C4nNrcGv8CHLCRSazsYxy4DEb4OH7hQr7D/vlo7p7V9qP/jQ/Id3V167Nqha3xSEqwDz7vtCm1oxd1qZZMr7ZQeTfsF8UNr8YWFnCFAwxFTGALCKUybasIFcuUG2fJ4fcLt8Vs/j6dEePylwls5SPiG1wjvmJHCO7RaaFhh2PblN6Jx8SIR0kHcYHiUHGRzutJKHQ9OVib8R5iRwLVA9M2coVDqF5leeKQL43L7/4YB72sM8segzJT9Lef6ZMiAHsbG5rbPXL6yqRmiOg4mAgcicB+IxnsgHaTf0mcOEpcDoXf0earBJk1Fog9YmgjpgqCfUelyl8zCE4oBPWcpQcqicP9+//2Py97CYE36ahkdTQ1jHHI6FRfNX4oTiTxmLMxmBEOFT0JUZ/lB7zGbKRGa+o2YkY9R/21tVs9BNDUYQ/xsSFP3dZA4r0lIV+jLr7/9DJleiV+iLk1ey+mRWQXee397a977H5OSfI+wPr8kST3GntdQpzF9XniKAqFntRnWsr2HOm2eIkqO3moEfcjS1HtiRnj3DIb+51wQ4XPh71ySnpjp2udepYz78Y67OZVSfNIX3oFn3/pXUVlyMa3aw5dPakfEqoc+lkWy8NSZ8CcDDUS1dB2quRo2YZaQasFCu46fJd0iCRf9PES+/MIDsuUdUSN8o9YTbsTtWPyjaGmsm21qeGFJ0ah53E2pK8MhdhEABXasL5FQhvvHH5enfWg6AuHHMPiehTS2JQ8J+ef/lKbWIpE38TAele/MIS2YCAL3IYjAccjb2Us050qpYRhsZkGadF7OWdnNAKtKQe72sxs9l3hEFjojajat9LKTDwa32+zESxlHifXdvrK8SCBJugK9E+obDp1mS3pFC0ZowMcL7e8oqMc0gMOi0ydzo6yt0kfp3VBIx0/AtM0cvG4m9G5JKXKHXmXYiHyAj5t+I5phI7QrXruvoIZ9IqVPgUR3byWHR0xjLkiErY+i7omzupKQcj8UV5UgctUejLyBfrlFVrk4jIx33J9mPvsCpHNru7VEm9NPv+lwObis1myAvlU6chWAiYUe5MrKHm8YBb0rDVIsoleWUCt6htcOMoy9ehAteopRECksiRcVpzAK6SUuIUtC0Lsy5lRVDt93xhO1YHLs8oUAFKPfw6D0M9BeL5c8TanGIv2HqfKQun6TMoy8vKBSleHAnx7G+12+0rpIsP0NB+nXSoKBdb+IEXkCAaVrBfaLh7oWUyVeMxK83Ebx9NgVj8NLtLkl8DDI1oH4mEtb93A4gH7uJ32wyU4bCMJ6MtK+5jR9PN1X33z3GzxvtGrLiWutrix5pKGhI2PaK666/n6093cZI64jEYhMmgoLePrdqUplqFmYMjrRCLff39fVwQzB3SgzqcCkr+uyprzemqJdU0LCmR+TX89BL2pfkKt7+opcxcsnnVh8uM/Dqsln4n507HZDjjzxqhq5XvVdZn0zsZ61HfmRgVAYFbWMhK4dI2rXitgTORyjfCr+QQ/CZRWJv5g6pJ+UkHBBukV0i0gZ6W5JzAy6lOvLstHDD5oxg8mVhWUe/9CLCXfk3ZyztMwopM4l0tn+KsrC3HvBOY8ZMZ5xu0tz/sJxeUv3wkv4abSwQMhVF9aXYZroj11X69AJPsgOAHGyKYXVcpJiUVl5UWZW4hSntwDP0MMNDQ1Yvp3eQe+vFi/agUOuPP7rSXqQHpU+DdUwZXQ3XrQg033uur3L+7z0gihQDYNe1Ad9Ta7iTacPd9KzjF/TsdtNCQytvE41NVdYOlcknYK5BRHEjwgV2bAio590TiQrhcNyXYtU4Suq2zFOsbqSgYNZcSwRFyRYIFpEskgJXja2N3pGDtn/2QdqIUZj1ysISJGz+QLcv0EZ66bJyzPG6Z8IFYYwHqcpFafFkz6XaRgzkb4vpmKyr6ZSN4BEbpl9wqJIcZEd4jN65FBIFmUuC2NcUGY+IRdEMH28KZ6VnZzmAZMoGacH8VI/FGPvX52WUWzpMA1+PvRrzinAeut40T4GnbAdCrBuA6FKa1GNPmx0BRTqL0ssr+vl8psTr9pcKe131mpBsjllKa+DXJG1dawOVPgJA6QrLp1KzCXh3GodCbAQLybHip7HCRcIWDyA4tKUoCzxYqE+3lEgc7KhxXRVVR757IOXfJuQLZ/mGQFgn2ZZqN3CVEZiYXR2vIwv8A/s5tin8bBC7Yqrrj3aSZn0cocU7Emk9TlJ30dpvCCRT4zDsu0+Kq8vi/F2hs0zMxX4ww8/BCEovzdTvLThUHbPhYibyqBpRkcOz85/Q6G2hekSkyVuZYqMJCxdHsUUhg+bXfDmuLqA6+yB+sQjdnUFC7gdXLUsEcCH1GGJC3G6CJZZUfJH0dwqBba6UbBnZcIsg2rB3oLY3sZsh+QKphVMSLHI4KcKYN9BrNNP5SCmtoIsDYkY0bLIVIycRc9jUjBko2DigTZ81mogEBlWOXvLTXd+M1XeReqfGqx+ahAqNDTnoqWGuWQbrnClWMT1/zo1y2XWeIhksNN4ED13mI3W928U6Cxh2bbjF3z/Vj596fg2O9XOS8ylqTuQU2zASZ9n0lAsjrjymhv2SBqWwZPs/2Bo+12GaKmDZWbiBAkbFNod63elLrsAQ8hQJaTGePasCZICrGGsSugzMCHwj8KtINeslxBwYfLvjHjeFsE68NjaQbCDcJRFrkCeBP2gqI4XCeJFuUGUUEWvSYldwao6SZ96OiJKpGllSbAoPf7Dfks0Lxyj5CrqH82azmFnHFOPZjN2Zij37/HJqo8/n378FdN65l3E19TsQnOb5FohKU1bU7iQYr2IL/GPci2vV9LDPhC2LsnqBah7Sk9Gr3X0wu2VNmTKVInz0kixCrFvZmpRLFxVrm4NZpRABoPBHzEmPW8z06TRYsruScPSef5c13Q4BriqdHFSh8kVW242kaagUzoy7opx+siUEdaxgNb24N/wvhidj2aRZB3bit2IJe5/kJo8CvrAJ0Ev+DI8EK8jf7wEc3NkmobMR+SWC6cuNgRAi7ok3hbBMt3efc2OYInohGQKpheixArNIoJkkaVoE62R2PKLkiYByVY3koWcMW1ipbdIFhgUpYklwTmuKEv8ov44oeuYk+BrCpIzs7VtE1FW8tqBJ193QTyMj/lDgAxS4h5PzjVHKfV623nYk2K1oV/MtgY5qZ0gdW06lkHsoEttW83l2g2D4JEIuxoD49soN6Hn2K5F8ojKtK2UShtPo0NfmjyjXHzlKqz4+Bjtp4UB8/GE2CKvNkssWbasLq1JDZv5FFw0aG1OtVMp6dJutRMvVRx8Iu5HmyCnCk/tb61CTB2cJgQv/7vJQHCaKNj5Q5yfLtxhGCxGiy/RF+fg9zr6JdmXaneYV96SkUVuvEuy+hhKVjjeQ09jT8dfYP/D7SKhwDlmuON2rP56HDte3A1jzLXYW3MPGKodC/xp6T10Y5w79JvLnKfmlMWJgKq66qobNqO6R800ePXpAtvbGJAi4YHCqyv27pK46jpfc0q2F6IkDF2VbGGVQMWDuBKdx9J3vf0oQysPMtsQzzfuFaNhCMdLxcrTOkYg0WpslVpV6dUHnXpD5cw7zumNQSRa1wH4NxiyljVbtzqX5vvc8n9kwN+OgxTreaxq+xg3+Zfd48tm3PqHwfQf3mGH7T6ObnPSPYZ1teY18wRdY54bm6Oqy9B1jsVlTm1Br9yJpglTlk0FxtyKlU1YmZebeYt4Xjh2YuXsHXgKHg2F2uej73c9NhSHXuiYrf8DlHlPQ5mYP8/atYKQ/r2sxHPTarisU+eaQIqvsV71M9ydlai/Bil5DRq4A87zNrWK+z/FTjXJJIfm9n2FIcip5NaF5+YElHWFnfIoDq1SNZTxK7vxe8Qz3Dr2W+vhmXhJyvMwJjo90S+ncxApPIvXlpd4X+7ZX8io8A9Lft4ZkrwzMI7vm1M5DhMbKlKLpLrD5JQMdnG1k0Ck7jEyZBLbw/Q8SAhnYvn/K0hamSFJ0mD0991J4d3u3nVJM1kXPaVYjHHvYzSNxgY/nstxwGpHXGfU680dDtmEF8bbmFr7Ga8O6ESJUejTOyPfitzzjuYAMdP2OPsUy0qxzQW2PVFBkCuLCCUUgRZHyRFO6JzeY5Zf1N+iTJBYWdOJJM0yoLBuxVvzxotLw+gNGH8LWkfEi19TzvF4dB6Pq0j/y6ufN/2kay02SGHsckOABn2sNjort1wotVza1taGh8O+A4G4vCu2lEsw2J0wfFjVCHxJ/hE2iz6wQ3Di6QOBwBLsAH88pFpHwG8N/YpHyO5YNnfu+9tmShKz1psH7IAepHBet9woEg6cBbtkH/UkV1SXjo6O5fiivqh6UOkYhFvEMlMdY+Ht+Pq+rtTvHk/bI/V8WdrMw2k0Ay/pu9y6ZyNs9DqBNkzG/f0D7tWpOD8YL7fhmq7vjYf8C6cFdE+nRmBPvPHd/VJdyX+mCrHlL2WX6N9OfFMYp9iJlywOXj6z0MeXJguL+2G+4Lc4TxxG40HZHrF0W5556UXnbUWSnGT9ZfHixZ0wu/Ia7uF+1v0TsinbQnKJ7/P5xuIdcVgueeBj4woiV9nkQbbUpA71mRx0+JRURMz7z0n5KT7kbsFYeTg+ZHeG9G4z/CZiZmAbzBLsi4+gu/uqcuisL2NV7JYYGzbCuHA4jf0YG06E1HBaZbl/mDVli+V0vVIfKb4HBofuNGW7YejH01HuKSj/NJwfsOmEDYbiGfgTym3LR9ngRkSwhHbIUZdNAGmqUmQ4lBxIlkV2LCIVY0vxZziuc2URsajEieKbltI7ze9RcjrG84impxGA8rTyRSQ6YhC2FOVJtyuqDB8dKeLxrCOZgyDi59ZOt+rGf3JCANsWbA47Ia8iE19OGSEx7t+72eaBAXoWiMJ8POz/GDyobCIGu/uWL1/ekW0+ifHxQngKtcl5KhmfMbsm5pvsfOasl3ZDr61JFpaNHzB4fJON159GJNFOOrKBdMlF5x2NdJlsOgWA7c0lPtf6mPo4v7W1dZWd/PMXRzboUk7BwHVyZ2fL4mT5og0K/eCVodWV22IImJMsTrZ+YTO0nZ001ZWlDyJeq524SeNgC5Irrrl+r6RhPTxpHzQMc0f38LZ9iSnNjGQQBjbzIb2K0FS8GQ78AyslMeBmdnT/XJoOyaHM6gMrc86pY4QiErps8RdR6nipQkBYZ4Y722tThafzh/T9pVzGGMgwDpw8eXJvbdeSsup4vl4lFQvc2y3pQ47GStpuCatSF+D3JX3YUdsgXXsnZSZ5DZAXgEjtEw63f5os26ampmaassW7hQhpnHwki5q1H4011ZVlWwCDfyf7kF+4cGEIOP0d4xcZxnY+RsRqBpazLZ1qEY+2rSK9qbaoBIqahcp0dxgpiDR1c5YffMjb+q0dx8oH8aLECvFQTtQvMbtYBrF48bLpiMEYyvTQCfO4jj7q1Guq4MXOAQK0dQAse/8V2xZ8CORzJghWFaTIRqISTYKX63o1g3fEw35mfX19Xr4UKOPfHLTfLehY31uFOPyDvpZRRwkfA/Qlm5NDOR+MHzvyOHqgs8mIXn70tYf0jyRJ1wn/23webQNg++dsJYtJ8nPi1Yav4h3pi99O4rq6uvYSv/tQPOU5k0AMHcPtlElEFTg9aCduyjiGsrUis3F1O/WV8pT5pAuQYlE40PZmuigwaLgRxt2J6eLYC8NLD4tQ7MVdEwsv6C80XSMJGg3gve+kIEm1U6fcLnUW7r3juuJj8Aa8kGx9EK1dSVX16YKv8HHWZw72juRZIDN79R15St82+vCjfXDTx4qG4gPtQdyrx+zEtRUHqgo1w6r3tWOs1xq/pHa+rXzTRYI6BAXDvqe2kQrjfpCNKzIqSs4iT+iLXUc6jfXNxGPiuUWdokrtccJlpUmIQ1OIJgwSS5JMkX8szIpHjIqKsH5RUkYK9JRGtAZL212upw6tfaoP5mcJgAJ0SpWSfY1MP7Iki+0CJsPC+J60J53u8s9sD4SXoUW1+OUJP7l6/JiRWQ/KhOrSpUsDdMynmzFjhoGO/HhOeSo1OFN69NO9M8XJEG64NPf/0XRLhngpgyGdghi7S3IQxjfIv2iqkcgXphShU9A/DtO9Z4ZCrV9lUzokbGQA1Nagmy5fDN62P7506SLJUGwwS5dr8jCMTPviGRyZPHSNL+KdsuYq2zPo5WUgAxEzZE1BZJtzYnyUMR/E4aZEv2zOacoQ9/2hbNI4iWsZlM1hv0O0811aSeqk7Hgauh+aFGT3zplTakdnCbNPhXtyCqQxt2SfspdSSPnj8JrBF2WTu0vz/DWb+OniQgXq99nMlFx60bl3YoxNOz2frrxomKog23macOtjScHdMsNA+lQW6SG2E3PWUJRAnOAdNdmAE4zulqNjIlkiT6SDWDYaTnkgXHqwDQ7imiuhbxtTqO8qCVOF5Ihsxf0oLuVj2d0KhKeFG5d8MP33V+Y8sFgFFdkfDNi/6QyrJZl+2PTzG0wDfgRbMa8AuWuR7kA01ZvP5mKguT8XkpDPusTzQjf5IH7u5Ajt17QEi4gt8BzmJO94GvTnpzB19k382smRpv2w6cHpeDTu87h8G5Megd2pRifl2UojxbeRkLP91/xejSRytqamUtUFY4ZtgkUkEKPKG6nysuGv4xk8MV08fOBsg4Fsq3Rx0oR1VJR6H0wTbgVhbN0sU5yM4VLcQMQhY7w0EaDHc2Oa4LwEBSM9F8Zkly0amNvHV6w46Co5zgfvzC2yq7Wz2BgX7iXVC2epeymVUndn+2Hd2dn8Lfpm7qZ9oH9G06LZtIxmC3Ii09HC5M0331zpEjpW9sBau+bWX1fB8K8wMFhibXrqLH6DE4soWawHF/FrihD/EHTpMSvvlIi8rcBYqJXAyoPIk3IjbgDHJswQYYmUGLRmCzerCCt5Qnqc0pWEnpcRimwhK3zzDvzDDc9hv8KTZt55Tp/pAKAK7CwEZLPf57qqNSbszCcolZWVVe3toU2ULoegD5VhzU8ZegqOijoJ9DPTOGWOSBOaOUiJtAQrZMjJXf09c25JY0BanPHFmTRhD0/oEcyA1wyQqx4h/XSp5L+cvqixWmtFbHVfLtNd1Vm1XIfJBsOcllWaxMhSnoAFD1eS5DTRO34OOb1j6RXG3MeSKZnH844fMZb+In7u8BiAja1nYAbCYfJoMtLnwergz/GM5k74UtQEsxg9Vh6niJja+zjsXXlI6mB7IbTcDM56HdlLsSYWEvUFwQp7XPKyuDr1mtL798zj8j4ejGQ/VoEPzAVuW+dUe5W9KguVp6SYhzv9l1zKhtWrKhAsfTC2wFHeCu+J+FL4uwobB1qSJquUKMmKEqY4/UFA/NQiUriIwGyKx4PtdEKx7hePQJngnIiVdYrzuKI8rmHzikxiSzm8GuH4Z0WKJrGix/6QP4XTNKZqbMeC9ZLpyueaBL2sbR+744I+Xc1CVRrg7up8KE+TWYS57320E/reAXhZbIG7u2lre2dUPwzroqMufsyMeFffyRw1RYz0lrDxBbppioR2vSNVFSXz6uvb7cYvmnhQDH0zFxEUPuA+w/PtnGCp7HSdLrng3Bcuv+q6HzHgjHUEMgxdPjPrRZoufqFn+qqqqsrm1sARPf3tXmtCuz0pa+uRAV4A4zEkOnYYid/LZGPLbubIi16EvUawQN4n0se5YwfTMDmkdlxs94Rq1DhsWUVbN3X3z98VcHqm36XZazVHNgaDzd+t5W3DA++EL6KEwkbkFFE0l/ahCTlOts4l3QvCAnwmB2cYkXJIBUxIrNTCGTOu+wlkax6ZXLAIUaxDd00H4rqrk1th1GXxaNFTTqMr+ZF0ihydJ/664mHooM2iYw5f9EvMlc3C/LkRMZCXlS+lj/6oPCqfSiG/aF2warG5AwvzjQ0DQl5IQez6BgE8wG9jievfcikN0ydb6W7ffW/NfX+FGYm8YSp1Jm7tVNzd/CjfO6+cj+bMUyXHZLrtaaikeUjxTT4V+5OW4cyTnrZcXHDzzTclQ5SOHZ7vXHXHUt63ZJWiKQCMJ7cnC7Ptl0LZvbkt+FvkUWI7n4SIeL7excquTxK8Up8qmZPNHpSV0z1LrBhG6LzllZhv13kWU8BdaQrwBM9/Ze9WS87u3fyzzx0S2QXZp4ql0ESd47SxhD6X/NxJHiUlej5mx8gElsQUjPiWKqE82jxr2g5DbpTUxMhNrIaWn3UeJT5REoV0RIQgvZI6CBYQtRwduwgT8qFhfDW+3mO6VggNi47gsxRX1YNkLVtlJYunsXKJDf3IPVofxIj6x7bWcbtPOuD460AQC97l+hIrgAbKOihTH55siaudypEOk+4ueQD6YfPRLY7DXU87JWcnz3zHwco+q3slyxd9PKfBER8QsQ6eLPci9pPi55wlIVK29jUCpX7XvSjTsTQBY9Le6NOj1663vVWGa6eDj1RZkD6VE8HCh03e+iPUuPKWV3JcZE7PXtI8+8EzEtF6tR2wLzW3H5qVvkglGtNHSB0KZf221KH2QiZMmNBkL2b3WNOmTcu5bMoRZjI0DwZ/aJ2Tdeyy+XjxBWmvQUtilECQLOkVXeNHB3wBURI4kB86paAASFapz4oTj2dFQX6wzA4SliCrqyi5xBUKda3oUatahPpuhZAhKPcklGuVYhW7pmwKl9Abw1Y9FUKG97LKKOw/cbAKu5YpayebdSmmO12lpntLDoBi8CLamwtFFCkWuUkM8HxYz1hKiPsvIMf7kfuWPjB8u0as3Uc4WIsFZE7Kz3rYkN2U3cliN+6zQ90o2TB+zCjSrcvoMBbTPXMkJevKXMrmrvMcT/AizFteyaqCN055Mv9i8zNNo1fbMWZMzfcFh4mULY7rFDFym6ODtrfTj7+YfqXhuO6xhJo0oBRlKiujGTNqQ1JzzRNEhIjE4F+UWHV/K1rSKIRbYfS+BPexHBEj+g8tO4VpPAmJlWpoht4UyCC2mI476XW/MeuFG66f+elDX4OodS19pX0IjUXLhPq+TpggXKhbc7SMeMo19aCiTCjJa273dmtC+Sz/CMhV0LHZFfZB3neSN6RWJ0BJ9Rmkze2F4KTwvKZROSpPQVm/MF386XVUOzz9fS59clTRJImg73RbEm/bXtjCiJTdY3oRGPekcKzcjinoe+2uzMWYSfcsN1JKi0jy5PDhlLe8klUJ7yHohBS/w33LlTCkAyFgt/+kyyT/YWYvLIeyXcv+LNuqpAa9piaQlS4dBlgQfo2U1i19pxhhophxohPXgyI/+oyyNnu24sUIF50TmYKEyZKEdSksUwo4l/61HFpKVqmtgR0Pz3mQgHUTx1lGTzFlaHzxUyXI1vXYxOw1InzkouXFiBaZlXBpE62Awv4TrXxh13Ht2kFPA8Yjp0Av5OO1AzP76B4sRlDmPYjZ9RLKnKowY6C/5iSBymQGojBbbaNW1tYNNuIVYBTq17iv7zqvmhoJZfd9KX1FRUU1xshDHOZlujTvndmlzUEygIKwJUluOoWJlVWyOvEy7+dK5fTs5b0+DjPUdbMX25Hb+OSwSZwsAwIajH42gii54vGwOm+GJZGKGx21RFJRaRaRHCJV5KIEbI1EifysMNoqBwQtmZMu/TP/kIpdZz1+dZfy2vMLH/oJX37nJotv+bm0cyERnxbNew1PoXEdgyMKVcUgGYnDlrKZBRYAo3rylvXHjtw2W+OR8XZYLxxTZfnSiKcuvCOkFbkNjkqtTysnC69lA7xGUtyaEwKGeTKlb+sIH4sD9COyd/jIfCkYXP1DVimlcj71goIwfG6UVXlpIuNbOW95JS0mx4+bpHn2g2dZWZkjfSCbVaWlZuwKDAGXMiMgO8obr9fzz9/4/X67/vEDEQ5vKyIQPOgQboEexCVYxGnonKYPcWYJljCRaCWnvzKCv2R9PdFpIohpwfvEuKpzZtxVu5a498UFj9yx36T/2wvZHpCYTA6GilVNFZWHSsTIVbQC0WguF0nJ5iWm4fPcEMBdnQ2r6Bfi6/5DiJwdZ9YeCF2NxMMdZ5A8YRA9DL9kTpGUrNd0HLBJ6LdR6W2ysm35lc6b9/5kxHQ01WqrBI6UNQKbbLT+018ugvKnUI76KkalvXy+QeNCRvDk+BCVdSV0ebtI/k2aMiuMv0sx+m6QMkKGANR7B4yr+EaNziRkiJ42GOP2lLQRcgxEHb+Nv38cZQVL4hjXljhKm79EZoGuIs5fCzmntRBwqbD5JXw3TwzR3K6nzLCxbVRpvYt7RSVGeJos141odXlFldRppSCZV/C53hR+7wu+Us8jM2ZcU59YRs9zv/AeF5ChT/AgjaEwDbaxxODY1H6sTJJYdRWP8kHaWj3Bzty+QHtWZGBeRzBgvwIJ482RYNuba7TlnIExDvZeflq64ihnqbtSkSbvbGzmdK8uXJ9i2eyKdAYYPZ6yiREzsrArdZ5PYBdlfq52UdCgg1CtnAmW11u5gSGNsXSv8tBMwDxwHe0J6fKU3AUJ5aUOUdDCRucDIFcbO0ovxXewy/UqTEdkm3wBEuycbaI18dUQmEz5Fa5zmCIVAtvY1AQ6jW3W5Jv/MxBJLL5y7tDBl2IrqR2d58ApGQFnCGiYzvsCpKbbl7+3wvcQOmUHSaKszZbBaqxRGEf6koifW0eUG/+6oCOZa1ArGoVaCWnoypbjnn/pppszkSuq+oyF9zaCP11M59KPLfOqQa5iXC7OqqxyUAYF0F8owZ8x44FafH0WvIu3pJAqin3sSP9EnuP36qONSGD/PL2wxZLldfugod36VJYND0BkuTM2K90DVsufpGnKdOQqy7wdRYexvMVImNO0DJaTnFJdXV3hqAKxRHgGMKsfupdsiOku339cLl+uL45C7Ju5QJR1Wuzg9S8kimSdMJYA92Rnp2mhGX+nZZcrywwwCn+eZZK1ouPG/3ktzyw9sDr4dCRxZ5ksq+huzZsTwcL92QHPyU5ZFcqRGYE8IKC5TOML0JWhiXkRIYIu1t8tP1Ikb8eClZgB0mi8KNGyWA4RLjypNH1iES5M20WdDM5a8GBWYlnQuajICqsDrU2eKSOLUMWyTDjobtffnr3vogcSvAr5NM5F+6mOchXI1Af4Pa5p2mWaru8xdHBlFb7qtscO5zfSdiV5rZhSu+eSH6bjTsT+UW/nkke+0wI7CKDknNzyVWTl+9pc8tA9pSfFX+h47KaaQrwFovWa2+0naYQT189900mV85sG5keW4/4+k99cbeUWhD2u+2zF7BFJF+KjHl5ZX2IUPzgX4uHzVa4PExtnZF1wlgks/TQpvs8yWbfoeFbYKHU3RPiiLxDQdNP4FgRpZM/Cxm+y4WXQv4p+OcQlWa1BkCk8ljEyhYG+S3rVNUpjl0RykEbRZo3o1/adNKU1VUnkSi1fFSVX8RyIaMXJlhIdpsdfaz/n4o+Jl/ssrOj7hZ2fW3dPgFHQURVlvqqttpjkAYkaAjK1HX5HRUIdtZHO9tfr6upyNDuQBlMlR6UJzRRk1AypejZTpH4J18RjuZaLZ+ZU3V16rJN8XL6yqXj4buyZFk/G7oZS74JovYhpH9LzysbFn7Bs0qxzcTGu5WSywQkgsB/1pNNtp0Kh9o8xyi5zUm5CGg1LhR7DNF/W+mejRo3yY2P5J5FXRUJ+vXYKvdDHc8kcnXxPTAWTXmheHJ6zX2J/w9t44Upe4FxnM9GwRQ4MVQnPAQecW57YyltvPaNTlnv3km79P13+RHAgXYqTqfiRwqNkK8aBMMUH6pW9DQoppnaV1RqAhXdauIUy48TKCoSkTKpZs+47r7UrbuGfoBE5OqykwcaqC+38Ojtbv8aeVMtoWs2pobWcaivFeo7TY0uZ5cuXr7UQIlN+EdPYP1OcXMNB/J5HHt1MijjJUynjXs3lPyebtLrHfxCmBV9BmqiUN0lidLJ9YCn/I93lf9btLt0iSRT2SoGAJTHN4/YxKYrp5g3zM7d388jiwpKoSjEriyQpoqqRgZDxjtdbbluHrLy8fMjPdavexJi/dYpM8+4Nm2U5f9xA2nYBSNGtqHfiqyvrumJz69PxnL2DfP7w9rz3H8YULzQa2DECayMQ7RhKteiGObZn8PPP39Tw/Ju37qqVeo/EvoE/U7iKYFKCjiA99KOeGj9aRAgbMssyP/lvcOzUY31W5Ax/nj/pyCF3HnLUbOSzSWJU1dAqzCXQjQ9haSKRLPpBevbbsaY/MV4RnOf0QBdB+7pVETdrUDePbC6UGJNovNFO0kFwiHeenbi5xCHihxfbA7nkEUuL505dj8F+TqapPSjvT0K8hyA1JivfXjtlA//phjI+AdGaQcr/GdIMqL6ZDgtIiftMioV+NB/Gez9IV59MYZC6PZEpjq1wJcaHjfB8zeW7pKampjRVGnouYTj4xPZAZAHGaqdT0qmyT+tPH5bA7K20kWwEot6nu9z+lyEN3sVG9G5RXN7SPfAsvof30K0IsJ5F5HfEFVddew+O/Bx1Q4svCIEowYJ6ScQwU36NzHrl5id0f9n2UchixApcx+pRdLS4T0wHi0gQTDvgUF6/vPPwTDD/96RjN+sMGB8vbgjtljRuW1CY362Qx69viF8OFmJ8uWjfqL2Fv86TglUonjkZQSyZOfP5KXZbMnnyZHdre+ddICz5M5yYpnCfR7sKwVlL2JJliUF5Z5ra09y+bzBwHFX4xgAADz1JREFU3wap1p+xEfbv8IV8Fl2TEjtWRn6OeL9FeqjdZOXwWKpDKD3yejT5vnlZ5bfOR64ZOuhRjGa9aasoAUOYZsjRQer2FkhHTiQtoQokGb28flVzPYj5LJCti0Gmfo/+eAz65XnoQ488PfOFlbA/eDeetZqEdH12ig6dFz0qvKH2hDT4TTxnn2nukpMx3bcNrYbsSZJoGhTbH03B1GIt2v+RaRivIs52PRuMd91xiNNn5Lxn+XxduAi4Djro7GHh9shQKc2dUc0HUlXVXd5ZF7G0dvCdh0gYvPEH5zSM4xQ6V2sclkuRk6Y6GIcHrYskf74664y9OiLBJ3xuvbJiw4jwuUzx42pTNAdllyktv1uKbcb5xJ6jNbHPWPH1N1+1DI8YypMku0L2AkIDx+HL+mc0eCunLTalfBgD3jZQvq9Llwd9bf/v04UzUNbe6eLlM4wWBLg8/luxrD9/EjMlNsRTtCHVk56l2NNFJ/lwGl4KhyrluwhbcyXLb0D1zWQAxP1IQgnpxn0Qkv8l7tc7R9m0Xk3140uX5oGnS3EdhuKn81hPP/oiTbfvv8ZIf3SMz2MZjrKKRALz8NHxEjosrVLO3Sm1GZ61O7GMSwSwjgskqhMfO0vx5oKOixq8fEVDiVUIOkQmh2fsNPSdQCQcODtTXA4fOAi4Iu2qGjs+z0NH+y5ds4PN2lgrPEakLJKFtwF1PaJc1ovBYlrwiPVHXHab8kvM/4Xfnfd/P7dF/qBr3q9Ijlbi0cU+iI09uUDWpOg0FcxxSeXWLRonIMQKy9amjSIRE9ZHZVtiXkVwnkg/i6C6uVUR08kfY0sj54OgUqMDnebH+MK8dszImrt/+OGHYGKNYBF5WEcwcmr9qpbT4D8sMawvzgdXVVxR39h8MPr5Rn1RXq5l4HF6KGtL4bkWWqTpdc1zh2l0kvmCXntmsQ7o/qVLlyZlu9nCdsmF5z17xVXXfYAX/LbZpi3G+G6X9/RQpPN/qHtvKNd78Uxv0PUCyxIgU6m/QJLVgYVEl2aZlKOvowi4Zr1646L99zprntftTjufr5mRscT0SVJlWbTGSZRkkWd0NIqSLahJkUkHcnLt1YnRABgUivh2bw7bn8fHoLR40wqzJp6ejwWMgKb9R5jmxbnVUI3AYPcPGCz9G74ql0BQ+gM6XylI+3iQq5hZkRiTz62grFPTCkxMKxxlCPMdJHZnnUHfJgi6de9VRrgbR+3bGhRRaZ2dzd9iigxSErVvL1Vb6Zr7zkhyaWLWRZINLY+n9MSIMuYjcaH3xazb1zMB7NF9r3t8p2Grn0d6hhXCNRTpL8GUagdWbl9bCPXhOvQvAthyzrLv85AZUs3pqmJKMc4Kj+vy4U2Hr6aoF3o7nUcJF/zaY4O5UqVHb3h0b3xppKsqh/UzAheff/YcsOvleaoG9kMS49Grdol+pXe32ZanMrLOBlsJfQTCl9VKwKwLyUcCqZ1NL6V8ZDVQ8pC61mv6NBgjX+/sbPkmn1jCZMPnsG83YF7oRij4KL7v78knhvnNS10D6fuZ+c2TcytGBCwl9+dfvXnhzNduXJmuAdJQ1tJ7BVECzQcSmaJf9BxnRLboB1tZIkyyrqhbrakh8fMBfAQwA8fFLFP/bV1vsRkO/B0vtssLtZ2QMc8ywx3/LNT6FWq9wsG2VzG45ZUEdbVV03JWbu/KK+HkoOn7XoZR+KUEr3X69OAD9z8FwoGnCraRSt2CRQInFWz9iqNiRf/etAiWLaxlbOVUrMlRPrVm5SDpTUHvBrarugvCdEOMtZX/uh3J4qLrdhO7t27MqJp/4iW1uLtvr1/F5qZ7vZyuAqBv8VdNkzd0eRTICZ7HD8vLvMcUSHWKqhok1cfnY/6JkJQ/HTx93xd6A4wZM2YYVYPKjoBU9bPeyL/Q8qT27rjDdkfjI2JmodUtVp8w+lCoQOtWLNUq+vdmFgQrtnyZVlTQ8BO7RTQ1GCdbqgm653H9q1i4KcyLaqfWuorljvZSPYHYwHKkmO7W3PuhpzT2Ycv/2odldRUVCQXOhVVu+lrFWqT+dyAI71SW+6f19/6N/Y+E8xpUlvnuR2pr3bTzXHqkVOpfRAx6+ObtsqGhobXEq++O+/9R3jIt4IzmzJkTueTi8w6BFPkKVLOQxtgWzaXvY4TbHyhg+LhqfYCAfYKl1JJofeK6VthkIVZBOlrnqzvWqjLo124fL/tqz7UCBpZHHKoB1WpYlF8Ei2gHodG9/iWHL9lnQSr6bTrMCHfcrUttRzwIP/TnTcbL9cnqQWV7NjY2tvRnPYq97KampmYI5R/OYztC2FT93jzmlzSrtra2lUOqK6ZiwOmz6UL0ufmQnH2atEK97EnqCLRqD3pzMC0hG3q5OBvZy6UuTZ8SCbbPthGZo6zjCNgmWFLqy6JYkEmG6MeCdbAkWKBRJNlKRiOkiJhSq1/HceTmpUDAMoaoaYf1qiQLU5FlpZ7jU1Shz7yh+P7hiJohE2N6WX28bE+uxibZR2O/ySPq6+shSmaXKwK6dOWNsIOEPJ3Jrluu9Y2np1Wul1x8/v4gPWRuIi/mIOJ59zxiyP9PVWXpLrB910cGWnvWIHptdHa8WF7q2Rg4k5X1PlcVQJkw3ycf8XnkdrToIHkt2XegIWCbYAnNLLHAiZEo0lKIzg2u4VVyWNWn+Oq7Hx3tMUS7HksUT5Sad9wLXz/2QT6BRd6z8pkf59W7CBihjuf8Xm0i+gVtDptXhzwfHlReMrm5ublfB/h4o8i+EelleVxetFc8AP/enjYMAoPbMLBPMkKBx+L14GPuCGB7lgUYa+bknhPGSCXyr9OVpmIk2cEijJvdumdztOHlNFGdBhno33eNHzdqb5qadJpJPtPRGIAPjDNcmmvL2FgDPahed2Ru+2mUuRnK/m1HR8fyXi+RCygaBOzrRhnmaKtVEpyMpFZ0gScMD68l0UKHFsrnnlT169E7PPzwjfnVXbAKjv2R8tnNd9nldHHHHYm+fF7gCMS+3o/QvSWPYj/Jv0IKOjm3Kss6dMUzQCqeamzs1Y90R9WMmUY4DkZRz4XdrpPwoJxA5iYcZZY0kfwZtuEe87jlTRjUf+7oi1dJ0nqs454a9ic01dScWinl57DwPTenPBwmhkkIWmiyD+y2TYYhzAsxck/Hte4wOysZRv3ndU2/gPYHXLyYsi8sR/VCjY4oKSlZLxgy6dk7Fs/euPzWUjbhlfcajHRfB8n1J72mWJffSnNufYyAbYJlKr1dwFYDOitxKstZ5Cp2Hp02lKKtTdBmob1CsEDi3q6oqTlSHnZYUfVnTdOblTL+G4PK0QHbVnzlKGGBJYIo/3lU6Xmfb9A4WGQ+BIPUIeg728Kvq1+lrrJciQVez0hd//dB++8zp6fCsMfjiUgZdIzzpEmTFPJMXbyDEOjE0PT4VfTzeMo3wd6A++BTZE88SJvj02R4FlnSRtMkUZmLl8XTGNTfxbWK5EisgD+m/qVjzFCfnHVvQJR/wn4NzusAApMFjllF3XH77Z57a+77S3GvRmWVsFvkXliR2C3/zBfoL2SI9Dfl5eVDOoLGgdDp+A364HZoV1Xm1CKMvvYuntPXdKm/GA63/6/nAIxwsq6O7pC9Q75fZJ8qcwr68ECsy+hnPXsqsickibtDOLCFg/uJDdzEPGA2W5dy9kUXnfsxSQl74pC5VsljaKZqxByj42cAY0KvqOFg07vFuLeO6wVZzKLkLc7sC1ULvDdNx2VD8pMTD8H9/i+ESI4/RvDeb0Me9t3+u/7pl0KjjWfNKdjUZgK+hsrRYcNCk0tRkQ+wx/Odz75yyxw7OT561KVYYqtt0xU3ytC6LulEWculo14uzWzZdkjLLeNvuWV1t0h8UfQIVFVVVba3h0eYmhiuTGM4HsrheDjKBXT30AXqpCnqdN2z4oILzvo+ZmOr6NtMDaisrKxqbw9NVJoYg85ejkegHCYfymENOoTnqQVErAV7RzW5hOurCy7487frUtuL6QZi/7sX8VLex2GdWwZXlY8sVL04n883Nqy0zYUphqL/DcKoWw6e1I5VsQ0Y6xvw4q+vrCz9olCmAR3eg7WSDR06tGz16vYJplTj8exV0LsMYw5teK1j3FmFcacBW36tkoZocLnMhvXXX3/lwoULe32xzloVZY+Bi8BUNr8wcG8+t5wRKDIEhgwZUu71Vm6QTbUxpb2P5vIppz9sIPyPbMrjuIwAI8AIMAKMACPACBQVAiBJF+LXjL3sjoa0JqP0HnpL22BfuZVOyRXSRXy+yvFFBRJXlhFgBBgBRoARYAQYAbsI0JQQyFJDF1ly+xZo7pKT/X7/6J55lJaWDkc8bNrra+uK70CKBenVoz3z5mtGgBEYOAhk/IobOFBwSxkBRmBdRQDk6nzoF12TvH1yGZT9SSE6DF2rUdDFGYFzx8qt8TKgEL4lFMJzXgQQz4+PjAAjUFwIMMEqrvvFtWUEGIEsEaipqSmtX9XyAwhWn208j8XWLxiRAKyLs2MEGIGBioB9Q6MDFSFuNyPACBQ1AiBXp/UluQJYQZfuPquoQePKMwKMQM4IMMHKGULOgBFgBAoVgREjRtAOFOf0cf2uiRn47ONiuThGgBEoJASYYBXS3eC6MAKMQF4RWLGyiaRXQ/OaabrMpPh6/XGjrksXhcMYAUZgYCDAOlgD4z5zKxmBAYfAqFGj/MtXrPoeBKumjxrf5tL07Xmz3z5Cm4thBAocAZZgFfgN4uoxAoyAMwSW1606pQ/JlSl17WgmV87uFadiBNZFBJhgrYt3ldvECAxwBEh6hf3Zzu0jGLBFnfwz9tmc1UflcTGMACNQBAjY3uy5CNrCVWQEGAFGwEJgeV3j8ZBeZbOZtlPkAlKTxxihQH53CXdaG07HCDACBYNAzsb0CqYlXBFGgBFgBGIIDK6u/CrYGcbGxWJr/HpH11SKb3Sp7R8JB15n4BkBRoAR6IkATxH2RISvGQFGoOgRaGhoaDXCgT9qQk4Bu3oTDYKR9nw5uRqc7S9bbT5pUjjc8WG+cuV8GAFGYN1CoHe+7NYtjLg1jAAjUOQIeL0VGxoq/HvTFL8F11rPSXOklO9B2eqh8hL3E83NzU1O8uA0jAAjMHAQYII1cO41t5QRYASAAMjWRhHTmCIE/eQkRVvoKIltdFQlgg34NQupVmO7m+UYIOcrqT5ya953gsHm7xhARoARYATsIvD/Vj0O4dkBjucAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - aiml.pachyderm.com
+          resources:
+          - pachydermexports
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - aiml.pachyderm.com
+          resources:
+          - pachydermexports/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - aiml.pachyderm.com
+          resources:
+          - pachydermexports/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - aiml.pachyderm.com
+          resources:
+          - pachyderms
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - aiml.pachyderm.com
+          resources:
+          - pachyderms/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - aiml.pachyderm.com
+          resources:
+          - pachyderms/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers/scale
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - anyuid
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: pachyderm-operator-controller-manager
+      deployments:
+      - name: pachyderm-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:5e33f9d095952866b9743cc8268fb740cce6d93439f00ce333a2de1e5974837e
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources: {}
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: registry.connect.redhat.com/pachyderm/pachyderm-operator@sha256:b3ec850de86c044a070330154975e3a392cd0e711f6d50213ec198e4f3350191
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 320Mi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              - image: registry.connect.redhat.com/pachyderm/backup-handler@sha256:b0ec000db72f5f34eba45d513329c973c1e38dbdbebf55ea7d3c2f806f296b90
+                name: backup
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 250Mi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: pachyderm-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          - coordination.k8s.io
+          resources:
+          - configmaps
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: pachyderm-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - pachyderm
+  - versioning
+  - machine learning
+  - artificial intelligence
+  links:
+  - name: Documentation
+    url: https://docs.pachyderm.com/latest/
+  maintainers:
+  - email: kyle@pachyderm.io
+    name: Kyle White
+  - email: eochieng@redhat.com
+    name: Edmund Ochieng
+  maturity: beta
+  minKubeVersion: v1.19.0
+  provider:
+    name: Pachyderm, Inc.
+    url: https://pachyderm.com
+  version: 0.1.2
+  relatedImages:
+  - name: pachyderm-operator
+    image: registry.connect.redhat.com/pachyderm/pachyderm-operator@sha256:b3ec850de86c044a070330154975e3a392cd0e711f6d50213ec198e4f3350191
+  - name: ose-kube-rbac-proxy
+    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:5e33f9d095952866b9743cc8268fb740cce6d93439f00ce333a2de1e5974837e
+  - name: pachd
+    image: registry.connect.redhat.com/pachyderm/pachd@sha256:116477fefdf413ea02c6ac3d013f1f91d3f6e4b16aed2408c9890832cdb41430
+  - name: worker
+    image: registry.connect.redhat.com/pachyderm/worker@sha256:374f83d92899707bc87b0318fda6bffa78d2e9e523b827bb3d40693a2d1bdecd
+  - name: etcd
+    image: registry.connect.redhat.com/pachyderm/etcd@sha256:d76af4fbc67557b401409618d5b197feaa59804bdac7532d8d339e23ecbfbe23
+  - name: postgresql
+    image: registry.redhat.io/rhel8/postgresql-13@sha256:9fd7af383b4070866b7ae013f19e9c672de7dff14e1661fd24d763277ac1cfd3
+  - name: pgbouncer
+    image: registry.connect.redhat.com/pachyderm/pgbouncer@sha256:00db44237a0b820f41b64bb7f7abe340a46299bec71abef392cb243bb269e01f
+  - name: init-utils
+    image: registry.connect.redhat.com/pachyderm/init-utils@sha256:97e77bdef29a4d731d8425d4a648988a2408e69328cac2fcc708521f32d0d719
+  - name: backup-handler
+    image: registry.connect.redhat.com/pachyderm/backup-handler@sha256:b0ec000db72f5f34eba45d513329c973c1e38dbdbebf55ea7d3c2f806f296b90
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: pachyderm-operator-controller-manager
+    failurePolicy: Fail
+    generateName: mpachyderm.kb.io
+    rules:
+    - apiGroups:
+      - aiml.pachyderm.com
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pachyderms
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-aiml-pachyderm-com-v1beta1-pachyderm
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: pachyderm-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vpachyderm.kb.io
+    rules:
+    - apiGroups:
+      - aiml.pachyderm.com
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - pachyderms
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-aiml-pachyderm-com-v1beta1-pachyderm

--- a/operators/pachyderm-operator/v0.1.2/metadata/annotations.yaml
+++ b/operators/pachyderm-operator/v0.1.2/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: pachyderm-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # OpenShift annotations.
+  com.redhat.openshift.versions: v4.6

--- a/operators/pachyderm-operator/v0.1.2/tests/scorecard/config.yaml
+++ b/operators/pachyderm-operator/v0.1.2/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Publish pachyderm operator v0.1.2 which deploys v2.1.6 of the pachyderm
charts under the hood. This version of the operator also adds support
for backup and restore of a pachyderm resource using the pachyderm
export custom resource.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>