### PR TITLE
operator mongodb-enterprise (1.17.2)

### DIFF
--- a/operators/mongodb-enterprise/1.17.2/bundle.Dockerfile
+++ b/operators/mongodb-enterprise/1.17.2/bundle.Dockerfile
@@ -1,0 +1,22 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=mongodb-enterprise
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.23.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/
+LABEL com.redhat.openshift.versions="v4.6"

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-appdb_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-appdb_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: mongodb-enterprise-appdb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - patch
+  - delete
+  - get

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-appdb_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-appdb_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: mongodb-enterprise-appdb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mongodb-enterprise-appdb
+subjects:
+- kind: ServiceAccount
+  name: mongodb-enterprise-appdb

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-appdb_v1_serviceaccount.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-appdb_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: mongodb-enterprise-appdb

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-database-pods_v1_serviceaccount.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-database-pods_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: mongodb-enterprise-database-pods

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-ops-manager_v1_serviceaccount.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise-ops-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: mongodb-enterprise-ops-manager

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise.clusterserviceversion.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb-enterprise.clusterserviceversion.yaml
@@ -1,0 +1,962 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDB",
+          "metadata": {
+            "name": "my-replica-set"
+          },
+          "spec": {
+            "credentials": "my-credentials",
+            "members": 3,
+            "opsManager": {
+              "configMapRef": {
+                "name": "my-project"
+              }
+            },
+            "persistent": true,
+            "type": "ReplicaSet",
+            "version": "4.4.0-ent"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDB",
+          "metadata": {
+            "name": "sample-sharded-cluster"
+          },
+          "spec": {
+            "configServerCount": 3,
+            "credentials": "my-credentials",
+            "mongodsPerShardCount": 3,
+            "mongosCount": 2,
+            "opsManager": {
+              "configMapRef": {
+                "name": "my-project"
+              }
+            },
+            "persistent": true,
+            "shardCount": 1,
+            "type": "ShardedCluster",
+            "version": "4.4.0-ent"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDBMulti",
+          "metadata": {
+            "name": "multi-replica-set"
+          },
+          "spec": {
+            "clusterSpecList": {
+              "clusterSpecs": [
+                {
+                  "clusterName": "e2e.cluster1.mongokubernetes.com",
+                  "members": 2
+                },
+                {
+                  "clusterName": "e2e.cluster2.mongokubernetes.com",
+                  "members": 1
+                },
+                {
+                  "clusterName": "e2e.cluster3.mongokubernetes.com",
+                  "members": 2
+                }
+              ]
+            },
+            "credentials": "my-credentials",
+            "duplicateServiceObjects": false,
+            "opsManager": {
+              "configMapRef": {
+                "name": "my-project"
+              }
+            },
+            "persistent": false,
+            "type": "ReplicaSet",
+            "version": "4.4.0-ent"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDBOpsManager",
+          "metadata": {
+            "name": "ops-manager"
+          },
+          "spec": {
+            "adminCredentials": "ops-manager-admin",
+            "applicationDatabase": {
+              "members": 3,
+              "podSpec": {
+                "cpu": 1
+              }
+            },
+            "configuration": {
+              "mms.fromEmailAddr": "admin@thecompany.com"
+            },
+            "externalConnectivity": {
+              "type": "LoadBalancer"
+            },
+            "version": "6.0.3"
+          }
+        },
+        {
+          "apiVersion": "mongodb.com/v1",
+          "kind": "MongoDBUser",
+          "metadata": {
+            "name": "my-replica-set-x509-user"
+          },
+          "spec": {
+            "db": "$external",
+            "mongodbResourceRef": {
+              "name": "my-replica-set"
+            },
+            "roles": [
+              {
+                "db": "admin",
+                "name": "dbOwner"
+              }
+            ],
+            "username": "CN=my-replica-set-x509-user,OU=cloud,O=MongoDB,L=New York,ST=New York,C=US"
+          },
+          "status": {
+            "phase": "Updated"
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: Database
+    certified: "true"
+    createdAt: ""
+    description: The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB into Kubernetes clusters, using our management, monitoring and backup platforms, Ops Manager and Cloud Manager.
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.23.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/mongodb/mongodb-enterprise-kubernetes
+    support: support@mongodb.com
+  name: mongodb-enterprise.v1.17.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: MongoDB Deployment
+        displayName: MongoDB Deployment
+        kind: MongoDB
+        name: mongodb.mongodb.com
+        resources:
+          - kind: StatefulSet
+            name: StatefulSet holding the Pod with MongoDB
+            version: apps/v1
+          - kind: Service
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: MongoDB Deployment Type
+            path: type
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:Standalone
+              - urn:alm:descriptor:com.tectonic.ui:select:ReplicaSet
+              - urn:alm:descriptor:com.tectonic.ui:select:ShardedCluster
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - description: Version of MongoDB to use.
+            displayName: MongoDB Version
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - description: In a Replica Set deployment type, specifies the amount of members.
+            displayName: Members of a Replica Set
+            path: members
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - displayName: Cloud/Ops Manager credentials
+            path: credentials
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfig
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - description: Project configuration for this deployment
+            displayName: Ops Manager project configuration
+            path: opsManager
+          - description: Name of the ConfigMap with the configuration for this project
+            displayName: Ops Manager Project Configuration
+            path: opsManager.configMapRef.name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfig
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
+          - description: Enable Persistent Storage with Volume Claims
+            displayName: Persistent Storage
+            path: persistent
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - description: Optional. Name of a Kubernetes Cluster Domain.
+            displayName: Name of Kubernetes Cluster Domain
+            path: clusterDomain
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Enable TLS
+            path: security.tls.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:security
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - displayName: Custom CA Config Map
+            path: security.tls.ca
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:security
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
+          - displayName: Enable authentication
+            path: security.authentication.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Authentication
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - displayName: Authentication Mode
+            path: security.authentication.modes
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Authentication
+              - urn:alm:descriptor:com.tectonic.ui:select:X509
+              - urn:alm:descriptor:com.tectonic.ui:select:SCRAM
+              - urn:alm:descriptor:com.tectonic.ui:select:LDAP
+          - displayName: Authentication Mode used for Inter cluster communication
+            path: security.authentication.internalCluster
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Authentication
+              - urn:alm:descriptor:com.tectonic.ui:select:X509
+              - urn:alm:descriptor:com.tectonic.ui:select:SCRAM
+              - urn:alm:descriptor:com.tectonic.ui:select:LDAP
+          - description: Number of Config Servers in Replica
+            displayName: Number of Config Servers
+            path: configServerCount
+          - description: Number of Shards in a Sharded Cluster
+            displayName: Number of Shards
+            path: shardCount
+          - description: Number of MongoDB Servers per Shard
+            displayName: Number of MongoDB Servers
+            path: mongodsPerShardCount
+          - description: Number of Mongo routers, in total, for the whole cluster
+            displayName: Number of Mongos
+            path: mongosCount
+        statusDescriptors:
+          - description: |
+              Phase the MongoDB Deployment is currently on. It can be any of Running, Pending, Failed.
+            displayName: Phase
+            path: phase
+          - description: |
+              Type describes the deployment type this MongoDB resource. Posible values
+              are Standalone, ReplicaSet or ShardedCluster.
+            displayName: Type
+            path: type
+          - description: |
+              Timestamp of last transition
+            displayName: Last Transition
+            path: lastTransition
+          - description: |
+              Current version of MongoDB
+            displayName: MongoDB Version
+            path: version
+        version: v1
+      - description: MongoDB Multi Deployment
+        displayName: MongoDB Multi Deployment
+        kind: MongoDBMulti
+        name: mongodbmulti.mongodb.com
+        resources:
+          - kind: StatefulSet
+            name: StatefulSet holding the Pod with MongoDB
+            version: apps/v1
+          - kind: Service
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: MongoDB Deployment Type
+            path: type
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:ReplicaSet
+          - description: Version of MongoDB to use.
+            displayName: MongoDB Version
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - description: In a Replica Set deployment type, specifies the amount of members.
+            displayName: Members of a Replica Set
+            path: members
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - displayName: Cloud/Ops Manager credentials
+            path: credentials
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfig
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - description: Project configuration for this deployment
+            displayName: Ops Manager project configuration
+            path: opsManager
+          - description: Name of the ConfigMap with the configuration for this project
+            displayName: Ops Manager Project Configuration
+            path: opsManager.configMapRef.name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfig
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
+          - description: Enable Persistent Storage with Volume Claims
+            displayName: Persistent Storage
+            path: persistent
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - description: Optional. Specify whether to duplicate service objects among different Kubernetes clusters.
+            displayName: Duplicate Service Objects
+            path: duplicateServiceObjects
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ClusterConfiguration
+          - description: Optional. Name of a Kubernetes Cluster Domain.
+            displayName: Name of Kubernetes Cluster Domain
+            path: clusterDomain
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Enable TLS
+            path: security.tls.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:security
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - displayName: Custom CA Config Map
+            path: security.tls.ca
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:security
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
+          - displayName: Enable authentication
+            path: security.authentication.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Authentication
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - displayName: Authentication Mode
+            path: security.authentication.modes
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Authentication
+              - urn:alm:descriptor:com.tectonic.ui:select:SCRAM
+          - description: Spec for each cluster that comprises MongoDB Replicaset
+            displayName: Cluster SpecList
+            path: clusterSpecList
+        statusDescriptors:
+          - description: |
+              Phase the MongoDB Deployment is currently on. It can be any of Running, Pending, Failed.
+            displayName: Phase
+            path: phase
+        version: v1
+      - description: MongoDB x509 User
+        displayName: MongoDB User
+        kind: MongoDBUser
+        name: mongodbusers.mongodb.com
+        resources:
+          - kind: Secret
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: Name of the database user.
+            path: username
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Name of the database that stores usernames.
+            path: db
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Secret Name that user stores the user’s password.
+            path: passwordSecretKeyRef.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - displayName: Name of the MongoDB resource to which this user is associated.
+            path: mongodbResourceRef.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:mongodb
+          - displayName: Database on which the role can act.
+            path: roles.db
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:Roles
+          - displayName: Name of the role to grant the database user.
+            path: roles.name
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:Roles
+          - description: MongoDB resource this user belongs to
+            displayName: MongoDB resource
+            path: mongodbResourceRef
+          - description: Roles this user will have
+            displayName: MongoDB roles
+            path: roles
+        statusDescriptors:
+          - description: |
+              The current state of the MongoDB User
+            displayName: State
+            path: phase
+        version: v1
+      - description: MongoDB Ops Manager
+        displayName: MongoDB Ops Manager
+        kind: MongoDBOpsManager
+        name: opsmanagers.mongodb.com
+        resources:
+          - kind: StatefulSet
+            name: ""
+            version: apps/v1
+          - kind: Service
+            name: ""
+            version: v1
+          - kind: ConfigMap
+            name: ""
+            version: v1
+        specDescriptors:
+          - displayName: The version of Ops Manager to deploy.
+            path: version
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfiguration
+          - displayName: Number of Ops Manager instances.
+            path: replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfiguration
+          - displayName: Secret containing admin user credentials.
+            path: adminCredentials
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfiguration
+          - displayName: Secret to enable TLS for Ops Manager allowing it to serve traffic over HTTPS.
+            path: security.tls.secretRef.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:OpsManagerConfiguration
+          - displayName: Number of ReplicaSet nodes for Application Database.
+            path: applicationDatabase.members
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ApplicationDatabase
+          - displayName: Secret containing the TLS certificate signed by known or custom CA.
+            path: applicationDatabase.security.tls.secretRef.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ApplicationDatabase
+          - displayName: ConfigMap with CA for Custom TLS Certificate
+            path: applicationDatabase.security.tls.ca
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:ApplicationDatabase
+          - displayName: Enable Backup Infrastructure
+            path: backup.enabled
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:fieldGroup:BackupInfrastructure
+          - description: Application Database configuration
+            displayName: Application Database
+            path: applicationDatabase
+          - description: configuration
+            displayName: configuration
+            path: configuration
+          - description: Configures external connectivity
+            displayName: External Connectivity
+            path: externalConnectivity
+        statusDescriptors:
+          - description: |
+              The current state of the MongoDBOpsManager.
+            displayName: Phase
+            path: opsManager.phase
+          - description: Type of deployment
+            displayName: Type
+            path: type
+        version: v1
+  description: |
+    The MongoDB Enterprise Kubernetes Operator enables easy deploys of MongoDB
+    into Kubernetes clusters, using our management, monitoring and backup
+    platforms, Ops Manager and Cloud Manager.
+
+    ## Before You Start
+
+    To start using the operator you''ll need an account in MongoDB Cloud Manager or
+    a MongoDB Ops Manager deployment.
+
+    * [Create a Secret with your OpsManager API key](https://docs.mongodb.com/kubernetes-operator/stable/tutorial/create-operator-credentials/#procedure)
+
+    * [Create a ConfigMap with your OpsManager project ID and URL](https://docs.mongodb.com/kubernetes-operator/stable/tutorial/create-project-using-configmap/)
+
+    By installing this integration, you will be able to deploy MongoDB instances
+    with a single simple command.
+
+    ## Required Parameters
+
+    * `opsManager` or `cloudManager` - Enter the name of the ConfigMap containing project information
+    * `credentials` - Enter the name of the Secret containing your OpsManager credentials
+    * `type` - Enter MongoDB Deployment Types ("Standalone", "ReplicaSet", "ShardedCluster"
+
+    ## Supported MongoDB Deployment Types ##
+
+    * Standalone: An instance of mongod that is running as a single server and
+    not as part of a replica set, this is, it does not do any kind of
+    replication.
+
+    * Replica Set: A replica set in MongoDB is a group of mongod processes that
+    maintain the same data set. Replica sets provide redundancy and high
+    availability, and are the basis for all production deployments. This section
+    introduces replication in MongoDB as well as the components and architecture
+    of replica sets. The section also provides tutorials for common tasks
+    related to replica sets.
+
+    * Sharded Cluster: The set of nodes comprising a sharded MongoDB deployment.
+    A sharded cluster consists of config servers, shards, and one or more mongos
+    routing processes. Sharding is a A database architecture that partitions
+    data by key ranges and distributes the data among two or more database
+    instances. Sharding enables horizontal scaling.
+
+    ## Requirements for deploying MongoDB OpsManager
+
+    * In order to deploy resources of type MongoDB OpsManager, you will need to
+    create a secret containing the [credentials](https://docs.mongodb.com/kubernetes-operator/stable/tutorial/plan-om-resource/#om-rsrc-prereqs)
+    for the Global Owner user
+
+    ## Security ##
+
+    The operator can enable TLS for all traffic between servers and also between
+    clients and servers. Before enabling `security.tls.enabled` to `true` you
+    should create your certificates.  or you can leave the operator to create all
+    the certificates for you. The operator ability to create certs is been
+    deprecated due to Kubernetes API changes.
+
+    For more information, please read the official MongoDB
+    Kubernetes Operator  [docs](https://docs.mongodb.com/kubernetes-operator/stable/).
+  displayName: MongoDB Enterprise Operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAJEXpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarVhtdiMpDPzPKfYIDUIIHYfP9/YGe/wtQXcnsZ1JMjP2xLQBg1CVSmLc+O/f6f7BiwIFF1ly0pQOvKJGDQUP+divsj79EdfnesVzCN8/9Lt7IKCL0NL+mtM5/+r39wK7KXjidwvldg7UjwN67hDyw0LnRmQWBTz0cyE9F6KwB/y5QNnHOpJmeX+EOnbbr5Pk/efsI7VjHcSfo4/fo8B7nbEPhTDI04HPQHEbQPbnHRUbwCe+YKKnjOe4ejxdlsAhr/x0vLPKPaJyP/lP+h9AobT7HTo+OjPd7ct+z6+d75aL3+1M7d75Qz/3oz4e5/qbs2c359inKzHBpek81HWU9YSJWCTS+lnCW/DHeJb1VryzA3sbIO9Hw44Vz+oDvD999N0XP/1YbfMNJsYwgqANoQEb68skQUOjwxk29vYzCCl1oBaoAV5Cb7ht8WtfXds1n7Fx95gZPBbzK9bs42+8P11oTqO890e+fQW7ggUFzDDk7BOzAIifF494Ofh6P74MVwKCvNycccBy1L1EZX9yy3hEC2jCREa7Y81LPxeAi7A3wxhPQOBIntgnf0gI4j38mIFPwUIZQRMqIPDMocPKEIkSwMnB9sZvxK+5gcPuhmYBCKZEAmiUCrCKEDbwR2IGhwoTR2ZOLJxZuSRKMXFKSZKJXxGSKCxJRLKolEw5Zs4pS84uay4alCCOrElFs6qWgk0LVi74dcGEUmqoVGPlmqrUXLWWBvq02LilJi27pq300KlDJ3rq0nPXXoYfoNKIg0caMvLQUSaoNmnGyTNNmXnqLDdq3m1Yn97fR81fqIWFlE2UGzX8VORawpucsGEGxEL0QFwMARA6GGZH9jEGZ9AZZocGRAUHWMkGTveGGBCMwwee/sbuDbkPuLkY/wi3cCHnDLq/gZwz6D5B7hm3F6h1yzbtILcQsjA0px6E8MOEkUvIxZLat1t3d9QCRxsxap9zbTJnSpC9Ujts4Njb6FI9zspJeXbVkeaYtbVJSEezUW6JaKAvwg/D5hQZLDanrtM00jbEY0rHKkDDT6qjjyI1Tvi0x0mumC00PWvDJgQFlzlr6JBLDpCAfhT8JmmB17ocZZ0GOWg/HHfrHjt+t10LAbGArAzLYWMFIjiYSgUyBMqQThxLoUockGq0iRauh56ughvMVW77wZ9+oOWHXtjDEyFKmyAyYgHI19rzRglrZxYvpcA/8Ec1h7rT63Q63Tw690qqSBQJdCs5llETtVGW9VzNejNAzPo0VWt1MD+hwMgT1lTWuj1MBWGlfqQ8kPXMvgMxs56QdF+17rOBX7WS9IlLzsj0nkswang2SsLdcyIt4xRwm+8UBaGTU0gRkaOh10kbtJLBoye6g78sscDpBA9P6YMn4ngidXfgQR1AIWLLjFyG1Mbw/UzR2d7Z2yfcx6EhKA+P6DfFAW1nywjatUeUGk5/Hc+t+2zgkxYhUnAuglk6BGE0m4lCmm4eaSwCwWjITao1orWjGS3EjpZENeNoxg6Qc0pZEYQv5m4m+E+rg/b47bE2dXwVCQDlNY2me6QRBA1iGCEhRbBjNe8F0L/N03a/bc8FWAUaKJ7FAsVBF7mPWO/Ahnz+XNZCdu86wOgwYwXw4fSOAb+8M1bowkooSoXgmAKCKaaBSwER/RBBCHJR5F0klsyWSyrl2vVkchv+ay0Z5IgTNARSNpvOJbKgdkog+dGr8b23CUVLwm3MXGAv9zf5i0grEqY2dchhniumDwkX78a3afXWuruDC3R9mMCg2ZH4pFQxsNVXIAEKVghKRpe2vqIfodLqTwXAD0EOsNTbjSm4FrCboDvIQtJa77P5ihzfpOrk0jpKqQEZ7DHj30T4X6IfnjjiviTJynfQ74d8NyRZ9rkzoXsbghrGJoIikuGb1hDza7FCQ/LrfeLpbnpOR3Asbg+2S4ERh9mALLv3h+dZXowU1hkdQYwG7ohDpp6qnEf9eXpzI9cWdmgiBua6CmmpVo28HNFiAtLnGDi/IqehYLLd3Urk7acMROiNULaywxE4lTNlYaszIj8MXSMIAxMLMiO81TxpLxc+CIX7plJ8UvScIGDEPQ49k2B8RYKHQut9i9BqjOQWhtomW3G6pguDF2NuDWpCnjZpyP5zL/y6dd8IhbzrPyQdZJhmjcKstRWoSBtK9xFbVKVqmeuN+i+Z/1TdVUuQfAgywAEVaqBb5jGvGCf+AbMfNsTNwZtkGeOslliVhF3371oCOWdAc1jWzoXOnfdCFO6VqDKjipiVCMkYgm2VSwIM1S8Fr33UuDLJhwg2GbEQRgIFRCgbAvlCuOD03tu7Qu8SSNxJSi3FYFjpE76mhtw+vUM+N0WU2lNeBwpqB4ofqpRdBsYiKONYcc3BfWosqbYCLxy8q5HfqNnu2s3qCbWCytHwsH1WvnPmihPU+zgkNxTMioQiqPKROhd1/PDXWS0Fn7nOvWNDLB3FmJYHN24vKtdqBTMuc/gFLogWAJRONyL636yEhYjY7Uv7T7q5vYnIXaXI4a12X+6Ezxni0lHxJpgdU+jNVbkDq+bfqkNeRT8KUJzPWBRn64tFuCcNAotWugWLirEIpXvd1MX+DaXc8K6Q/U9WkwT7ruqDnuh2+ukAQWQJ6SNBGIVWhI7g1qpdEMsDPMINBJBdGLWMKxhmwIhVoOPeYSGyrx28rx0dlxoL9WTGIj1ZjYIyEXV5UsKN/SqRUBi27+vRd9sa5fQjoqPf0ejoDEdZ4UjI0kdWVC3mRZArW4GP0hO6hmi+a2a6auawa2bU2YKyMMAD+2qGKrJ4lNuofE7Zhg1LnMnSI1IGDg0esfENVp1sQ7J0F91M8I1uCJakKNxHE/C0FNw+Ajg3QhWWmrsdcIR5ak2cp9aIA03kpImJTclWlaYGPtVWWk0HfmBnOq84dF1xglVxGWdK2GuVx4o8mvyRO7pD+0Up9evW/TleGy73BV77WqdpX0Is8iEsdgnx+yZeJ0hmIupmwlUcl5BT7SKus9BBm/ft6+xqXfwzibyq3OxgyhFHqt/IHuuMUMrBHLhVjyI/7AoDgDkkjh8GiTETsfU/ZHuEtrDMfYEAAAGFaUNDUElDQyBwcm9maWxlAAB4nH2RPUjDQBzFX1O1UioiVhBxyFB1sSAq4qhVKEKFUCu06mBy6YfQpCFJcXEUXAsOfixWHVycdXVwFQTBDxA3NydFFynxf2mhRYwHx/14d+9x9w4QqkWmWW1jgKbbZjIeE9OZFTHwiiD60IMRdMjMMmYlKQHP8XUPH1/vojzL+9yfo0vNWgzwicQzzDBt4nXiqU3b4LxPHGYFWSU+Jx416YLEj1xX6vzGOe+ywDPDZio5RxwmFvMtrLQwK5ga8SRxRNV0yhfSdVY5b3HWimXWuCd/YSirLy9xneYg4ljAIiSIUFDGBoqwEaVVJ8VCkvZjHv4B1y+RSyHXBhg55lGCBtn1g//B726t3MR4PSkUA9pfHOdjCAjsArWK43wfO07tBPA/A1d601+qAtOfpFeaWuQI6N4GLq6bmrIHXO4A/U+GbMqu5Kcp5HLA+xl9UwbovQWCq/XeGvs4fQBS1FXiBjg4BIbzlL3m8e7O1t7+PdPo7wdVb3KbaWTEXAAADRxpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+Cjx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDQuNC4wLUV4aXYyIj4KIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgIHhtbG5zOkdJTVA9Imh0dHA6Ly93d3cuZ2ltcC5vcmcveG1wLyIKICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICB4bXBNTTpEb2N1bWVudElEPSJnaW1wOmRvY2lkOmdpbXA6ZDk1YjhmMjctMWM0NS00YjU1LWEwZTMtNmNmMjM0Yzk1ZWVkIgogICB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOmVhMGY5MTI5LWJlMDItNDVjOS1iNGU4LTU3N2MxZTBiZGJhNyIKICAgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjcyNmY4ZGFlLTM4ZTYtNGQ4Ni1hNTI4LWM0NTc4ZGE4ODA0NSIKICAgZGM6Rm9ybWF0PSJpbWFnZS9wbmciCiAgIEdJTVA6QVBJPSIyLjAiCiAgIEdJTVA6UGxhdGZvcm09Ik1hYyBPUyIKICAgR0lNUDpUaW1lU3RhbXA9IjE2MzQ4MzgwMTYyMTQ2MTMiCiAgIEdJTVA6VmVyc2lvbj0iMi4xMC4yNCIKICAgdGlmZjpPcmllbnRhdGlvbj0iMSIKICAgeG1wOkNyZWF0b3JUb29sPSJHSU1QIDIuMTAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgc3RFdnQ6YWN0aW9uPSJzYXZlZCIKICAgICAgc3RFdnQ6Y2hhbmdlZD0iLyIKICAgICAgc3RFdnQ6aW5zdGFuY2VJRD0ieG1wLmlpZDo1YWNhZmVhMC0xZmY5LTRiMmUtYmY0NC02NTM3MzYwMGQzNjEiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkdpbXAgMi4xMCAoTWFjIE9TKSIKICAgICAgc3RFdnQ6d2hlbj0iMjAyMS0xMC0yMVQxODo0MDoxNiswMTowMCIvPgogICAgPC9yZGY6U2VxPgogICA8L3htcE1NOkhpc3Rvcnk+CiAgPC9yZGY6RGVzY3JpcHRpb24+CiA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgCjw/eHBhY2tldCBlbmQ9InciPz6528V0AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAB3RJTUUH5QoVESgQ+iToFAAAA8xJREFUeNrlW01PU0EUPTPV+oqb4h+wENYKXbmzsjLEKPAHwB1xQ6N7adiboBtrSAT5AaQmBpuYSN25MS17k5Zf0MemFGznungttCkf782bmTels2w6mbnnnnPv3DvzYrBhrMytIT01gz9/f5temkVv/NMUwKsg1MFEGvlizeTy3ALj9zuuGAf4T2QzydEBACwHINXzwwSOE29N7iAWqe7BsoOYsEdITx2ZigcsIupnzqh/8SC0/6Wx+aNy8yTg6X7rWsfEbu96/71JAGQzyY7n/Rg2AcZ3dQdFswA0Exs+je8KYUZ3UDQXA1bmlgFsScwkMFrEx++F4QXgPN/LaZpQR6IxiY2SO6QSGMj3Qd00jpPE5+FkgDz1B3kAMYt8sTQ8AGQzSTTHyqG83z+qcBpplVLQK4Hm2KpC473U2BzLDgcDwgY+QwFRIwP4knLjuwFRIQv0MGB5PgnntKwFAMUs0MMA53Rem/Ge25I4ufvCXgkQVrVXsSSW7JTAq7lpCJQNnK4IEJNhW2jqGdDGsrH6QrB5GyXwWMKXLoi5gdnL8dwuCXjRvy4xs0vjVGDonMa9MNlALQPiJxlJOcvruOlM2yMBzuQ3Q3Al44BFADA8lJ9LrtSKnD2wBwAhe/hhIVIZpWxiQJgG5qHkohYBoPP4q6tks2Qfh1GBzu3xhWQckM0eWgAIfprrBE+SN4LZBACTNIQzF4KO5EAnmxgQwhtckj2WMeBA8gARpqQ9sAcAAfnrbLk4QGBUsQcAHmIzXFLLrbZFDMgXS1KZoN2W1DHVwj6iUH8O4FQKPCcWc3t6AkGCTin0dpUDQPhq6OREgNixD4BmvBBYBlKNTaqpuChVD8B2wQWj98EnOrVA3hf4YHExJLb1l3FUsBeAfLEG0Bef//Y8H28FqSW2VT2p1VgNUi5QLKC4z1qCqoBYt78fkC/WfMWCwMUM21H5oFrzA4n4xrUt724xQy0fxRRVkd/LKQ0lWgHYLrgAvfQXN1vXSYAAmlUeS7VH63yxBMIVUvDdB1jX8S2BmZbYp70scNkRmXtXaQkOXN4b3FJNfbMAAEDzzoLcFRhV4TReaztOGAPAiwdPLgDh8OqUR7M6XoiaB6CbGtts4cLzwbtv1N8Z7hiv+Rsi823xzb0KRB8T7gMA3jxj59dcZoz3snBUY+VpCmD7nautXGcva2Aog8Siqa/Hov1sbuAxJZXgHC/o1Hz0Ehgsmn71/FIxaXz0AAwS8sj0ihYAcBb5CVJ9weFnwLnR1K6PHgC9FyJsFCVwq+9afAQlIITbnxXMjv+6222dh4/VtAAAAABJRU5ErkJggg==
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingwebhookconfigurations
+              verbs:
+                - create
+                - delete
+                - get
+                - update
+            - apiGroups:
+                - certificates.k8s.io
+              resources:
+                - certificatesigningrequests
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+          serviceAccountName: mongodb-enterprise-operator
+      deployments:
+        - name: mongodb-enterprise-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: controller
+                app.kubernetes.io/instance: mongodb-enterprise-operator
+                app.kubernetes.io/name: mongodb-enterprise-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: controller
+                  app.kubernetes.io/instance: mongodb-enterprise-operator
+                  app.kubernetes.io/name: mongodb-enterprise-operator
+              spec:
+                containers:
+                  - args:
+                      - -watch-resource=mongodb
+                      - -watch-resource=opsmanagers
+                      - -watch-resource=mongodbusers
+                    command:
+                      - /usr/local/bin/mongodb-enterprise-operator
+                    env:
+                      - name: OPERATOR_ENV
+                        value: prod
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: CURRENT_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MANAGED_SECURITY_CONTEXT
+                        value: "true"
+                      - name: IMAGE_PULL_POLICY
+                        value: Always
+                      - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+                        value: quay.io/mongodb/mongodb-enterprise-database-ubi
+                      - name: INIT_DATABASE_IMAGE_REPOSITORY
+                        value: quay.io/mongodb/mongodb-enterprise-init-database-ubi
+                      - name: INIT_DATABASE_VERSION
+                        value: 1.0.12
+                      - name: DATABASE_VERSION
+                        value: 2.0.2
+                      - name: OPS_MANAGER_IMAGE_REPOSITORY
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
+                      - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
+                        value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi
+                      - name: INIT_OPS_MANAGER_VERSION
+                        value: 1.0.9
+                      - name: INIT_APPDB_IMAGE_REPOSITORY
+                        value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi
+                      - name: INIT_APPDB_VERSION
+                        value: 1.0.12
+                      - name: OPS_MANAGER_IMAGE_PULL_POLICY
+                        value: Always
+                      - name: AGENT_IMAGE
+                        value: quay.io/mongodb/mongodb-agent-ubi@sha256:ffa842168cc0865bba022b414d49e66ae314bf2fd87288814903d5a430162620
+                      - name: MONGODB_IMAGE
+                        value: mongodb-enterprise-appdb-database-ubi
+                      - name: MONGODB_REPO_URL
+                        value: quay.io/mongodb
+                      - name: PERFORM_FAILOVER
+                        value: "true"
+                      - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_2_0_2
+                        value: quay.io/mongodb/mongodb-enterprise-database-ubi@sha256:eab363d30db05c6af7bde539b4c550e60c54bdab7403288a8b00a246089d3108
+                      - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_0_12
+                        value: quay.io/mongodb/mongodb-enterprise-init-database-ubi@sha256:1f0d83b1730ca3afbff504ca1439b1c66b1f344b32aed6e337a36c912a631469
+                      - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_0_9
+                        value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi@sha256:943185414fb86b643c5b5f2c85fa890d509e0f352bb9de492ed927a493a5332e
+                      - name: RELATED_IMAGE_INIT_APPDB_IMAGE_REPOSITORY_1_0_12
+                        value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi@sha256:9a8416762e874607278f9ae64af1b01d014031d91fc5aec3bb025d846cbe7218
+                      - name: RELATED_IMAGE_AGENT_IMAGE_11_0_5_6963_1
+                        value: quay.io/mongodb/mongodb-agent-ubi@sha256:e7176c627ef5669be56e007a57a81ef5673e9161033a6966c6e13022d241ec9e
+                      - name: RELATED_IMAGE_AGENT_IMAGE_11_12_0_7388_1
+                        value: quay.io/mongodb/mongodb-agent-ubi@sha256:ffa842168cc0865bba022b414d49e66ae314bf2fd87288814903d5a430162620
+                      - name: RELATED_IMAGE_AGENT_IMAGE_12_0_4_7554_1
+                        value: quay.io/mongodb/mongodb-agent-ubi@sha256:3e07e8164421a6736b86619d9d72f721d4212acb5f178ec20ffec045a7a8f855
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_0
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:f8977591e64c942e513f3672f6841a03bc1fc6c39a9a0f47785058c3aae4c360
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_1
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:322bdd4be1278cd393765332a2acc8e2610f248999be3b064695b41e0ad7fa31
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_2
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:af7dd4b4496ee7714d64596fa6d2e4d7ccc0084c8b7f4efade1ffa344756729c
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_3
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:7b9a286124784a646a952a8d3a3cd47481fee838a649f49506c08d5dc3ce487d
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_4
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:485ae0a64d9648a4085b52d1cd5b9b3bb51df9337e30a1c3d7cc29d2eea1f1d9
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_5
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:79441d3bddb5d2f6c6be64bcabf7092d154aa3407e057c7f159de0877ae987a0
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_6
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:a10baf02012eb4ce9b5c1bf8a7eac2e219c64a645d20aefc01241c6da332a18c
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_7
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:0bffc1901c56d00afe853911ddeb5ffef22f006d428f14fdd2428289c87f4eda
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_8
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:1c9c085196cafcfec47b7fe0d37c77e32914605d6fadda2e2138030e6646e422
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_9
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:b41059bfd5bc1ced5a1b6c405842473bf2cac091b6bc51b04d55d02b17dd6d7c
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_10
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:ee2c2914fb6c9719888ee7a13b42577206f2a634d4a82eacfefc8ff6a325fba8
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_11
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:c171d694178daeac720c69da0ab8ac5d1311ac719ef07ea4fa095f07ef9772b0
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_12
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:554ae3aab672aed1f307f3472d074df901c20461ed89899f6dc30706ec93d400
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_13
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:c7c3856813c5fb231d8118f3848b3f30974ea0b675a3ce395db0b75cfc348d12
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_14
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:7ffc31038b498ff3b884d59c8640d916b1d038c7e08e62167521287c698e1549
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_15
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:71e35d3972e5e49f31ca74f111e8ff6cf804d09d9a21303f6ad4ac43b0628e75
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_0
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e87a59f4f597b1bed408bd1fe0f0816e1037656fae3efd522c497fff4bc8212f
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_1
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e69c9e8791b9b78937cb3205ff41e77472ef51b6e6752f3ee3c48c532a765fb7
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_2
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:236e60a18f90f72ef26d20471c28265f244560e22b09779a726f809f12d55ff2
+                      - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_3
+                        value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e0530f7856b5038a6081532d2e04ca638de89404976be697620db484364a2461
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_11_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:dc9ae18097d195f3849f981410a1c3d6d761528a15c31b954f0523144800305a
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_2_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:8eff2e05a9abb07dc75cf90450317bc45011b0718f25afaa990e896be96f97a8
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_6_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:5cd3ed1053dae64c2cc7e13718cb93f899deffec7116ee7115cf92fa8f42f2e5
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_8_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:ed8a16becb323b2e4a79b4335ece0208fe24526a2e59b3cb487017f9a517fda9
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_0_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:0b0b86ae1650100278491f9eb7f8626cd8914f9c9570d0ed3946c775236e8e0d
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_11_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:4409ff1c1e0fc9bb09238051f099c955878bdf476cc9419ee2c947f20dd97ff4
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_4_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:2c2e98c4c87faece21154178cab15de8fe9e422f7eb575ddf7fed2b5ba3b1870
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_1_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:4b3c346acbc1743e70e02f5346ace810ec8b133ae3c920f7266aee360e6fca87
+                      - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_5_ent
+                        value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:14362d2593085a56eb092ebfbed7edf78c8e2d654e6b195dd67dccacee3f8464
+                    image: quay.io/mongodb/mongodb-enterprise-operator-ubi@sha256:208da2e5c879da7578a9c04dad342a2e1d0282cf9d3c79effa4f1ae036b6873a
+                    imagePullPolicy: Always
+                    name: mongodb-enterprise-operator
+                    resources:
+                      limits:
+                        cpu: 1100m
+                        memory: 1Gi
+                      requests:
+                        cpu: 500m
+                        memory: 200Mi
+                serviceAccountName: mongodb-enterprise-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - mongodb.com
+              resources:
+                - mongodb
+                - mongodb/finalizers
+                - mongodb/status
+              verbs:
+                - '*'
+            - apiGroups:
+                - mongodb.com
+              resources:
+                - mongodbmulti
+                - mongodbmulti/finalizers
+                - mongodbmulti/status
+              verbs:
+                - '*'
+            - apiGroups:
+                - mongodb.com
+              resources:
+                - mongodbusers
+                - mongodbusers/finalizers
+                - mongodbusers/status
+              verbs:
+                - '*'
+            - apiGroups:
+                - mongodb.com
+              resources:
+                - opsmanagers
+                - opsmanagers/finalizers
+                - opsmanagers/status
+              verbs:
+                - '*'
+          serviceAccountName: mongodb-enterprise-operator
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - mongodb
+    - databases
+    - nosql
+  links:
+    - name: Documentation
+      url: https://docs.opsmanager.mongodb.com/current/tutorial/install-k8s-operator/index.html
+  maintainers:
+    - email: support@mongodb.com
+      name: MongoDB, Inc
+  maturity: stable
+  minKubeVersion: 1.21.0
+  provider:
+    name: MongoDB, Inc
+  relatedImages:
+    - image: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi@sha256:943185414fb86b643c5b5f2c85fa890d509e0f352bb9de492ed927a493a5332e
+      name: init_ops_manager_image_repository_1_0_9
+    - image: quay.io/mongodb/mongodb-agent-ubi@sha256:ffa842168cc0865bba022b414d49e66ae314bf2fd87288814903d5a430162620
+      name: agent_image_11_12_0_7388_1
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:5cd3ed1053dae64c2cc7e13718cb93f899deffec7116ee7115cf92fa8f42f2e5
+      name: mongodb_image_4_2_6_ent
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:0b0b86ae1650100278491f9eb7f8626cd8914f9c9570d0ed3946c775236e8e0d
+      name: mongodb_image_4_4_0_ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:322bdd4be1278cd393765332a2acc8e2610f248999be3b064695b41e0ad7fa31
+      name: ops-manager-image-repository-5-0-1
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:1c9c085196cafcfec47b7fe0d37c77e32914605d6fadda2e2138030e6646e422
+      name: ops-manager-image-repository-5-0-8
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:2c2e98c4c87faece21154178cab15de8fe9e422f7eb575ddf7fed2b5ba3b1870
+      name: mongodb_image_4_4_4_ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:a10baf02012eb4ce9b5c1bf8a7eac2e219c64a645d20aefc01241c6da332a18c
+      name: ops-manager-image-repository-5-0-6
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:485ae0a64d9648a4085b52d1cd5b9b3bb51df9337e30a1c3d7cc29d2eea1f1d9
+      name: ops_manager_image_repository_5_0_4
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:dc9ae18097d195f3849f981410a1c3d6d761528a15c31b954f0523144800305a
+      name: mongodb-image-4-2-11-ent
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:4b3c346acbc1743e70e02f5346ace810ec8b133ae3c920f7266aee360e6fca87
+      name: mongodb-image-5-0-1-ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:f8977591e64c942e513f3672f6841a03bc1fc6c39a9a0f47785058c3aae4c360
+      name: ops_manager_image_repository_5_0_0
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:79441d3bddb5d2f6c6be64bcabf7092d154aa3407e057c7f159de0877ae987a0
+      name: ops_manager_image_repository_5_0_5
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:554ae3aab672aed1f307f3472d074df901c20461ed89899f6dc30706ec93d400
+      name: ops_manager_image_repository_5_0_12
+    - image: quay.io/mongodb/mongodb-enterprise-database-ubi@sha256:eab363d30db05c6af7bde539b4c550e60c54bdab7403288a8b00a246089d3108
+      name: mongodb-enterprise-database-image-2-0-2
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:554ae3aab672aed1f307f3472d074df901c20461ed89899f6dc30706ec93d400
+      name: ops-manager-image-repository-5-0-12
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:7ffc31038b498ff3b884d59c8640d916b1d038c7e08e62167521287c698e1549
+      name: ops-manager-image-repository-5-0-14
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:71e35d3972e5e49f31ca74f111e8ff6cf804d09d9a21303f6ad4ac43b0628e75
+      name: ops-manager-image-repository-5-0-15
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:a10baf02012eb4ce9b5c1bf8a7eac2e219c64a645d20aefc01241c6da332a18c
+      name: ops_manager_image_repository_5_0_6
+    - image: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi@sha256:943185414fb86b643c5b5f2c85fa890d509e0f352bb9de492ed927a493a5332e
+      name: init-ops-manager-image-repository-1-0-9
+    - image: quay.io/mongodb/mongodb-agent-ubi@sha256:584ff388983f963eba8033d439e7f9efbcfa0ed3c84b5843db6bf32d107f0b65
+      name: agent-image-12-0-4-7554-1
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:b41059bfd5bc1ced5a1b6c405842473bf2cac091b6bc51b04d55d02b17dd6d7c
+      name: ops-manager-image-repository-5-0-9
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e0530f7856b5038a6081532d2e04ca638de89404976be697620db484364a2461
+      name: ops-manager-image-repository-6-0-3
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:7ffc31038b498ff3b884d59c8640d916b1d038c7e08e62167521287c698e1549
+      name: ops_manager_image_repository_5_0_14
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:236e60a18f90f72ef26d20471c28265f244560e22b09779a726f809f12d55ff2
+      name: ops_manager_image_repository_6_0_2
+    - image: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi@sha256:9a8416762e874607278f9ae64af1b01d014031d91fc5aec3bb025d846cbe7218
+      name: init-appdb-image-repository-1-0-12
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:af7dd4b4496ee7714d64596fa6d2e4d7ccc0084c8b7f4efade1ffa344756729c
+      name: ops-manager-image-repository-5-0-2
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:0b0b86ae1650100278491f9eb7f8626cd8914f9c9570d0ed3946c775236e8e0d
+      name: mongodb-image-4-4-0-ent
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:14362d2593085a56eb092ebfbed7edf78c8e2d654e6b195dd67dccacee3f8464
+      name: mongodb-image-5-0-5-ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e87a59f4f597b1bed408bd1fe0f0816e1037656fae3efd522c497fff4bc8212f
+      name: ops_manager_image_repository_6_0_0
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:79441d3bddb5d2f6c6be64bcabf7092d154aa3407e057c7f159de0877ae987a0
+      name: ops-manager-image-repository-5-0-5
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:c7c3856813c5fb231d8118f3848b3f30974ea0b675a3ce395db0b75cfc348d12
+      name: ops-manager-image-repository-5-0-13
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:ed8a16becb323b2e4a79b4335ece0208fe24526a2e59b3cb487017f9a517fda9
+      name: mongodb-image-4-2-8-ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:1c9c085196cafcfec47b7fe0d37c77e32914605d6fadda2e2138030e6646e422
+      name: ops_manager_image_repository_5_0_8
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e69c9e8791b9b78937cb3205ff41e77472ef51b6e6752f3ee3c48c532a765fb7
+      name: ops_manager_image_repository_6_0_1
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e87a59f4f597b1bed408bd1fe0f0816e1037656fae3efd522c497fff4bc8212f
+      name: ops-manager-image-repository-6-0-0
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:5cd3ed1053dae64c2cc7e13718cb93f899deffec7116ee7115cf92fa8f42f2e5
+      name: mongodb-image-4-2-6-ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:236e60a18f90f72ef26d20471c28265f244560e22b09779a726f809f12d55ff2
+      name: ops-manager-image-repository-6-0-2
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:2c2e98c4c87faece21154178cab15de8fe9e422f7eb575ddf7fed2b5ba3b1870
+      name: mongodb-image-4-4-4-ent
+    - image: quay.io/mongodb/mongodb-agent-ubi@sha256:3e07e8164421a6736b86619d9d72f721d4212acb5f178ec20ffec045a7a8f855
+      name: agent_image_12_0_4_7554_1
+    - image: quay.io/mongodb/mongodb-agent-ubi@sha256:a4cadf209ab87eb7d121ccd8b1503fa5d88be8866b5c3cb7897d14c36869abf6
+      name: agent-image-11-12-0-7388-1
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e69c9e8791b9b78937cb3205ff41e77472ef51b6e6752f3ee3c48c532a765fb7
+      name: ops-manager-image-repository-6-0-1
+    - image: quay.io/mongodb/mongodb-enterprise-operator-ubi@sha256:208da2e5c879da7578a9c04dad342a2e1d0282cf9d3c79effa4f1ae036b6873a
+      name: mongodb-enterprise-operator
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:71e35d3972e5e49f31ca74f111e8ff6cf804d09d9a21303f6ad4ac43b0628e75
+      name: ops_manager_image_repository_5_0_15
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:dc9ae18097d195f3849f981410a1c3d6d761528a15c31b954f0523144800305a
+      name: mongodb_image_4_2_11_ent
+    - image: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi@sha256:9a8416762e874607278f9ae64af1b01d014031d91fc5aec3bb025d846cbe7218
+      name: init_appdb_image_repository_1_0_12
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:af7dd4b4496ee7714d64596fa6d2e4d7ccc0084c8b7f4efade1ffa344756729c
+      name: ops_manager_image_repository_5_0_2
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:c7c3856813c5fb231d8118f3848b3f30974ea0b675a3ce395db0b75cfc348d12
+      name: ops_manager_image_repository_5_0_13
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:e0530f7856b5038a6081532d2e04ca638de89404976be697620db484364a2461
+      name: ops_manager_image_repository_6_0_3
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:14362d2593085a56eb092ebfbed7edf78c8e2d654e6b195dd67dccacee3f8464
+      name: mongodb_image_5_0_5_ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:c171d694178daeac720c69da0ab8ac5d1311ac719ef07ea4fa095f07ef9772b0
+      name: ops-manager-image-repository-5-0-11
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:b41059bfd5bc1ced5a1b6c405842473bf2cac091b6bc51b04d55d02b17dd6d7c
+      name: ops_manager_image_repository_5_0_9
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:ee2c2914fb6c9719888ee7a13b42577206f2a634d4a82eacfefc8ff6a325fba8
+      name: ops_manager_image_repository_5_0_10
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:ed8a16becb323b2e4a79b4335ece0208fe24526a2e59b3cb487017f9a517fda9
+      name: mongodb_image_4_2_8_ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:ee2c2914fb6c9719888ee7a13b42577206f2a634d4a82eacfefc8ff6a325fba8
+      name: ops-manager-image-repository-5-0-10
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:7b9a286124784a646a952a8d3a3cd47481fee838a649f49506c08d5dc3ce487d
+      name: ops_manager_image_repository_5_0_3
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:7b9a286124784a646a952a8d3a3cd47481fee838a649f49506c08d5dc3ce487d
+      name: ops-manager-image-repository-5-0-3
+    - image: quay.io/mongodb/mongodb-enterprise-init-database-ubi@sha256:1f0d83b1730ca3afbff504ca1439b1c66b1f344b32aed6e337a36c912a631469
+      name: init_database_image_repository_1_0_12
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:4b3c346acbc1743e70e02f5346ace810ec8b133ae3c920f7266aee360e6fca87
+      name: mongodb_image_5_0_1_ent
+    - image: quay.io/mongodb/mongodb-agent-ubi@sha256:bbe8b314b8ddc1f534e57ecc05d4c36b2c00c6fb1736a48be1b3aee216a54fce
+      name: agent-image-11-0-5-6963-1
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:c171d694178daeac720c69da0ab8ac5d1311ac719ef07ea4fa095f07ef9772b0
+      name: ops_manager_image_repository_5_0_11
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:8eff2e05a9abb07dc75cf90450317bc45011b0718f25afaa990e896be96f97a8
+      name: mongodb-image-4-2-2-ent
+    - image: quay.io/mongodb/mongodb-agent-ubi@sha256:e7176c627ef5669be56e007a57a81ef5673e9161033a6966c6e13022d241ec9e
+      name: agent_image_11_0_5_6963_1
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:322bdd4be1278cd393765332a2acc8e2610f248999be3b064695b41e0ad7fa31
+      name: ops_manager_image_repository_5_0_1
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:8eff2e05a9abb07dc75cf90450317bc45011b0718f25afaa990e896be96f97a8
+      name: mongodb_image_4_2_2_ent
+    - image: quay.io/mongodb/mongodb-enterprise-init-database-ubi@sha256:1f0d83b1730ca3afbff504ca1439b1c66b1f344b32aed6e337a36c912a631469
+      name: init-database-image-repository-1-0-12
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:0bffc1901c56d00afe853911ddeb5ffef22f006d428f14fdd2428289c87f4eda
+      name: ops-manager-image-repository-5-0-7
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:4409ff1c1e0fc9bb09238051f099c955878bdf476cc9419ee2c947f20dd97ff4
+      name: mongodb-image-4-4-11-ent
+    - image: quay.io/mongodb/mongodb-enterprise-database-ubi@sha256:eab363d30db05c6af7bde539b4c550e60c54bdab7403288a8b00a246089d3108
+      name: mongodb_enterprise_database_image_2_0_2
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:0bffc1901c56d00afe853911ddeb5ffef22f006d428f14fdd2428289c87f4eda
+      name: ops_manager_image_repository_5_0_7
+    - image: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi@sha256:4409ff1c1e0fc9bb09238051f099c955878bdf476cc9419ee2c947f20dd97ff4
+      name: mongodb_image_4_4_11_ent
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:f8977591e64c942e513f3672f6841a03bc1fc6c39a9a0f47785058c3aae4c360
+      name: ops-manager-image-repository-5-0-0
+    - image: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi@sha256:485ae0a64d9648a4085b52d1cd5b9b3bb51df9337e30a1c3d7cc29d2eea1f1d9
+      name: ops-manager-image-repository-5-0-4
+  replaces: mongodb-enterprise.v1.17.0
+  skips:
+    - mongodb-enterprise.v1.17.1
+  version: 1.17.2

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_mongodb.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_mongodb.yaml
@@ -1,0 +1,759 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: mongodb.mongodb.com
+spec:
+  group: mongodb.com
+  names:
+    kind: MongoDB
+    listKind: MongoDBList
+    plural: mongodb
+    shortNames:
+    - mdb
+    singular: mongodb
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Version of MongoDB server.
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - description: The type of MongoDB deployment. One of 'ReplicaSet', 'ShardedCluster'
+        and 'Standalone'.
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The time since the MongoDB resource was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              additionalMongodConfig:
+                description: 'AdditionalMongodConfig is additional configuration that
+                  can be passed to each data-bearing mongod at runtime. Uses the same
+                  structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              agent:
+                properties:
+                  startupOptions:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              backup:
+                description: Backup contains configuration options for configuring
+                  backup for this MongoDB resource
+                properties:
+                  autoTerminateOnDeletion:
+                    description: AutoTerminateOnDeletion indicates if the Operator
+                      should stop and terminate the Backup before the cleanup, when
+                      the MongoDB CR is deleted
+                    type: boolean
+                  mode:
+                    enum:
+                    - enabled
+                    - disabled
+                    - terminated
+                    type: string
+                type: object
+              cloudManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
+              clusterDomain:
+                format: hostname
+                type: string
+              configServerCount:
+                type: integer
+              configSrv:
+                properties:
+                  additionalMongodConfig:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  agent:
+                    properties:
+                      startupOptions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              configSrvPodSpec:
+                properties:
+                  persistence:
+                    properties:
+                      multiple:
+                        properties:
+                          data:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          journal:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          logs:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                      single:
+                        properties:
+                          labelSelector:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          storage:
+                            type: string
+                          storageClass:
+                            type: string
+                        type: object
+                    type: object
+                  podTemplate:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              connectivity:
+                properties:
+                  replicaSetHorizons:
+                    items:
+                      additionalProperties:
+                        type: string
+                      description: 'MongoDBHorizonConfig holds a map of horizon names
+                        to the node addresses, e.g. {   "internal": "my-rs-2.my-internal-domain.com:31843",   "external":
+                        "my-rs-2.my-external-domain.com:21467" } The key of each item
+                        in the map is an arbitrary, user-chosen string that represents
+                        the name of the horizon. The value of the item is the host
+                        and, optionally, the port that this mongod node will be connected
+                        to from.'
+                      type: object
+                    type: array
+                type: object
+              credentials:
+                description: Name of the Secret holding credentials information
+                type: string
+              exposedExternally:
+                description: ExposedExternally determines whether a NodePort service
+                  should be created for the resource
+                type: boolean
+              featureCompatibilityVersion:
+                type: string
+              logLevel:
+                enum:
+                - DEBUG
+                - INFO
+                - WARN
+                - ERROR
+                - FATAL
+                type: string
+              members:
+                description: Amount of members for this MongoDB Replica Set
+                type: integer
+              mongodsPerShardCount:
+                type: integer
+              mongos:
+                properties:
+                  additionalMongodConfig:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  agent:
+                    properties:
+                      startupOptions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              mongosCount:
+                type: integer
+              mongosPodSpec:
+                properties:
+                  persistence:
+                    properties:
+                      multiple:
+                        properties:
+                          data:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          journal:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          logs:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                      single:
+                        properties:
+                          labelSelector:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          storage:
+                            type: string
+                          storageClass:
+                            type: string
+                        type: object
+                    type: object
+                  podTemplate:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              opsManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
+              persistent:
+                type: boolean
+              podSpec:
+                properties:
+                  persistence:
+                    properties:
+                      multiple:
+                        properties:
+                          data:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          journal:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          logs:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                      single:
+                        properties:
+                          labelSelector:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          storage:
+                            type: string
+                          storageClass:
+                            type: string
+                        type: object
+                    type: object
+                  podTemplate:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              prometheus:
+                description: Prometheus configurations.
+                properties:
+                  metricsPath:
+                    description: Indicates path to the metrics endpoint.
+                    pattern: ^\/[a-z0-9]+$
+                    type: string
+                  passwordSecretRef:
+                    description: Name of a Secret containing a HTTP Basic Auth Password.
+                    properties:
+                      key:
+                        description: Key is the key in the secret storing this password.
+                          Defaults to "password"
+                        type: string
+                      name:
+                        description: Name is the name of the secret storing this user's
+                          password
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  port:
+                    description: Port where metrics endpoint will bind to. Defaults
+                      to 9216.
+                    type: integer
+                  tlsSecretKeyRef:
+                    description: Name of a Secret (type kubernetes.io/tls) holding
+                      the certificates to use in the Prometheus endpoint.
+                    properties:
+                      key:
+                        description: Key is the key in the secret storing this password.
+                          Defaults to "password"
+                        type: string
+                      name:
+                        description: Name is the name of the secret storing this user's
+                          password
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  username:
+                    description: HTTP Basic Auth Username for metrics endpoint.
+                    type: string
+                required:
+                - passwordSecretRef
+                - username
+                type: object
+              security:
+                properties:
+                  authentication:
+                    description: Authentication holds various authentication related
+                      settings that affect this MongoDB resource.
+                    properties:
+                      agents:
+                        description: Agents contains authentication configuration
+                          properties for the agents
+                        properties:
+                          automationLdapGroupDN:
+                            type: string
+                          automationPasswordSecretRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          automationUserName:
+                            type: string
+                          clientCertificateSecretRef:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          mode:
+                            description: Mode is the desired Authentication mode that
+                              the agents will use
+                            type: string
+                        required:
+                        - mode
+                        type: object
+                      enabled:
+                        type: boolean
+                      ignoreUnknownUsers:
+                        description: IgnoreUnknownUsers maps to the inverse of auth.authoritativeSet
+                        type: boolean
+                      internalCluster:
+                        type: string
+                      ldap:
+                        description: LDAP Configuration
+                        properties:
+                          authzQueryTemplate:
+                            type: string
+                          bindQueryPasswordSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          bindQueryUser:
+                            type: string
+                          caConfigMapRef:
+                            description: Allows to point at a ConfigMap/key with a
+                              CA file to mount on the Pod
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          servers:
+                            items:
+                              type: string
+                            type: array
+                          timeoutMS:
+                            type: integer
+                          transportSecurity:
+                            enum:
+                            - tls
+                            - none
+                            type: string
+                          userCacheInvalidationInterval:
+                            type: integer
+                          userToDNMapping:
+                            type: string
+                          validateLDAPServerConfig:
+                            type: boolean
+                        type: object
+                      modes:
+                        items:
+                          type: string
+                        type: array
+                      requireClientTLSAuthentication:
+                        description: Clients should present valid TLS certificates
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  certsSecretPrefix:
+                    type: string
+                  roles:
+                    items:
+                      properties:
+                        authenticationRestrictions:
+                          items:
+                            properties:
+                              clientSource:
+                                items:
+                                  type: string
+                                type: array
+                              serverAddress:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        db:
+                          type: string
+                        privileges:
+                          items:
+                            properties:
+                              actions:
+                                items:
+                                  type: string
+                                type: array
+                              resource:
+                                properties:
+                                  cluster:
+                                    type: boolean
+                                  collection:
+                                    type: string
+                                  db:
+                                    type: string
+                                type: object
+                            required:
+                            - actions
+                            - resource
+                            type: object
+                          type: array
+                        role:
+                          type: string
+                        roles:
+                          items:
+                            properties:
+                              db:
+                                type: string
+                              role:
+                                type: string
+                            required:
+                            - db
+                            - role
+                            type: object
+                          type: array
+                      required:
+                      - db
+                      - role
+                      type: object
+                    type: array
+                  tls:
+                    properties:
+                      additionalCertificateDomains:
+                        items:
+                          type: string
+                        type: array
+                      ca:
+                        description: CA corresponds to a ConfigMap containing an entry
+                          for the CA certificate (ca.pem) used to validate the certificates
+                          created already.
+                        type: string
+                      enabled:
+                        description: DEPRECATED please enable TLS by setting `security.certsSecretPrefix`
+                          or `security.tls.secretRef.prefix`. Enables TLS for this
+                          resource. This will make the operator try to mount a Secret
+                          with a defined name (<resource-name>-cert). This is only
+                          used when enabling TLS on a MongoDB resource, and not on
+                          the AppDB, where TLS is configured by setting `secretRef.Name`.
+                        type: boolean
+                      secretRef:
+                        description: DEPRECATED please use security.certsSecretPrefix
+                          instead SecretRef points to a Secret object containing the
+                          certificates to use when enabling TLS.
+                        properties:
+                          prefix:
+                            description: DEPRECATED please use security.certsSecretPrefix
+                              instead
+                            type: string
+                        required:
+                        - prefix
+                        type: object
+                    type: object
+                type: object
+              service:
+                description: DEPRECATED please use `spec.statefulSet.spec.serviceName`
+                  to provide a custom service name. this is an optional service, it
+                  will get the name "<rsName>-service" in case not provided
+                type: string
+              shard:
+                properties:
+                  additionalMongodConfig:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  agent:
+                    properties:
+                      startupOptions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              shardCount:
+                type: integer
+              shardPodSpec:
+                properties:
+                  persistence:
+                    properties:
+                      multiple:
+                        properties:
+                          data:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          journal:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                          logs:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                      single:
+                        properties:
+                          labelSelector:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          storage:
+                            type: string
+                          storageClass:
+                            type: string
+                        type: object
+                    type: object
+                  podTemplate:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              statefulSet:
+                description: StatefulSetConfiguration holds the optional custom StatefulSet
+                  that should be merged into the operator created one.
+                properties:
+                  spec:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - spec
+                type: object
+              type:
+                enum:
+                - Standalone
+                - ReplicaSet
+                - ShardedCluster
+                type: string
+              version:
+                pattern: ^[0-9]+.[0-9]+.[0-9]+(-.+)?$|^$
+                type: string
+            required:
+            - credentials
+            - type
+            - version
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            properties:
+              backup:
+                properties:
+                  statusName:
+                    type: string
+                required:
+                - statusName
+                type: object
+              configServerCount:
+                type: integer
+              lastTransition:
+                type: string
+              link:
+                type: string
+              members:
+                type: integer
+              message:
+                type: string
+              mongodsPerShardCount:
+                type: integer
+              mongosCount:
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+              resourcesNotReady:
+                items:
+                  description: ResourceNotReady describes the dependent resource which
+                    is not ready yet
+                  properties:
+                    errors:
+                      items:
+                        properties:
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                        type: object
+                      type: array
+                    kind:
+                      description: ResourceKind specifies a kind of a Kubernetes resource.
+                        Used in status of a Custom Resource
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              shardCount:
+                type: integer
+              version:
+                type: string
+              warnings:
+                items:
+                  type: string
+                type: array
+            required:
+            - phase
+            - version
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_mongodbmulti.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_mongodbmulti.yaml
@@ -1,0 +1,526 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: mongodbmulti.mongodb.com
+spec:
+  group: mongodb.com
+  names:
+    kind: MongoDBMulti
+    listKind: MongoDBMultiList
+    plural: mongodbmulti
+    shortNames:
+    - mdbm
+    singular: mongodbmulti
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: The time since the MongoDBMulti resource was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              additionalMongodConfig:
+                description: 'AdditionalMongodConfig is additional configuration that
+                  can be passed to each data-bearing mongod at runtime. Uses the same
+                  structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              agent:
+                properties:
+                  startupOptions:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              backup:
+                description: Backup contains configuration options for configuring
+                  backup for this MongoDB resource
+                properties:
+                  autoTerminateOnDeletion:
+                    description: AutoTerminateOnDeletion indicates if the Operator
+                      should stop and terminate the Backup before the cleanup, when
+                      the MongoDB CR is deleted
+                    type: boolean
+                  mode:
+                    enum:
+                    - enabled
+                    - disabled
+                    - terminated
+                    type: string
+                type: object
+              cloudManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
+              clusterDomain:
+                format: hostname
+                type: string
+              clusterSpecList:
+                description: ClusterSpecList holds a list with a clusterSpec corresponding
+                  to each cluster
+                properties:
+                  clusterSpecs:
+                    items:
+                      description: ClusterSpecItem is the mongodb multi-cluster spec
+                        that is specific to a particular Kubernetes cluster, this
+                        maps to the statefulset created in each cluster
+                      properties:
+                        clusterName:
+                          description: ClusterName is name of the cluster where the
+                            MongoDB Statefulset will be scheduled, the name should
+                            have a one on one mapping with the service-account created
+                            in the central cluster to talk to the workload clusters.
+                          type: string
+                        exposedExternally:
+                          description: ExposedExternally determines whether a NodePort
+                            service should be created for the resource
+                          type: boolean
+                        members:
+                          description: Amount of members for this MongoDB Replica
+                            Set
+                          type: integer
+                        service:
+                          description: this is an optional service, it will get the
+                            name "<rsName>-service" in case not provided
+                          type: string
+                        statefulSet:
+                          description: StatefulSetConfiguration holds the optional
+                            custom StatefulSet that should be merged into the operator
+                            created one.
+                          properties:
+                            spec:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              connectivity:
+                properties:
+                  replicaSetHorizons:
+                    items:
+                      additionalProperties:
+                        type: string
+                      description: 'MongoDBHorizonConfig holds a map of horizon names
+                        to the node addresses, e.g. {   "internal": "my-rs-2.my-internal-domain.com:31843",   "external":
+                        "my-rs-2.my-external-domain.com:21467" } The key of each item
+                        in the map is an arbitrary, user-chosen string that represents
+                        the name of the horizon. The value of the item is the host
+                        and, optionally, the port that this mongod node will be connected
+                        to from.'
+                      type: object
+                    type: array
+                type: object
+              credentials:
+                description: Name of the Secret holding credentials information
+                type: string
+              duplicateServiceObjects:
+                description: 'In few service mesh options for ex: Istio, by default
+                  we would need to duplicate the service objects created per pod in
+                  all the clusters to enable DNS resolution. Users can however configure
+                  their ServiceMesh with DNS proxy(https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/)
+                  enabled in which case the operator doesn''t need to create the service
+                  objects per cluster. This options tells the operator whether it
+                  should create the service objects in all the clusters or not. By
+                  default, if not specified the operator would create the duplicate
+                  svc objects.'
+                type: boolean
+              featureCompatibilityVersion:
+                type: string
+              logLevel:
+                enum:
+                - DEBUG
+                - INFO
+                - WARN
+                - ERROR
+                - FATAL
+                type: string
+              opsManager:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
+              persistent:
+                type: boolean
+              security:
+                properties:
+                  authentication:
+                    description: Authentication holds various authentication related
+                      settings that affect this MongoDB resource.
+                    properties:
+                      agents:
+                        description: Agents contains authentication configuration
+                          properties for the agents
+                        properties:
+                          automationLdapGroupDN:
+                            type: string
+                          automationPasswordSecretRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          automationUserName:
+                            type: string
+                          clientCertificateSecretRef:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          mode:
+                            description: Mode is the desired Authentication mode that
+                              the agents will use
+                            type: string
+                        required:
+                        - mode
+                        type: object
+                      enabled:
+                        type: boolean
+                      ignoreUnknownUsers:
+                        description: IgnoreUnknownUsers maps to the inverse of auth.authoritativeSet
+                        type: boolean
+                      internalCluster:
+                        type: string
+                      ldap:
+                        description: LDAP Configuration
+                        properties:
+                          authzQueryTemplate:
+                            type: string
+                          bindQueryPasswordSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          bindQueryUser:
+                            type: string
+                          caConfigMapRef:
+                            description: Allows to point at a ConfigMap/key with a
+                              CA file to mount on the Pod
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          servers:
+                            items:
+                              type: string
+                            type: array
+                          timeoutMS:
+                            type: integer
+                          transportSecurity:
+                            enum:
+                            - tls
+                            - none
+                            type: string
+                          userCacheInvalidationInterval:
+                            type: integer
+                          userToDNMapping:
+                            type: string
+                          validateLDAPServerConfig:
+                            type: boolean
+                        type: object
+                      modes:
+                        items:
+                          type: string
+                        type: array
+                      requireClientTLSAuthentication:
+                        description: Clients should present valid TLS certificates
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  certsSecretPrefix:
+                    type: string
+                  roles:
+                    items:
+                      properties:
+                        authenticationRestrictions:
+                          items:
+                            properties:
+                              clientSource:
+                                items:
+                                  type: string
+                                type: array
+                              serverAddress:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          type: array
+                        db:
+                          type: string
+                        privileges:
+                          items:
+                            properties:
+                              actions:
+                                items:
+                                  type: string
+                                type: array
+                              resource:
+                                properties:
+                                  cluster:
+                                    type: boolean
+                                  collection:
+                                    type: string
+                                  db:
+                                    type: string
+                                type: object
+                            required:
+                            - actions
+                            - resource
+                            type: object
+                          type: array
+                        role:
+                          type: string
+                        roles:
+                          items:
+                            properties:
+                              db:
+                                type: string
+                              role:
+                                type: string
+                            required:
+                            - db
+                            - role
+                            type: object
+                          type: array
+                      required:
+                      - db
+                      - role
+                      type: object
+                    type: array
+                  tls:
+                    properties:
+                      additionalCertificateDomains:
+                        items:
+                          type: string
+                        type: array
+                      ca:
+                        description: CA corresponds to a ConfigMap containing an entry
+                          for the CA certificate (ca.pem) used to validate the certificates
+                          created already.
+                        type: string
+                      enabled:
+                        description: DEPRECATED please enable TLS by setting `security.certsSecretPrefix`
+                          or `security.tls.secretRef.prefix`. Enables TLS for this
+                          resource. This will make the operator try to mount a Secret
+                          with a defined name (<resource-name>-cert). This is only
+                          used when enabling TLS on a MongoDB resource, and not on
+                          the AppDB, where TLS is configured by setting `secretRef.Name`.
+                        type: boolean
+                      secretRef:
+                        description: DEPRECATED please use security.certsSecretPrefix
+                          instead SecretRef points to a Secret object containing the
+                          certificates to use when enabling TLS.
+                        properties:
+                          prefix:
+                            description: DEPRECATED please use security.certsSecretPrefix
+                              instead
+                            type: string
+                        required:
+                        - prefix
+                        type: object
+                    type: object
+                type: object
+              type:
+                enum:
+                - ReplicaSet
+                type: string
+              version:
+                pattern: ^[0-9]+.[0-9]+.[0-9]+(-.+)?$|^$
+                type: string
+            required:
+            - credentials
+            - type
+            - version
+            type: object
+          status:
+            properties:
+              backup:
+                properties:
+                  statusName:
+                    type: string
+                required:
+                - statusName
+                type: object
+              clusterStatusList:
+                description: ClusterStatusList holds a list of clusterStatuses corresponding
+                  to each cluster
+                properties:
+                  clusterStatuses:
+                    items:
+                      description: ClusterStatusItem is the mongodb multi-cluster
+                        spec that is specific to a particular Kubernetes cluster,
+                        this maps to the statefulset created in each cluster
+                      properties:
+                        clusterName:
+                          description: ClusterName is name of the cluster where the
+                            MongoDB Statefulset will be scheduled, the name should
+                            have a one on one mapping with the service-account created
+                            in the central cluster to talk to the workload clusters.
+                          type: string
+                        lastTransition:
+                          type: string
+                        members:
+                          type: integer
+                        message:
+                          type: string
+                        observedGeneration:
+                          format: int64
+                          type: integer
+                        phase:
+                          type: string
+                        resourcesNotReady:
+                          items:
+                            description: ResourceNotReady describes the dependent
+                              resource which is not ready yet
+                            properties:
+                              errors:
+                                items:
+                                  properties:
+                                    message:
+                                      type: string
+                                    reason:
+                                      type: string
+                                  type: object
+                                type: array
+                              kind:
+                                description: ResourceKind specifies a kind of a Kubernetes
+                                  resource. Used in status of a Custom Resource
+                                type: string
+                              message:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          type: array
+                        warnings:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - phase
+                      type: object
+                    type: array
+                type: object
+              lastTransition:
+                type: string
+              link:
+                type: string
+              message:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+              resourcesNotReady:
+                items:
+                  description: ResourceNotReady describes the dependent resource which
+                    is not ready yet
+                  properties:
+                    errors:
+                      items:
+                        properties:
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                        type: object
+                      type: array
+                    kind:
+                      description: ResourceKind specifies a kind of a Kubernetes resource.
+                        Used in status of a Custom Resource
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              version:
+                type: string
+              warnings:
+                items:
+                  type: string
+                type: array
+            required:
+            - phase
+            - version
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_mongodbusers.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_mongodbusers.yaml
@@ -1,0 +1,166 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: mongodbusers.mongodb.com
+spec:
+  group: mongodb.com
+  names:
+    kind: MongoDBUser
+    listKind: MongoDBUserList
+    plural: mongodbusers
+    shortNames:
+    - mdbu
+    singular: mongodbuser
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current state of the MongoDB User.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: The time since the MongoDB User resource was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              connectionStringSecretName:
+                type: string
+              db:
+                type: string
+              mongodbResourceRef:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                type: object
+              passwordSecretKeyRef:
+                description: 'SecretKeyRef is a reference to a value in a given secret
+                  in the same namespace. Based on: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#secretkeyselector-v1-core'
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              roles:
+                items:
+                  properties:
+                    db:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - db
+                  - name
+                  type: object
+                type: array
+              username:
+                type: string
+            required:
+            - db
+            - username
+            type: object
+          status:
+            properties:
+              db:
+                type: string
+              lastTransition:
+                type: string
+              message:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+              project:
+                type: string
+              resourcesNotReady:
+                items:
+                  description: ResourceNotReady describes the dependent resource which
+                    is not ready yet
+                  properties:
+                    errors:
+                      items:
+                        properties:
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                        type: object
+                      type: array
+                    kind:
+                      description: ResourceKind specifies a kind of a Kubernetes resource.
+                        Used in status of a Custom Resource
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              roles:
+                items:
+                  properties:
+                    db:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - db
+                  - name
+                  type: object
+                type: array
+              username:
+                type: string
+              warnings:
+                items:
+                  type: string
+                type: array
+            required:
+            - db
+            - phase
+            - project
+            - username
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_opsmanagers.yaml
+++ b/operators/mongodb-enterprise/1.17.2/manifests/mongodb.com_opsmanagers.yaml
@@ -1,0 +1,1014 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: opsmanagers.mongodb.com
+spec:
+  group: mongodb.com
+  names:
+    kind: MongoDBOpsManager
+    listKind: MongoDBOpsManagerList
+    plural: opsmanagers
+    shortNames:
+    - om
+    singular: opsmanager
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The number of replicas of MongoDBOpsManager.
+      jsonPath: .spec.replicas
+      name: Replicas
+      type: integer
+    - description: The version of MongoDBOpsManager.
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: The current state of the MongoDBOpsManager.
+      jsonPath: .status.opsManager.phase
+      name: State (OpsManager)
+      type: string
+    - description: The current state of the MongoDBOpsManager Application Database.
+      jsonPath: .status.applicationDatabase.phase
+      name: State (AppDB)
+      type: string
+    - description: The current state of the MongoDBOpsManager Backup Daemon.
+      jsonPath: .status.backup.phase
+      name: State (Backup)
+      type: string
+    - description: The time since the MongoDBOpsManager resource was created.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Warnings.
+      jsonPath: .status.warnings
+      name: Warnings
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              adminCredentials:
+                description: 'AdminSecret is the secret for the first admin user to
+                  create has the fields: "Username", "Password", "FirstName", "LastName"'
+                type: string
+              applicationDatabase:
+                properties:
+                  additionalMongodConfig:
+                    description: 'AdditionalMongodConfig is additional configuration
+                      that can be passed to each data-bearing mongod at runtime. Uses
+                      the same structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  agent:
+                    description: specify startup flags for the AutomationAgent and
+                      MonitoringAgent
+                    properties:
+                      startupOptions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  automationConfig:
+                    description: AutomationConfigOverride holds any fields that will
+                      be merged on top of the Automation Config that the operator
+                      creates for the AppDB. Currently only the process.disabled field
+                      is recognized.
+                    properties:
+                      processes:
+                        items:
+                          description: OverrideProcess contains fields that we can
+                            override on the AutomationConfig processes.
+                          properties:
+                            disabled:
+                              type: boolean
+                            name:
+                              type: string
+                          required:
+                          - disabled
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - processes
+                    type: object
+                  cloudManager:
+                    properties:
+                      configMapRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                    type: object
+                  clusterDomain:
+                    type: string
+                  connectivity:
+                    properties:
+                      replicaSetHorizons:
+                        items:
+                          additionalProperties:
+                            type: string
+                          description: 'MongoDBHorizonConfig holds a map of horizon
+                            names to the node addresses, e.g. {   "internal": "my-rs-2.my-internal-domain.com:31843",   "external":
+                            "my-rs-2.my-external-domain.com:21467" } The key of each
+                            item in the map is an arbitrary, user-chosen string that
+                            represents the name of the horizon. The value of the item
+                            is the host and, optionally, the port that this mongod
+                            node will be connected to from.'
+                          type: object
+                        type: array
+                    type: object
+                  credentials:
+                    description: Name of the Secret holding credentials information
+                    type: string
+                  featureCompatibilityVersion:
+                    type: string
+                  logLevel:
+                    enum:
+                    - DEBUG
+                    - INFO
+                    - WARN
+                    - ERROR
+                    - FATAL
+                    type: string
+                  members:
+                    description: Amount of members for this MongoDB Replica Set
+                    maximum: 50
+                    minimum: 3
+                    type: integer
+                  monitoringAgent:
+                    description: specify startup flags for just the MonitoringAgent.
+                      These take precedence over the flags set in AutomationAgent
+                    properties:
+                      startupOptions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  opsManager:
+                    properties:
+                      configMapRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                    type: object
+                  passwordSecretKeyRef:
+                    description: PasswordSecretKeyRef contains a reference to the
+                      secret which contains the password for the mongodb-ops-manager
+                      SCRAM-SHA user
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  podSpec:
+                    properties:
+                      persistence:
+                        properties:
+                          multiple:
+                            properties:
+                              data:
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  storage:
+                                    type: string
+                                  storageClass:
+                                    type: string
+                                type: object
+                              journal:
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  storage:
+                                    type: string
+                                  storageClass:
+                                    type: string
+                                type: object
+                              logs:
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  storage:
+                                    type: string
+                                  storageClass:
+                                    type: string
+                                type: object
+                            type: object
+                          single:
+                            properties:
+                              labelSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storage:
+                                type: string
+                              storageClass:
+                                type: string
+                            type: object
+                        type: object
+                      podTemplate:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  project:
+                    description: 'Deprecated: This has been replaced by the PrivateCloudConfig
+                      which should be used instead'
+                    type: string
+                  prometheus:
+                    description: Enables Prometheus integration on the AppDB.
+                    properties:
+                      metricsPath:
+                        description: Indicates path to the metrics endpoint.
+                        pattern: ^\/[a-z0-9]+$
+                        type: string
+                      passwordSecretRef:
+                        description: Name of a Secret containing a HTTP Basic Auth
+                          Password.
+                        properties:
+                          key:
+                            description: Key is the key in the secret storing this
+                              password. Defaults to "password"
+                            type: string
+                          name:
+                            description: Name is the name of the secret storing this
+                              user's password
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      port:
+                        description: Port where metrics endpoint will bind to. Defaults
+                          to 9216.
+                        type: integer
+                      tlsSecretKeyRef:
+                        description: Name of a Secret (type kubernetes.io/tls) holding
+                          the certificates to use in the Prometheus endpoint.
+                        properties:
+                          key:
+                            description: Key is the key in the secret storing this
+                              password. Defaults to "password"
+                            type: string
+                          name:
+                            description: Name is the name of the secret storing this
+                              user's password
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      username:
+                        description: HTTP Basic Auth Username for metrics endpoint.
+                        type: string
+                    required:
+                    - passwordSecretRef
+                    - username
+                    type: object
+                  security:
+                    properties:
+                      authentication:
+                        description: Authentication holds various authentication related
+                          settings that affect this MongoDB resource.
+                        properties:
+                          agents:
+                            description: Agents contains authentication configuration
+                              properties for the agents
+                            properties:
+                              automationLdapGroupDN:
+                                type: string
+                              automationPasswordSecretRef:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              automationUserName:
+                                type: string
+                              clientCertificateSecretRef:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              mode:
+                                description: Mode is the desired Authentication mode
+                                  that the agents will use
+                                type: string
+                            required:
+                            - mode
+                            type: object
+                          enabled:
+                            type: boolean
+                          ignoreUnknownUsers:
+                            description: IgnoreUnknownUsers maps to the inverse of
+                              auth.authoritativeSet
+                            type: boolean
+                          internalCluster:
+                            type: string
+                          ldap:
+                            description: LDAP Configuration
+                            properties:
+                              authzQueryTemplate:
+                                type: string
+                              bindQueryPasswordSecretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              bindQueryUser:
+                                type: string
+                              caConfigMapRef:
+                                description: Allows to point at a ConfigMap/key with
+                                  a CA file to mount on the Pod
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              servers:
+                                items:
+                                  type: string
+                                type: array
+                              timeoutMS:
+                                type: integer
+                              transportSecurity:
+                                enum:
+                                - tls
+                                - none
+                                type: string
+                              userCacheInvalidationInterval:
+                                type: integer
+                              userToDNMapping:
+                                type: string
+                              validateLDAPServerConfig:
+                                type: boolean
+                            type: object
+                          modes:
+                            items:
+                              type: string
+                            type: array
+                          requireClientTLSAuthentication:
+                            description: Clients should present valid TLS certificates
+                            type: boolean
+                        required:
+                        - enabled
+                        type: object
+                      certsSecretPrefix:
+                        type: string
+                      roles:
+                        items:
+                          properties:
+                            authenticationRestrictions:
+                              items:
+                                properties:
+                                  clientSource:
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverAddress:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            db:
+                              type: string
+                            privileges:
+                              items:
+                                properties:
+                                  actions:
+                                    items:
+                                      type: string
+                                    type: array
+                                  resource:
+                                    properties:
+                                      cluster:
+                                        type: boolean
+                                      collection:
+                                        type: string
+                                      db:
+                                        type: string
+                                    type: object
+                                required:
+                                - actions
+                                - resource
+                                type: object
+                              type: array
+                            role:
+                              type: string
+                            roles:
+                              items:
+                                properties:
+                                  db:
+                                    type: string
+                                  role:
+                                    type: string
+                                required:
+                                - db
+                                - role
+                                type: object
+                              type: array
+                          required:
+                          - db
+                          - role
+                          type: object
+                        type: array
+                      tls:
+                        properties:
+                          additionalCertificateDomains:
+                            items:
+                              type: string
+                            type: array
+                          ca:
+                            description: CA corresponds to a ConfigMap containing
+                              an entry for the CA certificate (ca.pem) used to validate
+                              the certificates created already.
+                            type: string
+                          enabled:
+                            description: DEPRECATED please enable TLS by setting `security.certsSecretPrefix`
+                              or `security.tls.secretRef.prefix`. Enables TLS for
+                              this resource. This will make the operator try to mount
+                              a Secret with a defined name (<resource-name>-cert).
+                              This is only used when enabling TLS on a MongoDB resource,
+                              and not on the AppDB, where TLS is configured by setting
+                              `secretRef.Name`.
+                            type: boolean
+                          secretRef:
+                            description: DEPRECATED please use security.certsSecretPrefix
+                              instead SecretRef points to a Secret object containing
+                              the certificates to use when enabling TLS.
+                            properties:
+                              prefix:
+                                description: DEPRECATED please use security.certsSecretPrefix
+                                  instead
+                                type: string
+                            required:
+                            - prefix
+                            type: object
+                        type: object
+                    type: object
+                  service:
+                    description: this is an optional service, it will get the name
+                      "<rsName>-service" in case not provided
+                    type: string
+                  type:
+                    enum:
+                    - Standalone
+                    - ReplicaSet
+                    - ShardedCluster
+                    type: string
+                  version:
+                    pattern: ^[0-9]+.[0-9]+.[0-9]+(-.+)?$|^$
+                    type: string
+                required:
+                - version
+                type: object
+              backup:
+                description: Backup
+                properties:
+                  blockStores:
+                    items:
+                      description: DataStoreConfig is the description of the config
+                        used to reference to database. Reused by Oplog and Block stores
+                        Optionally references the user if the Mongodb is configured
+                        with authentication
+                      properties:
+                        mongodbResourceRef:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        mongodbUserRef:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        name:
+                          type: string
+                      required:
+                      - mongodbResourceRef
+                      - name
+                      type: object
+                    type: array
+                  enabled:
+                    description: Enabled indicates if Backups will be enabled for
+                      this Ops Manager.
+                    type: boolean
+                  externalServiceEnabled:
+                    type: boolean
+                  fileSystemStores:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  headDB:
+                    description: HeadDB specifies configuration options for the HeadDB
+                    properties:
+                      labelSelector:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      storage:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                  jvmParameters:
+                    items:
+                      type: string
+                    type: array
+                  members:
+                    description: Members indicate the number of backup daemon pods
+                      to create.
+                    minimum: 1
+                    type: integer
+                  opLogStores:
+                    description: OplogStoreConfigs describes the list of oplog store
+                      configs used for backup
+                    items:
+                      description: DataStoreConfig is the description of the config
+                        used to reference to database. Reused by Oplog and Block stores
+                        Optionally references the user if the Mongodb is configured
+                        with authentication
+                      properties:
+                        mongodbResourceRef:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        mongodbUserRef:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        name:
+                          type: string
+                      required:
+                      - mongodbResourceRef
+                      - name
+                      type: object
+                    type: array
+                  queryableBackupSecretRef:
+                    description: QueryableBackupSecretRef references the secret which
+                      contains the pem file which is used for queryable backup. This
+                      will be mounted into the Ops Manager pod.
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  s3OpLogStores:
+                    description: S3OplogStoreConfigs describes the list of s3 oplog
+                      store configs used for backup.
+                    items:
+                      properties:
+                        customCertificate:
+                          description: Set this to "true" when you have custom certificates
+                            for your S3 buckets
+                          type: boolean
+                        irsaEnabled:
+                          description: 'This is only set to "true" when user is running
+                            in EKS and is using AWS IRSA to configure S3 snapshot
+                            store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/'
+                          type: boolean
+                        mongodbResourceRef:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        mongodbUserRef:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        name:
+                          type: string
+                        pathStyleAccessEnabled:
+                          type: boolean
+                        s3BucketEndpoint:
+                          type: string
+                        s3BucketName:
+                          type: string
+                        s3RegionOverride:
+                          type: string
+                        s3SecretRef:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - name
+                      - pathStyleAccessEnabled
+                      - s3BucketEndpoint
+                      - s3BucketName
+                      - s3SecretRef
+                      type: object
+                    type: array
+                  s3Stores:
+                    items:
+                      properties:
+                        customCertificate:
+                          description: Set this to "true" when you have custom certificates
+                            for your S3 buckets
+                          type: boolean
+                        irsaEnabled:
+                          description: 'This is only set to "true" when user is running
+                            in EKS and is using AWS IRSA to configure S3 snapshot
+                            store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/'
+                          type: boolean
+                        mongodbResourceRef:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        mongodbUserRef:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        name:
+                          type: string
+                        pathStyleAccessEnabled:
+                          type: boolean
+                        s3BucketEndpoint:
+                          type: string
+                        s3BucketName:
+                          type: string
+                        s3RegionOverride:
+                          type: string
+                        s3SecretRef:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - name
+                      - pathStyleAccessEnabled
+                      - s3BucketEndpoint
+                      - s3BucketName
+                      - s3SecretRef
+                      type: object
+                    type: array
+                  statefulSet:
+                    description: StatefulSetConfiguration holds the optional custom
+                      StatefulSet that should be merged into the operator created
+                      one.
+                    properties:
+                      spec:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - spec
+                    type: object
+                required:
+                - enabled
+                type: object
+              clusterDomain:
+                format: hostname
+                type: string
+              clusterName:
+                description: 'Deprecated: This has been replaced by the ClusterDomain
+                  which should be used instead'
+                format: hostname
+                type: string
+              configuration:
+                additionalProperties:
+                  type: string
+                description: The configuration properties passed to Ops Manager/Backup
+                  Daemon
+                type: object
+              externalConnectivity:
+                description: MongoDBOpsManagerExternalConnectivity if sets allows
+                  for the creation of a Service for accessing this Ops Manager resource
+                  from outside the Kubernetes cluster.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations is a list of annotations to be directly
+                      passed to the Service object.
+                    type: object
+                  externalTrafficPolicy:
+                    description: ExternalTrafficPolicy mechanism to preserve the client
+                      source IP. Only supported on GCE and Google Kubernetes Engine.
+                    enum:
+                    - Cluster
+                    - Local
+                    type: string
+                  loadBalancerIP:
+                    description: LoadBalancerIP IP that will be assigned to this LoadBalancer.
+                    type: string
+                  port:
+                    description: Port in which this `Service` will listen to, this
+                      applies to `NodePort`.
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type of the `Service` to be created.
+                    enum:
+                    - LoadBalancer
+                    - NodePort
+                    type: string
+                required:
+                - type
+                type: object
+              jvmParameters:
+                description: Custom JVM parameters passed to the Ops Manager JVM
+                items:
+                  type: string
+                type: array
+              replicas:
+                minimum: 1
+                type: integer
+              security:
+                description: Configure HTTPS.
+                properties:
+                  certsSecretPrefix:
+                    type: string
+                  tls:
+                    properties:
+                      ca:
+                        type: string
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                type: object
+              statefulSet:
+                description: Configure custom StatefulSet configuration
+                properties:
+                  spec:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - spec
+                type: object
+              version:
+                type: string
+            required:
+            - applicationDatabase
+            - version
+            type: object
+          status:
+            properties:
+              applicationDatabase:
+                properties:
+                  backup:
+                    properties:
+                      statusName:
+                        type: string
+                    required:
+                    - statusName
+                    type: object
+                  configServerCount:
+                    type: integer
+                  lastTransition:
+                    type: string
+                  link:
+                    type: string
+                  members:
+                    type: integer
+                  message:
+                    type: string
+                  mongodsPerShardCount:
+                    type: integer
+                  mongosCount:
+                    type: integer
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  phase:
+                    type: string
+                  resourcesNotReady:
+                    items:
+                      description: ResourceNotReady describes the dependent resource
+                        which is not ready yet
+                      properties:
+                        errors:
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                            type: object
+                          type: array
+                        kind:
+                          description: ResourceKind specifies a kind of a Kubernetes
+                            resource. Used in status of a Custom Resource
+                          type: string
+                        message:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  shardCount:
+                    type: integer
+                  version:
+                    type: string
+                  warnings:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - phase
+                - version
+                type: object
+              backup:
+                properties:
+                  lastTransition:
+                    type: string
+                  message:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  phase:
+                    type: string
+                  resourcesNotReady:
+                    items:
+                      description: ResourceNotReady describes the dependent resource
+                        which is not ready yet
+                      properties:
+                        errors:
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                            type: object
+                          type: array
+                        kind:
+                          description: ResourceKind specifies a kind of a Kubernetes
+                            resource. Used in status of a Custom Resource
+                          type: string
+                        message:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  version:
+                    type: string
+                  warnings:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - phase
+                type: object
+              opsManager:
+                properties:
+                  lastTransition:
+                    type: string
+                  message:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  phase:
+                    type: string
+                  replicas:
+                    type: integer
+                  resourcesNotReady:
+                    items:
+                      description: ResourceNotReady describes the dependent resource
+                        which is not ready yet
+                      properties:
+                        errors:
+                          items:
+                            properties:
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                            type: object
+                          type: array
+                        kind:
+                          description: ResourceKind specifies a kind of a Kubernetes
+                            resource. Used in status of a Custom Resource
+                          type: string
+                        message:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  url:
+                    type: string
+                  version:
+                    type: string
+                  warnings:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - phase
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/mongodb-enterprise/1.17.2/metadata/annotations.yaml
+++ b/operators/mongodb-enterprise/1.17.2/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: mongodb-enterprise
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.23.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: "v4.6"

--- a/operators/mongodb-enterprise/1.17.2/tests/scorecard/config.yaml
+++ b/operators/mongodb-enterprise/1.17.2/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.12.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.12.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.12.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.12.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.12.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.12.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
This is an emergency fix release for MongoDB Enterprise Operator 1.7.1. Our previous version contained wrong pinned images. For more information see https://www.mongodb.com/docs/kubernetes-operator/master/release-notes/#k8s-op-full-1-17-series