### PR TITLE
operator cloud-native-postgresql (1.15.2)

### DIFF
--- a/operators/cloud-native-postgresql/1.15.2/metadata/annotations.yaml
+++ b/operators/cloud-native-postgresql/1.15.2/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cloud-native-postgresql
-  operators.operatorframework.io.bundle.channels.v1: stable-v1.15,null
+  operators.operatorframework.io.bundle.channels.v1: stable-v1.15,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable-v1.15
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1


### PR DESCRIPTION
fix: remove `null` channel on cloud-native-postgresql

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>