### PR TITLE
operator conjur-follower-operator (2.2.1)

### DIFF
--- a/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-conjurfollower-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-conjurfollower-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: conjur-follower-operator-conjurfollower-editor-role
+rules:
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers/status
+  verbs:
+  - get

--- a/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-conjurfollower-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-conjurfollower-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: conjur-follower-operator-conjurfollower-viewer-role
+rules:
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - conjur.cyberark.com
+  resources:
+  - conjurfollowers/status
+  verbs:
+  - get

--- a/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: conjur-follower-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: conjur-follower-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator.clusterserviceversion.yaml
+++ b/operators/conjur-follower-operator/2.2.1/manifests/conjur-follower-operator.clusterserviceversion.yaml
@@ -1,0 +1,528 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "conjur.cyberark.com/v1",
+          "kind": "ConjurFollower",
+          "metadata": {
+            "labels": {
+              "app": "conjur-follower"
+            },
+            "name": "my-conjur-follower",
+            "namespace": "my-follower-namespace"
+          },
+          "spec": {
+            "images": {
+              "configurator": "registry.connect.redhat.com/cyberark/conjur-openshift-follower-configurator@sha256:1ff94e32ddb5ed9dc7a218d4a96e133f19c17e24c46d977b92c6b07a87688e94",
+              "conjur": "registry.connect.redhat.com/cyberark/conjur-openshift-follower-conjur@sha256:6d102eea4801a4bee2f694a1a2e80ea87f26e2316343157c492eec4b82880412",
+              "info": "registry.connect.redhat.com/cyberark/conjur-openshift-follower-info@sha256:a19f60bb5bee4709df33c853a04b75b4534209f6991b24ef3c787e81f72d378f",
+              "nginx": "registry.connect.redhat.com/cyberark/conjur-openshift-follower-nginx@sha256:4ffb8a0acf103f7e3b1f0944ecb244475f1939db00c5d2c2ca55bef8ecaf7185",
+              "postgres": "registry.connect.redhat.com/cyberark/conjur-openshift-follower-postgres@sha256:badb31931dc7fffbfbb2b3f2dd82968452e2b28848b4fdd033f1342ebd71e2e8",
+              "syslogNg": "registry.connect.redhat.com/cyberark/conjur-openshift-follower-syslog-ng@sha256:8a34b4d2c29aeb1cb78f79d2c082bb5c03ffefca9574092dbcb6796ec3e9d229"
+            },
+            "master": {
+              "account": "my-company",
+              "authenticatorID": "conjur-openshift-follower",
+              "authnLogin": "host/conjur-openshift-follower",
+              "caCertificateFrom": {
+                "configMapKeyRef": {
+                  "key": "conjur.master-cert",
+                  "name": "follower"
+                }
+              },
+              "hostname": "conjur.my-company.net"
+            },
+            "replicas": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Security
+    olm.skipRange: "<2.2.1"
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    support: CyberArk
+  name: conjur-follower-operator.v2.2.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ConjurFollower is the Schema for the conjurfollowers API
+      displayName: ConjurFollower
+      kind: ConjurFollower
+      name: conjurfollowers.conjur.cyberark.com
+      resources:
+      - kind: Deployment
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: ServiceAccount
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: The Conjur configuration file (YAML) for the Follower.
+        displayName: Conjur Config File
+        path: configFileFrom
+      - description: Selects a key of a ConfigMap.
+        displayName: From a ConfigMap
+        path: configFileFrom.configMapKeyRef
+      - description: ConfigMap key
+        displayName: Key
+        path: configFileFrom.configMapKeyRef.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ConfigMap name
+        displayName: Name
+        path: configFileFrom.configMapKeyRef.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
+      - description: Selects a key of a secret in the Follower Pod's namespace.
+        displayName: From a Secret
+        path: configFileFrom.secretKeyRef
+      - description: Secret key
+        displayName: Key
+        path: configFileFrom.secretKeyRef.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Secret name
+        displayName: Name
+        path: configFileFrom.secretKeyRef.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Additional envVars to add to the Follower containers.
+        displayName: Container Enviroment Variables
+        path: containerEnv
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Configurator
+        path: containerEnv.configurator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:EnvVars
+      - displayName: Conjur
+        path: containerEnv.conjur
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:EnvVars
+      - displayName: Info
+        path: containerEnv.info
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:EnvVars
+      - displayName: NGINX
+        path: containerEnv.nginx
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:EnvVars
+      - displayName: PostgreSQL
+        path: containerEnv.postgres
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:EnvVars
+      - displayName: syslog-ng
+        path: containerEnv.syslogNg
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:EnvVars
+      - description: Configuration of resources in the Follower containers.
+        displayName: Container Resources
+        path: containerResources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: 'Provision the Configurator container with the following resource
+          limits:'
+        displayName: Configurator
+        path: containerResources.configurator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: 'Provision the Conjur container with the following resource limits:'
+        displayName: Conjur
+        path: containerResources.conjur
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: 'Provision the Info container with the following resource limits:'
+        displayName: Info
+        path: containerResources.info
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: 'Provision the NGINX container with the following resource limits:'
+        displayName: NGINX
+        path: containerResources.nginx
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: 'Provision the PostgreSQL container with the following resource
+          limits:'
+        displayName: PostgreSQL
+        path: containerResources.postgres
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: 'Provision the syslog-ng container with the following resource
+          limits:'
+        displayName: syslog-ng
+        path: containerResources.syslogNg
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Determines when to pull the Follower container images.
+        displayName: Image Pull Policy
+        path: imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: The paths to the Images used by the Follower.
+        displayName: Image Paths
+        path: images
+      - description: The path of the Configurator container image.
+        displayName: Configurator Image
+        path: images.configurator
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Conjur container image.
+        displayName: Conjur Image
+        path: images.conjur
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the Info container image.
+        displayName: Info Image
+        path: images.info
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the NGINX container image.
+        displayName: NGINX Image
+        path: images.nginx
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the PostgreSQL container image.
+        displayName: PostgreSQL Image
+        path: images.postgres
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The path of the syslog-ng container image.
+        displayName: syslog-ng Image
+        path: images.syslogNg
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Conjur cluster connection details.
+        displayName: Conjur Cluster Configuration
+        path: master
+      - description: 'The Account used when deploying Conjur. For example: "my-org".'
+        displayName: Conjur Account
+        path: master.account
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The audience field of the JWT token when using authn-jwt authentication.
+        displayName: Audience
+        path: master.audience
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The authentication type to use.
+        displayName: Authentication
+        path: master.authentication
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The service id of the Authenticator endpoint.
+        displayName: Authenticator Service ID
+        path: master.authenticatorID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Application Identity (host id) for the Follower.
+        displayName: Application Identity
+        path: master.authnLogin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The CA Certificate used to issue the Conjur certificate.
+        displayName: CA Certificate
+        path: master.caCertificateFrom
+      - description: Selects a key of a ConfigMap.
+        displayName: From a ConfigMap
+        path: master.caCertificateFrom.configMapKeyRef
+      - description: ConfigMap key
+        displayName: Key
+        path: master.caCertificateFrom.configMapKeyRef.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ConfigMap name
+        displayName: Name
+        path: master.caCertificateFrom.configMapKeyRef.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
+      - description: Selects a key of a secret in the Follower Pod's namespace.
+        displayName: From a Secret
+        path: master.caCertificateFrom.secretKeyRef
+      - description: Secret key
+        displayName: Key
+        path: master.caCertificateFrom.secretKeyRef.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Secret name
+        displayName: Name
+        path: master.caCertificateFrom.secretKeyRef.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: The Master FQDN. If there is a load balancer, then specify its
+          FQDN here.
+        displayName: Conjur Cluster Master FQDN
+        path: master.hostname
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The desired number of member Pods for the Follower.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Use these options to override the names of the Kubernetes resources
+          that are created for this Follower.
+        displayName: Kubernetes Resources
+        path: resourceNames
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Deploy the Follower into this Deployment resource.
+        displayName: Deployment
+        path: resourceNames.deployment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Follower Service name.
+        displayName: Service
+        path: resourceNames.service
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Conjur ServiceAccount name.
+        displayName: Service Account
+        path: resourceNames.serviceAccount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The attributes for the Conjur Follower Service
+        displayName: Service
+        path: service
+      - description: Additional annotations to add to the downstream service
+        displayName: Additional Annotations
+        path: service.additionalAnnotations
+      - description: External reference that discovery mechanisms will return as an
+          alias for this service (e.g. a DNS CNAME record)
+        displayName: External Name
+        path: service.externalName
+      - description: Denotes if this Service desires to route external traffic to
+          node-local or cluster-wide endpoints
+        displayName: External Traffic Policy
+        path: service.externalTrafficPolicy
+      - description: Allows passing connections from a particular client to the same
+          Pod each time
+        displayName: Session Affinity
+        path: service.sessionAffinity
+      - description: The ServiceType of the Conjur Follower Service
+        displayName: Type
+        path: service.type
+      statusDescriptors:
+      - displayName: Namespace
+        path: lastReconciled.controller.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Pod
+        path: lastReconciled.controller.pod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Version
+        path: lastReconciled.controller.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Timestamp
+        path: lastReconciled.timestamp
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: status
+        path: status
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1
+  description: |-
+    Use this Operator for managing Conjur Followers in an OpenShift cluster.
+
+    CyberArk products secure your most sensitive and high-value assets—and supporting your Identity Security goals is our top priority. We offer 24/7 service for high priority issues to all customers with resources across ten countries and in all continents.
+
+    CyberArk Conjur makes secrets management simple. Conjur provides a seamless open source interface to securely authenticate, control, and audit non-human access across tools, applications, containers, and cloud environments via robust secrets management.
+  displayName: Conjur Enterprise Follower Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAADwAAAAmCAYAAACYsfiPAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAGAAAAABAAAAYAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAPKADAAQAAAABAAAAJgAAAAC96Oe7AAAACXBIWXMAAA7EAAAOxAGVKw4bAAACymlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj45NjwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6UmVzb2x1dGlvblVuaXQ+MjwvdGlmZjpSZXNvbHV0aW9uVW5pdD4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+OTY8L3RpZmY6WFJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4zODA8L2V4aWY6UGl4ZWxYRGltZW5zaW9uPgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjI0MjwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoQu0uyAAANGUlEQVRoBd0aCXBURba7//8zkwyokBkCKFhSyCoBSTIERAIGkURUanV10AyHCgiuCivrIipYOygYQFEOUYiIiiSRzHoiK8gqgSgIZBI5ggcRPDAck4CQZI5/dO97f+azYXVra4uhirWr/nT/169fv9fv6Nf9h5BzXPI2Cdma4qbdP7crqNFm51er2wtq1AkW3FsuJG95uWS9n8uanivicQG8JDCSGjhHQbV6H6XsaiH45/BkM0kJCmFcS3W+en2O4++I46mqUoIej04oFfj+/1H8fuZZXqVYzBZUNt9ww7bw6vxgdCrC8l496Bi2tWkhtguqRKeCnbF5+VtbluVvauqFMCzx8eKcKSM+SxJ+Wws6ZP3hjPyPGpflf/Lz/IItLZ0s8vmbG7vkbzy22HrHOr+yxZP/yYkV+Rsanhr69qE0qy/Pv+m0O1iws62TSjA4qa82qHy/26GkTCa66CwoX7YxP60KmZxYJZTivlSL1p8gNofN1B767oFuQfZRX2cQUCYM+/DorZLMFl//zg+f5u7qstzvpzoRoOkkmjg72xVrPX7wG1+NlIk8Sxhi18abO0/YeJO7CoOW3y9YMIgyEaJJ9gY9EothO7Bvluh24ABHwf1CsI3D09+RvvtinDAIq7ji4KJBr9UONYVFoc+XYpld7sp91w9cuTc2sHjPSIu34Yv3283+BMNo8gNf3v3ENS/v3t8aDwVGPG95rc0am7ti79JBr9aus94JSY7QSTNppqppXOfTiELduS9Ul5Co+tyHUy6Pq9VPSO7z2wuJzm4gTN9NdGMzUWxdc5dUv071WDFE8s8swQYt/Pw2YbPfQXT1g8oJ2Q/E4ShsciJ30gSmzTHGCD+55cEBr+c9v+Mzg5L7B8/7rJ5o+kfEJo8nnP/YGLLf23X7x7Q5L3Nu5fScZwcv+vxywcnU3Pmf3myosbWKzXEXMURInGye9Oljg04k/BdkTo6wuHhJE1gLxwSViLkdVUzt9wXQnjiwaPMdgogFckwfu+WJa/fjhO38G7saEdXE2/KnqxF2f+7sihFUSAt1TR239ZEhexEPzb9bIMADhJj7OMKSUZIWtAwtQrSWqMnTgKnlKdiIHjy63ojE/oHCZvjj/tkSDutaRDODlgU7VHdwowZ4W2cM2Yu+7Jm4XIGIrwdGjkyqsMhT8gRujhIRi5r0Th1KaKVdyoU8EmuDE5HaWrNSWoyYiEY7miB/hop1eucuFxJVdUKTNtV/Q4PFkzRoi76T38vK8JafDmSIe7YlaQJTVeMkop6REsphlZOobm4ptYGRqmdiWX9uaHOoplPPpDVzc+4p64ICsMhxTURimEsLFNYz8c3svveVLyFcK3amk4sRx+tNTq6dNB8GvwS24tulo103U/BIJAJBWz7eo3C5K9XunEE4cXAuFlWv8H6Zfe+aAkMSRZljVlWFGyMByeYIeQDPsDn/LDjvaDDxJIvxUQYnF6DAySpnL3BFnBUVBKYsruCT9mOm5WjRFoMYis/BbOkQaEuCKwq3Ijb6aYV/yAZobugzdvWtXNOeN9TmTEptXWUi3qte4Xsf8TJHrXICAY7tZJWzF5hsjvOiqoRxYh7x6pbcGOsz4qWRooUME0zdQrmw8R+bD1tMN639Jm4KAKBHTh4lTtkuGFu0963xSxEH/RZdgEfBJVhy41YSBI6LIaFJS9LxjLznujOH8lcw3QM8LE2v3TDheO/fL+lN2qbO7F2wqEEP84XBykmH+1y/OEvI7H54jhPVuLt23aQTJiX01X374kQjGgQvPd5O0m/SBOZhTRUi9iRT5FLw1Tl71t//FfKI2toTGLkHmuN7DV14syST2RmDF4QNDh5sGEtr1z+IezYxt6Liw0ZeaB+tqPWb0duIRDtTRk9bA+KdByWe43Yf9LQ7Y8D8tb1y5v7lX0z5wZdBY3BGzsvzm4ubkTO/I+C9beF4PMshCRHU6kf4Vf2euSyj/7ylGQOeeRLHJnCTIngSNIxpn5/VVT4eAsZG9MyZN6pXv3lrBKHranc8sgqZ9daWSyESN9OYrhvgsJhhmVtNKLQPxlNSUUF0j8efGqOOhwzCe8B545V926ZVkm2IaYb/eEQ0X8+LH9BEQhuXDJiaktFv3nR4VmX0K7quNXu9+s9J75lTtAhhrbXaq++8MRk5c8t65Twz2sJP7L1J0axFM6nELCEqKvxmpLky69lLmWw8BCarSIIu2V01/eveuUXteIw+Vbvz0QcRv3fO/Gs5JeOEEF+l8MiiYNAfRhP3egMsEEh+apl0geMrKajHUywHg2aKSMCvrwETnwiG+aXO1XdlKo0mnL1MJDoNHIIzyhbu3jHtII5Fn7bGxWkl9/ccCWwx6YdgBbcXCY2D4HA5QG+HW8vekKVUMkJL9ux8ZDNiJwRFyzjffBXZ+99K3Bfj0TYjz9/mypy5gy0KcT+O91mw30zt8Uw0z8GWQK2DlgX7DdYYkMyTzzl2p9/g0p2tSBQyAUj+z/CnX9MCwhJwxLUeC2axYcGt+nQ/jLVgWP+nYvb9+/yJsUjrF/0WrBXB1jhmRpigl5d3ZsZlCm6Na81U67bV36o+Y1wr+H9r/nJcgjFzYOv2Lyn9cizi/Irw8aFIDB9xwQBv+5SYrUdMiMM/15R+j90X9xub9tOOVY2YCCSUKuA0YGvfxuY4vr2kyeUZ3VE3dLudG1RxkiOHtgUiCXqkTZbXJQvJaR6SBadwUtAadwV+umSANyWsSy6uwyUnFGuuhNbx7Gvyk37VmA4p7aVT31W8hhdlJgzHNjUrDkVtNhObhq/fb0IaZgG+LmSK82RafRPkqWZ/W+DfqUXYkZpA6KIs36WpTLTgpMKVVfiwPWYrg4zHJ1O61J3tW4lEVE1b4M4uxL1TkDy/edZ12ZV3lYia5u5TOBD20w0ykx7lsvJENKasc3t8XqTnzvR1d1BlvUTZLIXQWYAzl8o282NaNCY9yQxWCvPMkBl5Guba4PLckQ0Cc1zMxPhMQzaONp2KvYh8dO8+3LzXUqPKY4rMG0iq8zBxOk+4sgvrXVm+OxHHbZdvURR+rMOpTj3Nd49vrl3TjulE7glHMQUuFsapnI+VXZmFE+BzxtBQdUkBImJJy/KN6eyZmBrTT8ygsvJBx6x7Nh2p8IdcHt8CWOrdR3cHDro9owbDgX9dqKbkMRzTzjO2qyz0tdAMwGfRVJB7f0NNyV3Y17rAh6I0MJinYdyHCIcFvYEKeQ40hxNHu3jSwcQUJjuI0CK+9Bzf7LqdpQcQV1CRRqkE04ppkKo2CWJMF5SVQVL+N3IK7sbkVJlr4QZ3VuFkpqRO12PhsY01pZs7e0akqjylgks0IhNGfYwa9yLB7t0n2+vqlsQA6Q0kD5oNu7N8Lxg0Nq9D5p0rgJveoWBpPuISwSOQLrouyrzlIsadbRjXr4ERH5t95l2Pnury/KGTxBwpcHHHonLKiSZwDwFcMgnZixeYpB4EMa2HBIs1V9adnWGee7genU4pfUg3xBTAhHwcC4WUWzQ1Vpe+hG+gmLaSzf6iq+kSN4cbf6pHQXfscXCjBww1PBrkKEHt1geLIT8nm3CMDCsuiyg/Cm1aV5emYaTuXtNRrqujKqycHKoofQW0kM0pWyN07WochAWYihBGBivEOYdIwgbHuYEAew37DKqpVNArKEkp4uiVxHaBXTdWgsN9gG/cEI938PjggzhpD2M6wlOEcLNQAotPiSLsr2o0+jtwpgnuDO/MUG2gGfp1yqS2oMGtINkpEH6IUCNbG2rKDoNb2incLhBhPAB9hHJuN+lFT6D/YzFrxIhQm9wbANvg4MpIIGDUWbf9TT0AqQKUKQJgCW0x6KB51AfXhsEAnKDhQEN1yUyTHPyAP74FFjFY5uR7g9Gdx4Ild1t9rWr4Nii2c115k0h6MXxOWdtQXbYJNUGCy+HzaOFdVJKIzqP1ICxjsh2uBgXEEQJxhUsEAg1Y0rfAVCHI0KywtsMs2rAYxND0sbAuOZLN+Uq6Z9TOo8GSPag4K5AxkOg5TukL7fsUZqCw7TzeruirGNXQxJAYXLM4oDIDh61tmqkzWC80w07Y7c65uyP6MGgsHVR/yoB7HmDSDZppg30d+hem4wO4uM5OwPu0Ydeqbxqqe1wHZnt7h2xfAc6V5vH9kSkplwHX4zkxbgbs67geq4WFjVuAAD5Ae7BAYyiVhzBbyoWqaPLHyYoU8G8iMWNrY03ZFK5FfuCC78CdJi5sfEtlx6pLN4D5zWQSnevK9q2VhPICrOJ+c7tI7HGcs0Zg1Px08F2oxRSYC3EA1rqrO3vUCmKoRTLRFghKl4W+KP1CZzG43xKqsCvLhKHO5xpZLDRqWgLA98Iqm3dWGJkh0k+GIHSbybQgV3EtWhaqeXPl8eryDWCqm+FK62HoO5nWZ+zFnNBq+F9IpWvguLah6tWVYM5FoLDh+A6L8q2uNe/VuWyaMrjNjTDXD1FdG4+0wXpNk/4ncv7TQ+5yDS4AAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - pods/exec
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - conjur.cyberark.com
+          resources:
+          - conjurfollowers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - conjur.cyberark.com
+          resources:
+          - conjurfollowers
+          - conjurfollowers/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - conjur.cyberark.com
+          resources:
+          - conjurfollowers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - extensions
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        serviceAccountName: conjur-follower-operator-controller-manager
+      deployments:
+      - name: conjur-follower-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: controller-manager
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: conjur-follower-operator
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-operator@sha256:e9c2fc4c18d84655ed5b30066a1294a2ed1151eeaf9248a8dbdd0ddff4171d7f
+                imagePullPolicy: Always
+                name: conjur-follower-operator
+                resources: {}
+              serviceAccountName: conjur-follower-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - credential
+  - cyber
+  - cyberark
+  - conjur
+  - enterprise
+  - management
+  - password
+  - secret
+  - secrets management
+  - security
+  - vault
+  links:
+  - name: Conjur Secrets Manager Enterprise Documentation
+    url: https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm
+  maintainers:
+  - email: conj_maintainers@cyberark.com
+    name: Conjur Maintainers
+  maturity: stable
+  minKubeVersion: 1.19.0
+  provider:
+    name: CyberArk
+    url: https://www.cyberark.com/
+  relatedImages:
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-operator@sha256:e9c2fc4c18d84655ed5b30066a1294a2ed1151eeaf9248a8dbdd0ddff4171d7f
+    name: conjur-openshift-follower-operator
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-configurator@sha256:1ff94e32ddb5ed9dc7a218d4a96e133f19c17e24c46d977b92c6b07a87688e94
+    name: conjur-openshift-follower-configurator
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-conjur@sha256:6d102eea4801a4bee2f694a1a2e80ea87f26e2316343157c492eec4b82880412
+    name: conjur-openshift-follower-conjur
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-info@sha256:a19f60bb5bee4709df33c853a04b75b4534209f6991b24ef3c787e81f72d378f
+    name: conjur-openshift-follower-info
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-nginx@sha256:4ffb8a0acf103f7e3b1f0944ecb244475f1939db00c5d2c2ca55bef8ecaf7185
+    name: conjur-openshift-follower-nginx
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-postgres@sha256:badb31931dc7fffbfbb2b3f2dd82968452e2b28848b4fdd033f1342ebd71e2e8
+    name: conjur-openshift-follower-postgres
+  - image: registry.connect.redhat.com/cyberark/conjur-openshift-follower-syslog-ng@sha256:8a34b4d2c29aeb1cb78f79d2c082bb5c03ffefca9574092dbcb6796ec3e9d229
+    name: conjur-openshift-follower-syslog-ng
+  version: 2.2.1

--- a/operators/conjur-follower-operator/2.2.1/manifests/conjur.cyberark.com_conjurfollowers.yaml
+++ b/operators/conjur-follower-operator/2.2.1/manifests/conjur.cyberark.com_conjurfollowers.yaml
@@ -1,0 +1,1123 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: conjurfollowers.conjur.cyberark.com
+spec:
+  group: conjur.cyberark.com
+  names:
+    kind: ConjurFollower
+    listKind: ConjurFollowerList
+    plural: conjurfollowers
+    singular: conjurfollower
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConjurFollower is the Schema for the conjurfollowers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConjurFollowerSpec defines the desired state of ConjurFollower
+            properties:
+              configFileFrom:
+                description: The Conjur configuration file (YAML) for the Follower.
+                properties:
+                  configMapKeyRef:
+                    description: Selects a key of a ConfigMap.
+                    properties:
+                      key:
+                        description: ConfigMap key
+                        type: string
+                      name:
+                        description: ConfigMap name
+                        type: string
+                    type: object
+                  secretKeyRef:
+                    description: Selects a key of a secret in the Follower Pod's namespace.
+                    properties:
+                      key:
+                        description: Secret key
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    type: object
+                type: object
+              containerEnv:
+                description: Additional envVars to add to the Follower containers.
+                properties:
+                  configurator:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  conjur:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  info:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  nginx:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  postgres:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  syslogNg:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              containerResources:
+                description: Configuration of resources in the Follower containers.
+                properties:
+                  configurator:
+                    description: 'Provision the Configurator container with the following
+                      resource limits:'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  conjur:
+                    description: 'Provision the Conjur container with the following
+                      resource limits:'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  info:
+                    description: 'Provision the Info container with the following
+                      resource limits:'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  nginx:
+                    description: 'Provision the NGINX container with the following
+                      resource limits:'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  postgres:
+                    description: 'Provision the PostgreSQL container with the following
+                      resource limits:'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  syslogNg:
+                    description: 'Provision the syslog-ng container with the following
+                      resource limits:'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                type: object
+              imagePullPolicy:
+                default: Always
+                description: Determines when to pull the Follower container images.
+                type: string
+              images:
+                description: The paths to the Images used by the Follower.
+                properties:
+                  configurator:
+                    description: The path of the Configurator container image.
+                    type: string
+                  conjur:
+                    description: The path of the Conjur container image.
+                    type: string
+                  info:
+                    description: The path of the Info container image.
+                    type: string
+                  nginx:
+                    description: The path of the NGINX container image.
+                    type: string
+                  postgres:
+                    description: The path of the PostgreSQL container image.
+                    type: string
+                  syslogNg:
+                    description: The path of the syslog-ng container image.
+                    type: string
+                type: object
+              master:
+                description: The Conjur cluster connection details.
+                properties:
+                  account:
+                    description: 'The Account used when deploying Conjur. For example:
+                      "my-org".'
+                    type: string
+                  audience:
+                    default: conjur
+                    description: The audience field of the JWT token when using authn-jwt
+                      authentication.
+                    type: string
+                  authentication:
+                    default: authn-k8s
+                    description: The authentication type to use.
+                    enum:
+                    - authn-k8s
+                    - authn-jwt
+                    type: string
+                  authenticatorID:
+                    default: conjur-follower
+                    description: The service id of the Authenticator endpoint.
+                    type: string
+                  authnLogin:
+                    default: ""
+                    description: The Application Identity (host id) for the Follower.
+                    type: string
+                  caCertificateFrom:
+                    description: The CA Certificate used to issue the Conjur certificate.
+                    properties:
+                      configMapKeyRef:
+                        description: Selects a key of a ConfigMap.
+                        properties:
+                          key:
+                            description: ConfigMap key
+                            type: string
+                          name:
+                            description: ConfigMap name
+                            type: string
+                        type: object
+                      secretKeyRef:
+                        description: Selects a key of a secret in the Follower Pod's
+                          namespace.
+                        properties:
+                          key:
+                            description: Secret key
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        type: object
+                    type: object
+                  hostname:
+                    description: The Master FQDN. If there is a load balancer, then
+                      specify its FQDN here.
+                    type: string
+                required:
+                - account
+                - authenticatorID
+                - caCertificateFrom
+                - hostname
+                type: object
+              replicas:
+                default: 1
+                description: The desired number of member Pods for the Follower.
+                format: int32
+                type: integer
+              resourceNames:
+                description: Use these options to override the names of the Kubernetes
+                  resources that are created for this Follower.
+                properties:
+                  deployment:
+                    default: conjur-follower
+                    description: Deploy the Follower into this Deployment resource.
+                    type: string
+                  service:
+                    default: conjur-follower
+                    description: The Follower Service name.
+                    type: string
+                  serviceAccount:
+                    default: conjur-follower
+                    description: The Conjur ServiceAccount name.
+                    type: string
+                type: object
+              service:
+                description: The attributes for the Conjur Follower Service
+                properties:
+                  additionalAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Additional annotations to add to the downstream service
+                    type: object
+                  externalName:
+                    description: External reference that discovery mechanisms will
+                      return as an alias for this service (e.g. a DNS CNAME record)
+                    type: string
+                  externalTrafficPolicy:
+                    description: Denotes if this Service desires to route external
+                      traffic to node-local or cluster-wide endpoints
+                    type: string
+                  sessionAffinity:
+                    default: None
+                    description: Allows passing connections from a particular client
+                      to the same Pod each time
+                    type: string
+                  type:
+                    default: ClusterIP
+                    description: The ServiceType of the Conjur Follower Service
+                    type: string
+                type: object
+            required:
+            - images
+            - master
+            type: object
+          status:
+            description: ConjurFollowerStatus defines the observed state of ConjurFollower
+            properties:
+              lastReconciled:
+                description: ConjurFollowerLastReconciled defines the time the follower
+                  was last reconciled
+                properties:
+                  controller:
+                    description: ConjurFollowerController defines the operator information
+                    properties:
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  timestamp:
+                    format: date-time
+                    type: string
+                required:
+                - controller
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ConjurFollowerResources defines the resources of the
+                  ConjurFollower
+                properties:
+                  deployment:
+                    description: ConjurFollowerResourceStatus defines the status for
+                      the different resources
+                    properties:
+                      error:
+                        type: boolean
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                  service:
+                    description: ConjurFollowerResourceStatus defines the status for
+                      the different resources
+                    properties:
+                      error:
+                        type: boolean
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                  serviceAccount:
+                    description: ConjurFollowerResourceStatus defines the status for
+                      the different resources
+                    properties:
+                      error:
+                        type: boolean
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                required:
+                - deployment
+                - service
+                - serviceAccount
+                type: object
+              selector:
+                type: string
+              status:
+                type: string
+            required:
+            - lastReconciled
+            - resources
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/conjur-follower-operator/2.2.1/metadata/annotations.yaml
+++ b/operators/conjur-follower-operator/2.2.1/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: conjur-follower-operator
+  operators.operatorframework.io.bundle.channels.v1: preview,stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # Annotations to specify OCP versions compatibility.
+  com.redhat.openshift.versions: v4.6

--- a/operators/conjur-follower-operator/2.2.1/tests/scorecard/config.yaml
+++ b/operators/conjur-follower-operator/2.2.1/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.2.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
- Included the missing files mentioned below in the new bundle
- Update image paths to use sha digest
- Set OCP support to v4.6, as per the Managing Openshift Versions guide
- Set spec.replaces to conjur-follower-operator.v2.1.5
- Trim build from spec.version