### PR TITLE
operator redis-enterprise-operator-cert (v6.2.18-3)

### DIFF
--- a/operators/redis-enterprise-operator-cert/v6.2.18-3/manifests/redis-enterprise-operator-cert.clusterserviceversion.yaml
+++ b/operators/redis-enterprise-operator-cert/v6.2.18-3/manifests/redis-enterprise-operator-cert.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     categories: Database
-    containerImage: registry.connect.redhat.com/redislabs/redis-enterprise-operator:6.2.18-3
+    containerImage: registry.connect.redhat.com/redislabs/redis-enterprise-operator@sha256:afd2c3dd1e432c410af77202e9ce262fa69f4734357480c292db73f4608ec4ec
     alm-examples: |-
       [
         {
@@ -606,3 +606,7 @@ spec:
     image: registry.connect.redhat.com/redislabs/services-manager@sha256:1c20d9f1dc847db43aea55832caef6e497c1971d2dbcec4e8421092e469907e9
   - name: rs-image
     image: registry.connect.redhat.com/redislabs/redis-enterprise@sha256:396b19cde93ddd272b1e28b9fe52041c06ad06c89da8bbaf6840b9af11260518
+  - name: redis-enterprise-operator-afd2c3dd1e432c410af77202e9ce262fa69f4734357480c292db73f4608ec4ec-annotation
+    image: registry.connect.redhat.com/redislabs/redis-enterprise-operator@sha256:afd2c3dd1e432c410af77202e9ce262fa69f4734357480c292db73f4608ec4ec
+  - name: admission
+    image: registry.connect.redhat.com/redislabs/redis-enterprise-operator@sha256:afd2c3dd1e432c410af77202e9ce262fa69f4734357480c292db73f4608ec4ec


### PR DESCRIPTION
**New operator bundle**

Name: **redis-enterprise-operator-cert**
Version: **v6.2.18-3**

Certification project: 5f7c891807b2d26af5043280

Test result URL: https://catalog.redhat.com/api/containers/v1/projects/certification/test-results/id/636d57253aa0eccdf13af4fd
Test logs URL: https://catalog.redhat.com/api/containers/v1/projects/certification/artifacts/id/636d57233aa0eccdf13af4fb
