### PR TITLE
operator pmem-csi-operator-os (v1.0.2)

### DIFF
--- a/operators/pmem-csi-operator-os/v1.0.2/manifests/pmem-csi-operator-os.clusterserviceversion.yaml
+++ b/operators/pmem-csi-operator-os/v1.0.2/manifests/pmem-csi-operator-os.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Storage
     certified: "false"
-    containerImage: registry.connect.redhat.com/intel/pmem-csi-driver-os@sha256:6d24fd56c756ada2ef760d6395cafb9d8a49e84b9c96d2bb2b7238ad98cfd576
-    createdAt: 2022-02-10T14:34:34Z
+    containerImage: registry.connect.redhat.com/intel/pmem-csi-driver-os@sha256:2b382216692397f4da19ee255408b16a8936fae5b06165095070f718bef5717f
+    createdAt: 2022-09-02T12:09:08Z
     description: An operator for deploying and managing the PMEM-CSI driver
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: ""
@@ -135,7 +135,7 @@ spec:
                   value: pmem-csi-operator-os
                 - name: GODEBUG
                   value: x509ignoreCN=0
-                image: registry.connect.redhat.com/intel/pmem-csi-driver-os@sha256:6d24fd56c756ada2ef760d6395cafb9d8a49e84b9c96d2bb2b7238ad98cfd576
+                image: registry.connect.redhat.com/intel/pmem-csi-driver-os@sha256:2b382216692397f4da19ee255408b16a8936fae5b06165095070f718bef5717f
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   failureThreshold: 5

--- a/operators/pmem-csi-operator-os/v1.0.2/metadata/annotations.yaml
+++ b/operators/pmem-csi-operator-os/v1.0.2/metadata/annotations.yaml
@@ -3,12 +3,12 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: pmem-csi-operator
+  operators.operatorframework.io.bundle.package.v1: pmem-csi-operator-os
   operators.operatorframework.io.bundle.channels.v1: alpha,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout:
   com.redhat.openshift.versions: v4.6-v4.10
-  
+
   # Annotations for testing.

--- a/operators/pmem-csi-operator-os/v1.0.2/metadata/annotations.yaml
+++ b/operators/pmem-csi-operator-os/v1.0.2/metadata/annotations.yaml
@@ -3,12 +3,12 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: pmem-csi-operator-os
+  operators.operatorframework.io.bundle.package.v1: pmem-csi-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout:
-  com.redhat.openshift.versions: v4.6-v4.9
-
+  com.redhat.openshift.versions: v4.6-v4.10
+  
   # Annotations for testing.


### PR DESCRIPTION
1. Updated PMEM-CSI driver container image version sha key 
( https://connect.redhat.com/projects/6112818bee4963304e288f24/images)

2.Updated annotation YAML file with openshift version 4.10
