### PR TITLE
operator couchdb-operator-certified (2.2.3)

### DIFF
--- a/operators/couchdb-operator-certified/2.2.3/manifests/backups.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/backups.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,1315 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: backups.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+    - bu
+    singular: backup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.formation_type
+      name: Type
+      type: string
+    - jsonPath: .status
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'Backup represents a specific backup of a CDCP-managed system.
+          It is a noun, not a verb: more akin to a row in a database table than a
+          directive to take a backup.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'BackupSpec contains metadata about a Backup. TODO: Document
+              individual fields, after a review of the backup subsystem.'
+            properties:
+              cos_id:
+                type: string
+              formation_id:
+                pattern: ^[a-z0-9-]*$
+                type: string
+              formation_resource_configs:
+                additionalProperties:
+                  description: ResourceConfig specifies and configures a workload
+                    - usually a set of Pods - under the management of a Formation.
+                    ResourceConfigs typically map to a single Kubernetes workload
+                    object, such as StatefulSet or Deployment.
+                  properties:
+                    affinity:
+                      description: If specified, the scheduling constraints for Pods
+                        under the management of this ResourceConfig.
+                      nullable: true
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is alpha-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces. This field
+                                      is alpha-level and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is alpha-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces. This field
+                                      is alpha-level and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    cpu:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: How much CPU - as in the PodSpec, measured in millicpus
+                        - should be allocated to Pods under management of this ResourceConfig.
+                        This allocation is a reservation for scheduling, not a limit.
+                      nullable: true
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    dedicated:
+                      description: Whether or not this resource config should be deployed
+                        on "dedicated" resources. The implementation of "dedicated"
+                        resources is undefined by CDCP and may vary environment-to-environment.
+                      nullable: true
+                      type: boolean
+                    disk:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: How much disk - measured in bytes - should be allocated
+                        to the `/data` volume mounted in containers under management
+                        of this ResourceConfig.
+                      nullable: true
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    env:
+                      additionalProperties:
+                        type: string
+                      description: A free-form map of configuration values for workloads
+                        under management of this ResourceConfig. These values are
+                        typically injected in to a ConfigMap associated with the ResourceConfig,
+                        but a database implementation is free to do otherwise. These
+                        values are generally *not* injected in to the container's
+                        runtime environment.
+                      nullable: true
+                      type: object
+                    images:
+                      additionalProperties:
+                        type: string
+                      description: A free-form map of fully-qualified image references
+                        for use by this ResourceConfig. This list is deliberately
+                        unstructured; database implementors may use whatever keys
+                        are appropriate to their application.
+                      type: object
+                    initialized:
+                      description: Whether or not the workload managed by this ResourceConfig
+                        has been initialized, i.e., if the Pods under management have
+                        booted and successfully been marked ready at least once. This
+                        is not guaranteed to happen in a timely fashion.
+                      nullable: true
+                      type: boolean
+                    memory:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: How much memory - as in the PodSpec, measured in
+                        bytes - should be allocated to Pods under management of this
+                        ResourceConfig.
+                      nullable: true
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    replicas:
+                      description: The number of "replicas" - typically Pods - that
+                        will be created under this ResourceConfig.
+                      format: int32
+                      nullable: true
+                      type: integer
+                    resource_scaling_policy:
+                      description: If specified, configures the resource scaling policy
+                        for Pods under management of this ResourceConfig. If left
+                        unset, Memory and CPU values will be ignored. Disk resources
+                        are not managed under this policy; their scalability is left
+                        to their StorageClass.
+                      enum:
+                      - dynamic
+                      - static
+                      - ""
+                      nullable: true
+                      type: string
+                    scheduler_name:
+                      description: If specified, the Kubernetes scheduler for Pods
+                        under management of this ResourceConfig.
+                      type: string
+                    secrets:
+                      additionalProperties:
+                        type: string
+                      description: A free-form map of "secret" configuration values
+                        for workloads under management of this ResourceConfig. These
+                        values are obscured by the controller after resources are
+                        initialized.
+                      nullable: true
+                      type: object
+                    storage:
+                      description: Configuration for storage volumes. This is *exclusive*
+                        of the special /conf emptydir. If /conf is specified here,
+                        it will be ignored.
+                      items:
+                        description: StorageConfig defines the structure of configurable
+                          storage to be attached to a CDCP-managed workload. Note
+                          that StorageConfig is for _configurable_ storage - e.g.,
+                          if a volume needs to be parameterized by an existing claim,
+                          or a specialized storage class based on the deployment environment.
+                          Non-configurable storage - such as /conf empty dirs - should
+                          not be represented by StorageConfigs.
+                        properties:
+                          claim_name:
+                            type: string
+                          mount_path:
+                            type: string
+                          name:
+                            type: string
+                          spec:
+                            description: PersistentVolumeClaimSpec describes the common
+                              attributes of storage devices and allows a Source for
+                              provider-specific attributes
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                description: 'This field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim) * An existing
+                                  custom resource that implements data population
+                                  (Alpha) In order to use custom resource types that
+                                  implement data population, the AnyVolumeDataSource
+                                  feature gate must be enabled. If the provisioner
+                                  or an external controller can support the specified
+                                  data source, it will create a new volume based on
+                                  the contents of the specified data source.'
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                description: 'Resources represents the minimum resources
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                              selector:
+                                description: A label query over volumes to consider
+                                  for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by
+                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim. Value of Filesystem is
+                                  implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                          storage_config_type:
+                            description: StorageConfigType manages the CDCP's interpretation
+                              of a StorageConfig; each of the types has near-identical
+                              specifications but slightly different behavior.
+                            enum:
+                            - template
+                            - existing
+                            - create
+                            - ""
+                            type: string
+                        type: object
+                      type: array
+                    storage_class:
+                      description: The name of the storage class that should be used
+                        to back the `/data` volume mounted in containers under management
+                        of this ResourceConfig. An empty string indicates a non-persistent
+                        EmptyDir storage class.
+                      type: string
+                    toleration:
+                      description: If specified, the tolerations for Pods under the
+                        management of this ResourceConfig.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    version:
+                      description: The version of this ResourceConfig. This is not
+                        necessarily identical to the version of the Formation; for
+                        example, a PostgreSQL formation at version 10.4 could include
+                        an etcd ResourceConfig at version 3.3.9.
+                      type: string
+                  type: object
+                type: object
+              formation_type:
+                type: string
+              formation_version:
+                type: string
+              restore_data:
+                type: string
+              secret_ref:
+                description: Stores a snapshot of the ResourceConfigs for the Formation
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              size_in_bytes:
+                format: int64
+                type: integer
+              type:
+                description: The Type of the Backup indicates the mechanism by which
+                  the backup was triggered. Typically "scheduled" or "ondemand".
+                type: string
+            type: object
+          status:
+            description: "ResourceState represents the state of various CDCP resources,
+              such as Formations and Recipes. It is used to drive the state machines
+              in recipe-controller, bucket-controller (and perhaps others?) as well
+              as by APIOperations to coordinate Recipe activity. Note that formation-controller
+              uses FormationState, not ResourceState. See RecipeStatus for more details
+              on the use of ResourceState by recipe-controller. \n The awkwardness
+              here is due to APIOperations' need for a consistent type across resources
+              to allow flexibility to Recipe authors. If and when APIOperations are
+              deprecated, the scope of ResourceState will be reduced. \n ResourceState
+              should be considered deprecated and is not be used in any newly developed
+              packages."
+            enum:
+            - new
+            - prepared
+            - running
+            - watching
+            - skipped
+            - failing
+            - failed
+            - completed
+            - OK
+            - Error
+            - ""
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/manifests/buckets.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/buckets.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: buckets.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: Bucket
+    listKind: BucketList
+    plural: buckets
+    singular: bucket
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Bucket models a S3 compatible bucket
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec defines the data-format required for a bucket
+            properties:
+              backup_encryption_key_crn:
+                description: If specified, the CRN of the customer-owned KP key to
+                  be used to encrypt the COS bucket
+                type: string
+              cos_bucket_name:
+                description: If specified, the name of the bucket used in COS (defaults
+                  to the name of the bucket resource)
+                type: string
+              secret:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              secret_key_ref:
+                type: string
+            type: object
+          status:
+            properties:
+              state:
+                description: "ResourceState represents the state of various CDCP resources,
+                  such as Formations and Recipes. It is used to drive the state machines
+                  in recipe-controller, bucket-controller (and perhaps others?) as
+                  well as by APIOperations to coordinate Recipe activity. Note that
+                  formation-controller uses FormationState, not ResourceState. See
+                  RecipeStatus for more details on the use of ResourceState by recipe-controller.
+                  \n The awkwardness here is due to APIOperations' need for a consistent
+                  type across resources to allow flexibility to Recipe authors. If
+                  and when APIOperations are deprecated, the scope of ResourceState
+                  will be reduced. \n ResourceState should be considered deprecated
+                  and is not be used in any newly developed packages."
+                enum:
+                - new
+                - prepared
+                - running
+                - watching
+                - skipped
+                - failing
+                - failed
+                - completed
+                - OK
+                - Error
+                - ""
+                type: string
+              usage:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/manifests/couchdb-operator-certified.clusterserviceversion.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/couchdb-operator-certified.clusterserviceversion.yaml
@@ -1,0 +1,432 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/os.linux: supported
+  annotations:
+    alm-examples: |-
+      [
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "CouchDBCluster",
+            "metadata": {
+                "name": "example-couchdbcluster"
+            },
+            "spec": {
+                "cpu": "1",
+                "disk": "1Gi",
+                "storageClass": "",
+                "environment": {
+                    "adminPassword": "changeme",
+                    "search": true
+                },
+                "memory": "1Gi",
+                "size": 3
+            }
+        },
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "FormationLock",
+            "metadata": {
+                "name": "example-formationlock"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "Recipe",
+            "metadata": {
+                "name": "example-recipe"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "RecipeTemplate",
+            "metadata": {
+                "name": "example-recipetemplate"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "Backup",
+            "metadata": {
+                "name": "example-backup"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "Bucket",
+            "metadata": {
+                "name": "example-bucket"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "couchdb.databases.cloud.ibm.com/v1",
+            "kind": "Formation",
+            "metadata": {
+                "name": "example-formation"
+            },
+            "spec": {}
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Database
+    certified: "true"
+    containerImage: registry.connect.redhat.com/ibm/couchdb-operator@sha256:968c56be05781854ccc6068cc2f2f9f81dc7a34219210791810c2138d40a1cc3
+    createdAt: "2022-11-14T09:42:47Z"
+    description: |
+      Apache CouchDB is a highly available NOSQL database for web and mobile applications
+    olm.skipRange: "<2.2.3"
+    support: IBM
+    operators.operatorframework.io/internal-objects: '["backups.couchdb.databases.cloud.ibm.com","buckets.couchdb.databases.cloud.ibm.com","formationlocks.couchdb.databases.cloud.ibm.com","formations.couchdb.databases.cloud.ibm.com","recipes.couchdb.databases.cloud.ibm.com","recipetemplates.couchdb.databases.cloud.ibm.com"]'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+  name: couchdb-operator.v2.2.3
+  namespace: placeholder
+spec:
+  displayName: Operator for Apache CouchDB
+  apiservicedefinitions: {}
+  minKubeVersion: 1.14.0
+  customresourcedefinitions:
+    owned:
+    - description: |
+            Represents a deployment of an Apache CouchDB cluster
+
+            License
+            By installing this product you accept the license terms http://www.apache.org/licenses/LICENSE-2.0
+      displayName: CouchDB Cluster
+      kind: CouchDBCluster
+      name: couchdbclusters.couchdb.databases.cloud.ibm.com
+      resources:
+      - kind: Formation
+        name: formations.couchdb.databases.cloud.ibm.com
+        version: v1
+      specDescriptors:
+      - description: Number of CouchDB nodes in the cluster
+        displayName: Cluster size
+        path: size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Storage class to use
+        displayName: Storage class
+        path: storageClass
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Admin Password of CouchDB
+        displayName: Admin Password
+        path: environment.adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: Alters defaults for use in a development setting, note this will disable TLS
+        displayName: Development Mode
+        path: devMode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Specify the resouce requirements and limits for the database container
+        displayName: DB Resource Requirements (Optional)
+        path: resources.db
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: Specify the resouce requirements and limits for the search container
+        displayName: Search Resource Requirements (Optional)
+        path: resources.search
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: Specify the resouce requirements and limits for the management container
+        displayName: Management Resource Requirements (Optional)
+        path: resources.mgmt
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      version: v1
+    - description: Internal representation of a CouchDB Backup. Used internally by
+        the Operator for Apache CouchDB.
+      displayName: (Internal) CouchDB Backup
+      kind: Backup
+      name: backups.couchdb.databases.cloud.ibm.com
+      version: v1
+    - description: Internal representation of a COS Bucket. Used internally by the
+        Operator for Apache CouchDB.
+      displayName: (Internal) CouchDB COS Bucket
+      kind: Bucket
+      name: buckets.couchdb.databases.cloud.ibm.com
+      version: v1
+    - description: Internal representation of a CouchDB Cluster. Used internally by
+        the Operator for Apache CouchDB.
+      displayName: (Internal) CouchDB Formation
+      kind: Formation
+      name: formations.couchdb.databases.cloud.ibm.com
+      resources:
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: apps/v1
+      - kind: ServiceAccount
+        name: ''
+        version: v1
+      - kind: NetworkPolicy
+        name: ''
+        version: networking.k8s.io/v1
+      version: v1
+    - description: Internal lock on a CouchDB Formation. Used internally by the Operator
+        for Apache CouchDB.
+      displayName: (Internal) CouchDB Formation Lock
+      kind: FormationLock
+      name: formationlocks.couchdb.databases.cloud.ibm.com
+      version: v1
+    - description: Internal recipe for CouchDB. Used internally by the Operator for
+        Apache CouchDB.
+      displayName: (Internal) CouchDB Recipe
+      kind: Recipe
+      name: recipes.couchdb.databases.cloud.ibm.com
+      version: v1
+    - description: Internal recipe template for CouchDB. Used internally by the Operator
+        for Apache CouchDB.
+      displayName: (Internal) CouchDB Recipe Template
+      kind: RecipeTemplate
+      name: recipetemplates.couchdb.databases.cloud.ibm.com
+      version: v1
+  description: |
+    Apache CouchDB lets you access your data where you need it. The [Couch Replication Protocol](http://docs.couchdb.org/en/master/replication/protocol.html) is implemented in a variety of projects and products that span every imaginable computing environment from globally distributed server-clusters, over mobile phones to web browsers.
+
+    Store your data safely, on your own servers, or with any leading cloud provider. Your web- and native applications love CouchDB, because it speaks JSON natively and supports binary data for all your data storage needs.
+
+    The [Couch Replication Protocol](http://docs.couchdb.org/en/master/replication/protocol.html) lets your data flow seamlessly between server clusters to mobile phones and web browsers, enabling a compelling [offline-first](http://offlinefirst.org/) user-experience while maintaining high performance and strong reliability. CouchDB comes with a developer-friendly query language, and optionally MapReduce for simple, efficient, and comprehensive data retrieval.
+
+    ### Operator for Apache CouchDB Features
+    * Fully automated deployment and configuration of Apache CouchDB clusters.
+    * Support single, multiple, or all namespace install modes.
+
+    #### Security
+    * TLS - TLS  is supported using Red Hat Service certificates or user-provided certificates.
+    * Authentication - The parameter `require_valid_user` defaults to `true`, which means that no requests are allowed from anonymous users. Every request must be authenticated.
+    * Authorization - Databases are initially accessible by Apache CouchDB admins only.
+
+    #### High Availability
+    * Nodes - Each database node in an Apache CouchDB cluster requires its own Kubernetes node. It's recommended that you run it with a minimum of three nodes for any production deployment.
+    * Zones - The Apache CouchDB cluster database nodes are spread across available Kubernetes fault zones where available.
+    * Replicas - The default configuration for each database is two shards (Q=2) and three shard copies (N=3), where each shard copy is deployed on a separate node in the cluster.
+
+    ### Reading and writing to Apache CouchDB
+
+    The Operator for Apache CouchDB automatically generates a Service. This can be accessed using port-forwarding e.g. `kubectl port-forward svc/my-couchdb-cluster 443:443 -u admin:mypassword`. Alternatively, configure an OpenShift Route to expose the service externally.
+
+    ### CouchDB 2.3.1 Update Instructions
+    When the operator is updated to v2.0 or above any existing CouchDB 2.3.1 cluster will not be automatically upgraded to CouchDB 3. The user must manually trigger this process by removing the version statement `version: 2.3.1` in the CouchDBCluster CR for each CouchDB cluster
+    The operator will then perform a rolling update, with the new pods running CouchDB3.
+    It is advised that customers do this straightaway as CouchDB 2.3.1 is no longer supported.
+
+    [Read the complete guide to using the Operator for Apache CouchDB](https://ibm.biz/BdfGQy)
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTYuMC4zLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+CjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiCgkgd2lkdGg9IjEwOS43MTRweCIgaGVpZ2h0PSI3MnB4IiB2aWV3Qm94PSIwIDAgMTA5LjcxNCA3MiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMTA5LjcxNCA3MjsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8Zz4KCTxkZWZzPgoJCTxyZWN0IGlkPSJTVkdJRF8xXyIgd2lkdGg9IjEwOS43MTQiIGhlaWdodD0iNzIiLz4KCTwvZGVmcz4KCTxjbGlwUGF0aCBpZD0iU1ZHSURfMl8iPgoJCTx1c2UgeGxpbms6aHJlZj0iI1NWR0lEXzFfIiAgc3R5bGU9Im92ZXJmbG93OnZpc2libGU7Ii8+Cgk8L2NsaXBQYXRoPgoJPHBhdGggc3R5bGU9ImNsaXAtcGF0aDp1cmwoI1NWR0lEXzJfKTtmaWxsOiNFNDI1Mjg7IiBkPSJNODkuMTQzLDQ4YzAsNC41NDctMi4zOTUsNi43NzQtNi44NTcsNi44NTR2MC4wMDNIMjcuNDI5di0wLjAwMwoJCWMtNC40NjItMC4wNzktNi44NTctMi4zMDctNi44NTctNi44NTRjMC00LjU0NiwyLjM5NS02Ljc3NCw2Ljg1Ny02Ljg1NHYtMC4wMDRoNTQuODU2djAuMDA0CgkJQzg2Ljc0OCw0MS4yMjYsODkuMTQzLDQzLjQ1NCw4OS4xNDMsNDggTTgyLjI4NSw1OC4yOXYtMC4wMDRIMjcuNDI5djAuMDA0Yy00LjQ2MiwwLjA3OC02Ljg1NywyLjMwNi02Ljg1Nyw2Ljg1MwoJCXMyLjM5NSw2Ljc3NSw2Ljg1Nyw2Ljg1NFY3Mmg1NC44NTZ2LTAuMDA0YzQuNDYzLTAuMDc4LDYuODU3LTIuMzA3LDYuODU3LTYuODU0Uzg2Ljc0OCw1OC4zNjgsODIuMjg1LDU4LjI5IE05OS40MjksMjAuNTc5di0wLjAwNAoJCWMtNC40NjIsMC4wNzktNi44NTcsMi4zMDctNi44NTcsNi44NTR2MzcuNzE0YzAsNC41NDcsMi4zOTYsNi43NzUsNi44NTcsNi44NTR2LTAuMDA3YzYuNjkzLTAuMjM2LDEwLjI4Ni02LjkyLDEwLjI4Ni0yMC41NjEKCQlWMzQuMjg2QzEwOS43MTUsMjUuMTkzLDEwNi4xMjIsMjAuNzM3LDk5LjQyOSwyMC41NzkgTTEwLjI4NiwyMC41NzV2MC4wMDRDMy41OTQsMjAuNzM3LDAsMjUuMTkzLDAsMzQuMjg2djE3LjE0MwoJCWMwLDEzLjY0MSwzLjU5NCwyMC4zMjQsMTAuMjg2LDIwLjU2MXYwLjAwN2M0LjQ2Mi0wLjA3OCw2Ljg1Ny0yLjMwNyw2Ljg1Ny02Ljg1NFYyNy40MjkKCQlDMTcuMTQzLDIyLjg4MiwxNC43NDgsMjAuNjU0LDEwLjI4NiwyMC41NzUgTTk5LjQyOSwxNy4xNDNjMC0xMS4zNjctNS45ODgtMTYuOTM3LTE3LjE0NC0xNy4xMzNWMEgyNy40Mjl2MC4wMQoJCUMxNi4yNzQsMC4yMDYsMTAuMjg2LDUuNzc2LDEwLjI4NiwxNy4xNDN2MC4wMDZjNi42OTMsMC4xMTgsMTAuMjg2LDMuNDYsMTAuMjg2LDEwLjI4YzAsNi44MiwzLjU5MywxMC4xNjIsMTAuMjg2LDEwLjI4djAuMDA1aDQ4CgkJdi0wLjAwNWM2LjY5Mi0wLjExOCwxMC4yODUtMy40NiwxMC4yODUtMTAuMjhjMC02LjgyLDMuNTkzLTEwLjE2MiwxMC4yODYtMTAuMjhWMTcuMTQzeiIvPgo8L2c+Cjwvc3ZnPgo=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: couchdb-operator
+      deployments:
+      - name: couchdb-operator
+        spec:
+          selector:
+            matchLabels:
+              name: couchdb-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: couchdb-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values: [amd64]
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 3
+                    preference:
+                      matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values: [amd64]
+              containers:
+              - env:
+                - name: RELATED_IMAGE_COUCHDB3
+                  value: registry.connect.redhat.com/ibm/couchdb3@sha256:1f8b0f31be95395c07436d92c89bf30eaca4f62cba805643d5562a64167f574a
+                - name: RELATED_IMAGE_MGMT
+                  value: registry.connect.redhat.com/ibm/couchdb-operator-mgmt@sha256:2115a1370e45bcdb9a59445ed78f4abc10d73ae090f07a8309941ba760b8a0bb
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: REGISTRY_SECRET
+                image: registry.connect.redhat.com/ibm/couchdb-operator@sha256:968c56be05781854ccc6068cc2f2f9f81dc7a34219210791810c2138d40a1cc3
+                imagePullPolicy: IfNotPresent
+                args: ["-registry=registry.connect.redhat.com/ibm", "--v=2", "--architecture=amd64"]
+                name: couchdb-operator
+                resources:
+                  limits:
+                    cpu: 1
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+              serviceAccountName: couchdb-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - deployments
+          - deployments/scale
+          - events
+          - endpoints
+          - services
+          - configmaps
+          - secrets
+          - pods
+          - pods/exec
+          - persistentvolumeclaims
+          - namespaces
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          - replicasets
+          - deployments
+          - deployments/scale
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - networkpolicies
+          - deployments
+          - deployments/scale
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - create
+          - delete
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - create
+          - delete
+          - update
+          - list
+          - watch
+        - apiGroups:
+          - couchdb.databases.cloud.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - create
+          - delete
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - couchdb-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        serviceAccountName: couchdb-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Apache
+  - CouchDB
+  - Cloudant
+  - NoSQL
+  links:
+  - name: Apache CouchDB Homepage
+    url: http://couchdb.apache.org/
+  - name: Documentation
+    url: https://ibm.biz/BdfGQy
+  maintainers:
+  - email: support@cloudant.com
+    name: IBM
+  maturity: stable
+  provider:
+    name: IBM
+  version: 2.2.3
+  relatedImages:
+  - name: COUCHDB3
+    image: registry.connect.redhat.com/ibm/couchdb3@sha256:1f8b0f31be95395c07436d92c89bf30eaca4f62cba805643d5562a64167f574a
+  - name: COUCHDB-MGMT
+    image: registry.connect.redhat.com/ibm/couchdb-operator-mgmt@sha256:2115a1370e45bcdb9a59445ed78f4abc10d73ae090f07a8309941ba760b8a0bb

--- a/operators/couchdb-operator-certified/2.2.3/manifests/couchdbclusters.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/couchdbclusters.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,537 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: couchdbclusters.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: CouchDBCluster
+    listKind: CouchDBClusterList
+    plural: couchdbclusters
+    shortNames:
+    - alt
+    singular: couchdbcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              cpu:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              devMode:
+                type: boolean
+              disk:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              environment:
+                description: TODO CodeGen this from cdcp.couchdb.configuration? Everything
+                  is a string - type conversion only occurs in python
+                properties:
+                  OSProcessTimeout:
+                    description: Set the timeout for Query Servers (ms).
+                    format: int64
+                    type: integer
+                  adminPassword:
+                    description: Password for the "admin" user.
+                    type: string
+                  advanced:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: 'Advanced - overrides for properties not explicitly
+                      supported by the operator Example entry in a CouchDBCluster
+                      resource: advanced: { "uuids": { "algorithm": "utc_random" }
+                      }'
+                    type: object
+                  clouseau:
+                    properties:
+                      closeIfIdle:
+                        description: Close idle search indexes
+                        type: boolean
+                      idleCheckIntervalSecs:
+                        description: Clouseau idle index check interval in seconds
+                        format: int32
+                        type: integer
+                      logLevel:
+                        description: Log4j log level for Clouseau
+                        format: int32
+                        type: integer
+                      maxIndexesOpen:
+                        description: Max search indexes that Clouseau will hold open
+                        format: int32
+                        type: integer
+                    type: object
+                  compactionDaemon:
+                    properties:
+                      checkInterval:
+                        description: The delay, in seconds, between each check for
+                          which database and view indexes need to be compacted.
+                        format: int32
+                        type: integer
+                      minFileSize:
+                        description: If a database or view index file is smaller then
+                          this value (in bytes) compaction will not happen. Very small
+                          files always have a very high fragmentation therefore it's
+                          not worth to compact them.
+                        format: int64
+                        type: integer
+                      snoozePeriodMS:
+                        description: With lots of databases and/or with lots of design
+                          docs in one or more databases, the compaction_daemon can
+                          create significant CPU load when checking whether databases
+                          and view indexes need compacting. The snooze_period_ms setting
+                          ensures a smoother CPU load.
+                        format: int32
+                        type: integer
+                    type: object
+                  compactions:
+                    description: A list of rules to determine when to run automatic
+                      compaction.
+                    type: string
+                  couchjsStackSize:
+                    description: Stack size for the CouchJS process
+                    format: int64
+                    type: integer
+                  databaseCompaction:
+                    properties:
+                      checkpointAfter:
+                        description: Checkpoint after every N bytes were written
+                        format: int64
+                        type: integer
+                      docBufferSize:
+                        description: Buffer size for database compaction. Larger buffer
+                          sizes can originate smaller files (bytes).
+                        format: int64
+                        type: integer
+                    type: object
+                  defaultSecurity:
+                    description: Default security object for databases if not explicitly
+                      set. When set to everyone, anyone can performs reads and writes.
+                      When set to admin_only, only admins can read and write. When
+                      set to admin_local, sharded databases can be read and written
+                      by anyone but the shards can only be read and written by admins.
+                    type: string
+                  dreyfus:
+                    description: CouchDB 3 Specific configuration
+                    properties:
+                      limit:
+                        description: Default number of results returned from a global
+                          search query
+                        format: int32
+                        type: integer
+                      limitPartitions:
+                        description: Default number of results returned from a search
+                          on a partition of a database
+                        format: int32
+                        type: integer
+                      maxLimit:
+                        description: Maximum number of results that can be returned
+                          from a global search query
+                        format: int32
+                        type: integer
+                      maxLimitPartitions:
+                        description: Maximum number of results that can be returned
+                          when searching a partition of a database
+                        format: int32
+                        type: integer
+                      retryLimit:
+                        description: CouchDB will try to re-connect to Clouseau using
+                          a bounded exponential backoff with this number of iterations
+                        format: int32
+                        type: integer
+                    type: object
+                  enableDatabaseRecovery:
+                    description: Enable this to only "soft-delete" databases when
+                      DELETE /{db} requests are made. This will place a .recovery
+                      directory in your data directory and move deleted databases/shards
+                      there instead. You can then manually delete these files later,
+                      as desired.
+                    type: boolean
+                  erlang:
+                    properties:
+                      processLimit:
+                        description: Set the maximum number of concurrent processes.
+                        format: int64
+                        type: integer
+                      tls:
+                        description: Enable TLS Erlang distribution
+                        type: boolean
+                    type: object
+                  fabric:
+                    properties:
+                      requestTimeout:
+                        description: Timeout for internal cluster RPC (ms)
+                        format: int64
+                        type: integer
+                    type: object
+                  ken:
+                    properties:
+                      batchChannels:
+                        description: number of background view builds that can be
+                          running in parallel at any given time
+                        format: int32
+                        type: integer
+                      incrementalChannels:
+                        description: how many additional short jobs are allowed to
+                          run concurrently with the main jobs
+                        format: int32
+                        type: integer
+                      maxIncrementalUpdates:
+                        description: Threshold for whether a job is only allowed to
+                          run in the main queue
+                        format: int32
+                        type: integer
+                    type: object
+                  logLevel:
+                    description: CouchDB log level
+                    type: string
+                  mango:
+                    properties:
+                      defaultLimit:
+                        description: Default limit value for mango _find queries.
+                        format: int32
+                        type: integer
+                      indexAllDisabled:
+                        description: Set to true to disable the 'index all fields'
+                          text index, which can lead to out of memory issues when
+                          users have documents with nested array fields.
+                        type: boolean
+                    type: object
+                  maxAttachmentSize:
+                    description: Set the maximum size of attachments (bytes).
+                    format: int64
+                    type: integer
+                  maxDBsOpen:
+                    description: Set the maximum number of open db shards per node.
+                    format: int32
+                    type: integer
+                  maxDocumentSize:
+                    description: Set the maximum size of documents (bytes).
+                    format: int64
+                    type: integer
+                  maxHttpRequestSize:
+                    description: Set the maximum size of HTTP requests (bytes).
+                    format: int64
+                    type: integer
+                  queryServer:
+                    properties:
+                      OSProcessLimit:
+                        description: Hard limit on the number of OS processes usable
+                          by Query Servers.
+                        format: int32
+                        type: integer
+                      OSProcessSoftLimit:
+                        description: Soft limit on the number of OS processes usable
+                          by Query Servers.
+                        format: int32
+                        type: integer
+                      reduceLimit:
+                        description: Controls 'Reduce overflow error' that raises
+                          when output of reduce functions is too big.
+                        type: boolean
+                    type: object
+                  replicator:
+                    properties:
+                      connectionTimeout:
+                        description: HTTP connection timeout per replication (ms).
+                        format: int64
+                        type: integer
+                      httpConnections:
+                        description: Maximum number of HTTP connections per replication.
+                        format: int32
+                        type: integer
+                      interval:
+                        description: Scheduling interval in milliseconds. During each
+                          reschedule cycle scheduler might start or stop up to "max_churn"
+                          number of jobs.
+                        format: int32
+                        type: integer
+                      maxChurn:
+                        description: Maximum number of replications to start and stop
+                          during rescheduling. This parameter along with "interval"
+                          defines the rateof job replacement. During startup, however
+                          a much larger number ofjobs could be started (up to max_jobs)
+                          in short period of time.
+                        format: int32
+                        type: integer
+                      maxHistory:
+                        description: Each replication job maintains a log historic
+                          events such as "added", "started", "crashed". That is used
+                          to determine the appropriate exponential backoff for crashed
+                          jobs, as well as to calculate metrics. This parameter defines
+                          how many of those events to keep.
+                        format: int32
+                        type: integer
+                      maxJobs:
+                        description: Number of actively running replications. Making
+                          this too high could cause performance issues. Making it
+                          too low could mean replications jobs might not have enough
+                          time to make progress before getting unscheduled again.
+                        format: int32
+                        type: integer
+                      retriesPerRequest:
+                        description: If a request fails, the replicator will retry
+                          it up to N times. The default value for N is 5 (before version
+                          2.1.1 it was 10). The requests are retried with a doubling
+                          exponential backoff starting at 0.25 seconds. So by default
+                          requests would be retried in 0.25, 0.5, 1, 2, 4 second intervals.
+                          When number of retires is exhausted, the whole replication
+                          job is stopped and will retry again later.
+                        format: int32
+                        type: integer
+                      verifySSLCertificates:
+                        description: Whether the replicator should verify SSL certificates.
+                        type: boolean
+                      workerBatchSize:
+                        description: With lower batch sizes checkpoints are done more
+                          frequently. Lower batch sizes also reduce the total amount
+                          of used RAM memory.
+                        format: int32
+                        type: integer
+                      workerProcesses:
+                        description: More worker processes can give higher network
+                          throughput but can also imply more disk and network IO.
+                        format: int32
+                        type: integer
+                    type: object
+                  requireValidUser:
+                    description: Require valid user for all requests
+                    type: boolean
+                  reshard:
+                    properties:
+                      deleteSource:
+                        description: Indicates if the source shard should be deleted
+                          after resharding has finished
+                        type: boolean
+                      maxJobs:
+                        description: Maximum number of resharding jobs per cluster
+                          node
+                        format: int32
+                        type: integer
+                      maxRetries:
+                        description: How many times to retry shard splitting steps
+                          if they fail
+                        format: int32
+                        type: integer
+                      retryIntervalSec:
+                        description: How long to wait between subsequent retries
+                        format: int32
+                        type: integer
+                      sourceCloseTimeoutSec:
+                        description: How many seconds to wait for the source shard
+                          to close
+                        format: int32
+                        type: integer
+                      updateShardMapTimeoutSec:
+                        description: How many seconds to wait for the shard map update
+                          operation to complete
+                        format: int32
+                        type: integer
+                    type: object
+                  search:
+                    description: Enable Search Index support
+                    type: boolean
+                  smoosh:
+                    properties:
+                      channels:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: Settings that control the resource allocation
+                          for all user defined compaction channel
+                        type: object
+                      cleanupIndexFiles:
+                        description: If the compaction daemon should delete files
+                          for indexes that are no longer associated with any design
+                          document
+                        type: boolean
+                      dbChannels:
+                        description: List of channels that are sent the names of database
+                          files when those files are updated
+                        type: string
+                      staleness:
+                        description: The number of minutes that the priority calculation
+                          on an individual can be stale for before it is recalculated
+                        format: int32
+                        type: integer
+                      viewChannels:
+                        description: List of channels that are sent the names of views
+                          when those views are updated
+                        type: string
+                      waitSecs:
+                        description: Time a channel waits before starting compactions
+                        format: int32
+                        type: integer
+                    type: object
+                  tls:
+                    description: Enable TLS support
+                    type: boolean
+                  viewCompaction:
+                    properties:
+                      keyValueBufferSize:
+                        description: Buffer size for database compaction. Larger buffer
+                          sizes can originate smaller files (bytes).
+                        format: int64
+                        type: integer
+                    type: object
+                type: object
+              memory:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              resources:
+                properties:
+                  db:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  mgmt:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  search:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                type: object
+              securitycontext:
+                properties:
+                  fsGroup:
+                    format: int32
+                    type: integer
+                  runAsNonRoot:
+                    type: boolean
+                  runAsUser:
+                    format: int32
+                    type: integer
+                type: object
+              size:
+                format: int32
+                type: integer
+              storageClass:
+                type: string
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              formationGeneration:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/manifests/formationlocks.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/formationlocks.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,128 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: formationlocks.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: FormationLock
+    listKind: FormationLockList
+    plural: formationlocks
+    singular: formationlock
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FormationLock is used by the Recipe system to gate execution
+          of Recipes. See the recipes package for more details on semantics.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FormationLockSpec records the current state of a FormationLock,
+              mapping a given Formation to the currently held locks. This data structure
+              should be treated with care; it is essential for correctness semantics
+              of Recipes.
+            properties:
+              lock_references:
+                additionalProperties:
+                  description: Lock is an ancillary data structure for FormationLock.
+                  properties:
+                    blockers:
+                      description: The Recipes blocking admission of this lock at
+                        time of lock acquisition. See the locks implementation for
+                        behavioral details.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                    recipe_id:
+                      description: The ID of the Recipe holding this lock.
+                      nullable: true
+                      type: string
+                    timestamp:
+                      description: The CreationTimestamp of the Recipe holding this
+                        lock.
+                      format: date-time
+                      nullable: true
+                      type: string
+                  type: object
+                description: A map of template name -> lock representing the most-recently-held
+                  lock for any given template. This field is used to manage ordering
+                  among recipes.
+                nullable: true
+                type: object
+              read_locks:
+                additionalProperties:
+                  description: Lock is an ancillary data structure for FormationLock.
+                  properties:
+                    blockers:
+                      description: The Recipes blocking admission of this lock at
+                        time of lock acquisition. See the locks implementation for
+                        behavioral details.
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                    recipe_id:
+                      description: The ID of the Recipe holding this lock.
+                      nullable: true
+                      type: string
+                    timestamp:
+                      description: The CreationTimestamp of the Recipe holding this
+                        lock.
+                      format: date-time
+                      nullable: true
+                      type: string
+                  type: object
+                description: A map of template name -> lock reference for currently
+                  held read-locks.
+                nullable: true
+                type: object
+              write_lock:
+                description: The currently held write-lock, if any.
+                nullable: true
+                properties:
+                  blockers:
+                    description: The Recipes blocking admission of this lock at time
+                      of lock acquisition. See the locks implementation for behavioral
+                      details.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  recipe_id:
+                    description: The ID of the Recipe holding this lock.
+                    nullable: true
+                    type: string
+                  timestamp:
+                    description: The CreationTimestamp of the Recipe holding this
+                      lock.
+                    format: date-time
+                    nullable: true
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/manifests/formations.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/formations.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,1429 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: formations.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: Formation
+    listKind: FormationList
+    plural: formations
+    singular: formation
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Formation represents an instance of a database managed by CDCP.
+          The Formation and its fields are the primary public API of CDCP.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FormationSpec defines the high-level structure of the specification
+              of a Formation. Most specification is typically delegated to the `ResourceConfigs`
+              field.
+            properties:
+              account:
+                description: "The logical \"account\" that owns this Formation. Must
+                  be identical to Formation.ObjectMeta.Namespace. \n This field will
+                  be deprecated in a future release."
+                type: string
+              backups:
+                description: The backup configuration for this Formation. See BackupsConfig
+                  for more detail.
+                properties:
+                  enabled:
+                    description: Whether or not backups are enabled for this Formation.
+                    nullable: true
+                    type: boolean
+                type: object
+              disablements:
+                description: 'If there are any Disablements, disable the instance.
+                  This can mean scaling down the pods, revoking network policies,
+                  or anything else. Any system that wishes to disable a Formation
+                  should add an entry to the Disablements slice and remove it when
+                  the disablement criterion is lifted. Some example reasons for Disablement
+                  include: non-payment, access revoked, version end-of-life.'
+                items:
+                  type: string
+                nullable: true
+                type: array
+              fqdn:
+                description: "The fully qualified domain name of the Formation. \n
+                  This field will be deprecated in a future release."
+                nullable: true
+                type: string
+              frozen:
+                description: "Whether or not the Formation is frozen. \n This field
+                  will be deprecated in a future release."
+                nullable: true
+                type: boolean
+              id:
+                description: "The ID of this Formation. Must be identical to Formation.ObjectMeta.Name.
+                  \n This field will be deprecated in a future release."
+                pattern: ^[a-z0-9-]*$
+                type: string
+              kicker:
+                description: The Formation Controller uses Generations to avoid doing
+                  unnecessary work when Formation.Spec has not changed. In some cases,
+                  however, the full state of the Formation is not encoded in Formation.Spec.
+                  The Kicker field exists for these situations. It is a no-op in the
+                  controller, but mutating it is guaranteed to increment Formation.Generation
+                  and forcing a re-evaluation of the state of the world.
+                nullable: true
+                type: integer
+              resource_configs:
+                additionalProperties:
+                  description: ResourceConfig specifies and configures a workload
+                    - usually a set of Pods - under the management of a Formation.
+                    ResourceConfigs typically map to a single Kubernetes workload
+                    object, such as StatefulSet or Deployment.
+                  properties:
+                    affinity:
+                      description: If specified, the scheduling constraints for Pods
+                        under the management of this ResourceConfig.
+                      nullable: true
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is alpha-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces. This field
+                                      is alpha-level and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is alpha-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces. This field
+                                      is alpha-level and is only honored when PodAffinityNamespaceSelector
+                                      feature is enabled.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    cpu:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: How much CPU - as in the PodSpec, measured in millicpus
+                        - should be allocated to Pods under management of this ResourceConfig.
+                        This allocation is a reservation for scheduling, not a limit.
+                      nullable: true
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    dedicated:
+                      description: Whether or not this resource config should be deployed
+                        on "dedicated" resources. The implementation of "dedicated"
+                        resources is undefined by CDCP and may vary environment-to-environment.
+                      nullable: true
+                      type: boolean
+                    disk:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: How much disk - measured in bytes - should be allocated
+                        to the `/data` volume mounted in containers under management
+                        of this ResourceConfig.
+                      nullable: true
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    env:
+                      additionalProperties:
+                        type: string
+                      description: A free-form map of configuration values for workloads
+                        under management of this ResourceConfig. These values are
+                        typically injected in to a ConfigMap associated with the ResourceConfig,
+                        but a database implementation is free to do otherwise. These
+                        values are generally *not* injected in to the container's
+                        runtime environment.
+                      nullable: true
+                      type: object
+                    images:
+                      additionalProperties:
+                        type: string
+                      description: A free-form map of fully-qualified image references
+                        for use by this ResourceConfig. This list is deliberately
+                        unstructured; database implementors may use whatever keys
+                        are appropriate to their application.
+                      type: object
+                    initialized:
+                      description: Whether or not the workload managed by this ResourceConfig
+                        has been initialized, i.e., if the Pods under management have
+                        booted and successfully been marked ready at least once. This
+                        is not guaranteed to happen in a timely fashion.
+                      nullable: true
+                      type: boolean
+                    memory:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: How much memory - as in the PodSpec, measured in
+                        bytes - should be allocated to Pods under management of this
+                        ResourceConfig.
+                      nullable: true
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    replicas:
+                      description: The number of "replicas" - typically Pods - that
+                        will be created under this ResourceConfig.
+                      format: int32
+                      nullable: true
+                      type: integer
+                    resource_scaling_policy:
+                      description: If specified, configures the resource scaling policy
+                        for Pods under management of this ResourceConfig. If left
+                        unset, Memory and CPU values will be ignored. Disk resources
+                        are not managed under this policy; their scalability is left
+                        to their StorageClass.
+                      enum:
+                      - dynamic
+                      - static
+                      - ""
+                      nullable: true
+                      type: string
+                    scheduler_name:
+                      description: If specified, the Kubernetes scheduler for Pods
+                        under management of this ResourceConfig.
+                      type: string
+                    secrets:
+                      additionalProperties:
+                        type: string
+                      description: A free-form map of "secret" configuration values
+                        for workloads under management of this ResourceConfig. These
+                        values are obscured by the controller after resources are
+                        initialized.
+                      nullable: true
+                      type: object
+                    storage:
+                      description: Configuration for storage volumes. This is *exclusive*
+                        of the special /conf emptydir. If /conf is specified here,
+                        it will be ignored.
+                      items:
+                        description: StorageConfig defines the structure of configurable
+                          storage to be attached to a CDCP-managed workload. Note
+                          that StorageConfig is for _configurable_ storage - e.g.,
+                          if a volume needs to be parameterized by an existing claim,
+                          or a specialized storage class based on the deployment environment.
+                          Non-configurable storage - such as /conf empty dirs - should
+                          not be represented by StorageConfigs.
+                        properties:
+                          claim_name:
+                            type: string
+                          mount_path:
+                            type: string
+                          name:
+                            type: string
+                          spec:
+                            description: PersistentVolumeClaimSpec describes the common
+                              attributes of storage devices and allows a Source for
+                              provider-specific attributes
+                            properties:
+                              accessModes:
+                                description: 'AccessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                description: 'This field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim) * An existing
+                                  custom resource that implements data population
+                                  (Alpha) In order to use custom resource types that
+                                  implement data population, the AnyVolumeDataSource
+                                  feature gate must be enabled. If the provisioner
+                                  or an external controller can support the specified
+                                  data source, it will create a new volume based on
+                                  the contents of the specified data source.'
+                                properties:
+                                  apiGroup:
+                                    description: APIGroup is the group for the resource
+                                      being referenced. If APIGroup is not specified,
+                                      the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is
+                                      required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being
+                                      referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being
+                                      referenced
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                description: 'Resources represents the minimum resources
+                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                              selector:
+                                description: A label query over volumes to consider
+                                  for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              storageClassName:
+                                description: 'Name of the StorageClass required by
+                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim. Value of Filesystem is
+                                  implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: VolumeName is the binding reference to
+                                  the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                          storage_config_type:
+                            description: StorageConfigType manages the CDCP's interpretation
+                              of a StorageConfig; each of the types has near-identical
+                              specifications but slightly different behavior.
+                            enum:
+                            - template
+                            - existing
+                            - create
+                            - ""
+                            type: string
+                        type: object
+                      type: array
+                    storage_class:
+                      description: The name of the storage class that should be used
+                        to back the `/data` volume mounted in containers under management
+                        of this ResourceConfig. An empty string indicates a non-persistent
+                        EmptyDir storage class.
+                      type: string
+                    toleration:
+                      description: If specified, the tolerations for Pods under the
+                        management of this ResourceConfig.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    version:
+                      description: The version of this ResourceConfig. This is not
+                        necessarily identical to the version of the Formation; for
+                        example, a PostgreSQL formation at version 10.4 could include
+                        an etcd ResourceConfig at version 3.3.9.
+                      type: string
+                  type: object
+                description: Configuration of the various ResourceConfigs under management
+                  of this Formation. Could be an arbitrary set of keys, but each must
+                  map to a known Component in the ResourceCollection that corresponds
+                  to the Formation's type.
+                type: object
+              type:
+                description: The type of the Formation. This field is the top-level
+                  selector that maps a Formation to a ResourceCollection, which in
+                  turn defines the set of Resources that are managed by the formation.
+                type: string
+              version:
+                description: The version of the Formation. Typically not used; ResourceConfig
+                  version identifiers are canonical.
+                type: string
+            type: object
+          status:
+            description: FormationStatus represents the controller's view of the state
+              of the Formation. This status is used in conjunction with the state-of-the-world
+              to drive decisions by the formation-controller state machine.
+            properties:
+              certificates:
+                additionalProperties:
+                  type: string
+                description: A map providing TLS public keys for connecting to the
+                  system under management.
+                type: object
+              components:
+                description: A list of the components that comprise the controller-level
+                  view of the Formation. This field is internal controller metadata
+                  and should not be used to infer anything about the state of the
+                  Formation or the systems under its management.
+                items:
+                  description: FormationComponent is a reference to an instance of
+                    a CDCP Resource - typically, but not always, a Kubernetes Resource.
+                  properties:
+                    kind:
+                      description: The Kind of a FormationComponent maps to the Type
+                        (!) of the underlying CDCP Resource. See ResourceCollection
+                        for more details. The pair of (Kind, Name) must be unique
+                        within a given Formation.
+                      type: string
+                    name:
+                      description: The Name of a FormationComponent is typically a
+                        Formation-specific identifier for the underlying CDCP Resource.
+                        See ResourceCollection for more details. The pair of (Kind,
+                        Name) must be unique within a given Formation.
+                      type: string
+                    status:
+                      description: The current convergence status of the FormationComponent.
+                      properties:
+                        message:
+                          description: "An arbitrary message reflecting the status
+                            of the convergence of this component. \n This field will
+                            be deprecated in a future release."
+                          nullable: true
+                          type: string
+                        observed_generation:
+                          description: The value of Formation.Generation the last
+                            time this component was successfully converged.
+                          format: int64
+                          nullable: true
+                          type: integer
+                        state:
+                          description: The current "state" of the FormationComponent,
+                            from the controller's point of view. This field should
+                            not be relied upon to infer anything about the state of
+                            the FormationComponent or its associated Resources.
+                          enum:
+                          - OK
+                          - Creating
+                          - Updating
+                          - Converging
+                          - Destroying
+                          - ""
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              connections:
+                additionalProperties:
+                  items:
+                    description: Connection represents a method to connect to a Formation.
+                      A single Formation may have many Connections; see FormationStatus.
+                    properties:
+                      group:
+                        type: string
+                      hostname:
+                        type: string
+                      port:
+                        format: int32
+                        type: integer
+                      protocol:
+                        type: string
+                    type: object
+                  type: array
+                description: A map representing available connectivity methods to
+                  the system under management. The keys in this map are database-specific.
+                  They often reflect protocols.
+                type: object
+              observed_generation:
+                description: The value of Formation.Generation at the time the Formation
+                  controller last successfully completed a convergence. A Formation
+                  specification at generation N is guaranteed to have been reflected
+                  in the state-of-the-world when ObservedGeneration >= N. The values
+                  of ObservedGeneration are not guaranteed to be continuous, though
+                  they are monotonic. When Formation.Generation == ObservedGeneration,
+                  the Formation controller has no work to do.
+                format: int64
+                type: integer
+              pending_recipe:
+                description: The behavior of the Formation controller is coupled to
+                  the Recipe mechanism by supporting blocking Formation convergence
+                  on Recipe execution. This field manages that coupling.
+                nullable: true
+                type: string
+              state:
+                description: The current "state" of the Formation, from the controller's
+                  point of view. This field is an implementation detail and should
+                  not be relied upon to infer anything about the state of the Formation
+                  or the systems under its management. This field will generally take
+                  one of the ResourceState values. See ObservedGeneration for more
+                  information about inferring controller state.
+                enum:
+                - OK
+                - Processing
+                - Error
+                - ""
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/manifests/recipes.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/recipes.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,787 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: recipes.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: Recipe
+    listKind: RecipeList
+    plural: recipes
+    shortNames:
+    - rp
+    singular: recipe
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.template
+      name: Type
+      type: string
+    - jsonPath: .spec.formation_id
+      name: Status
+      type: string
+    - jsonPath: .spec.formation_type
+      name: Formation
+      type: string
+    - jsonPath: .spec.formation_version
+      name: Database
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Recipe represents an imperative action to be taken against a
+          Formation. Recipes are specified by RecipeTemplates and parameterized by
+          user-defined arguments. The RecipeTemplate language supports a wide variety
+          of actions to be expressed.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RecipeSpec represents the basic specification of a Recipe.
+              Under normal operations, only Template, ArgsSecretRef, and FormationID
+              are specified by the caller; other fields are populated by recipe-controller
+              based on those three.
+            properties:
+              args_secret:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              formation_id:
+                type: string
+              formation_type:
+                type: string
+              formation_version:
+                type: string
+              lock_strategy:
+                description: LockStrategy defines the locking strategy for a given
+                  Recipe (or RecipeTemplate). Recipe locks semantics follow an extended
+                  rwlock pattern. See plumbing/pkg/controllers/recipes for more information.
+                enum:
+                - write
+                - read
+                - noop
+                - ""
+                type: string
+              on_failure_operation_groups:
+                items:
+                  properties:
+                    build_template:
+                      properties:
+                        api_template:
+                          nullable: true
+                          properties:
+                            action:
+                              enum:
+                              - create
+                              - update
+                              - delete
+                              - ""
+                              type: string
+                            kind:
+                              type: string
+                            resource_json:
+                              type: string
+                            target:
+                              type: string
+                            wait_for_status:
+                              description: "ResourceState represents the state of
+                                various CDCP resources, such as Formations and Recipes.
+                                It is used to drive the state machines in recipe-controller,
+                                bucket-controller (and perhaps others?) as well as
+                                by APIOperations to coordinate Recipe activity. Note
+                                that formation-controller uses FormationState, not
+                                ResourceState. See RecipeStatus for more details on
+                                the use of ResourceState by recipe-controller. \n
+                                The awkwardness here is due to APIOperations' need
+                                for a consistent type across resources to allow flexibility
+                                to Recipe authors. If and when APIOperations are deprecated,
+                                the scope of ResourceState will be reduced. \n ResourceState
+                                should be considered deprecated and is not be used
+                                in any newly developed packages."
+                              enum:
+                              - new
+                              - prepared
+                              - running
+                              - watching
+                              - skipped
+                              - failing
+                              - failed
+                              - completed
+                              - OK
+                              - Error
+                              - ""
+                              type: string
+                          type: object
+                        cdb_template:
+                          nullable: true
+                          properties:
+                            command:
+                              properties:
+                                args:
+                                  type: string
+                                exec:
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              nullable: true
+                              type: object
+                            strategy:
+                              enum:
+                              - all
+                              - one
+                              - ""
+                              type: string
+                          type: object
+                        guard:
+                          type: string
+                        primitive_template:
+                          nullable: true
+                          properties:
+                            args:
+                              additionalProperties:
+                                type: string
+                              nullable: true
+                              type: object
+                            name:
+                              type: string
+                            selector:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              nullable: true
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        type:
+                          enum:
+                          - cdb_template
+                          - api_template
+                          - primitive_template
+                          - ""
+                          type: string
+                      type: object
+                    operations:
+                      items:
+                        properties:
+                          api_spec:
+                            properties:
+                              action:
+                                enum:
+                                - create
+                                - update
+                                - delete
+                                - ""
+                                type: string
+                              kind:
+                                type: string
+                              resource_json:
+                                type: string
+                              target:
+                                type: string
+                              wait_for_status:
+                                description: "ResourceState represents the state of
+                                  various CDCP resources, such as Formations and Recipes.
+                                  It is used to drive the state machines in recipe-controller,
+                                  bucket-controller (and perhaps others?) as well
+                                  as by APIOperations to coordinate Recipe activity.
+                                  Note that formation-controller uses FormationState,
+                                  not ResourceState. See RecipeStatus for more details
+                                  on the use of ResourceState by recipe-controller.
+                                  \n The awkwardness here is due to APIOperations'
+                                  need for a consistent type across resources to allow
+                                  flexibility to Recipe authors. If and when APIOperations
+                                  are deprecated, the scope of ResourceState will
+                                  be reduced. \n ResourceState should be considered
+                                  deprecated and is not be used in any newly developed
+                                  packages."
+                                enum:
+                                - new
+                                - prepared
+                                - running
+                                - watching
+                                - skipped
+                                - failing
+                                - failed
+                                - completed
+                                - OK
+                                - Error
+                                - ""
+                                type: string
+                            type: object
+                          cdb_spec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              pod_name:
+                                type: string
+                              pod_namespace:
+                                type: string
+                            type: object
+                          nonce:
+                            type: string
+                          primitive_spec:
+                            properties:
+                              args:
+                                additionalProperties:
+                                  type: string
+                                nullable: true
+                                type: object
+                              name:
+                                type: string
+                              selector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                nullable: true
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                            type: object
+                          recipe_id:
+                            type: string
+                          result:
+                            properties:
+                              error:
+                                type: string
+                              exit_code:
+                                maximum: 2
+                                minimum: 0
+                                type: integer
+                              stderr:
+                                type: string
+                              stdout:
+                                type: string
+                            type: object
+                          status:
+                            description: "ResourceState represents the state of various
+                              CDCP resources, such as Formations and Recipes. It is
+                              used to drive the state machines in recipe-controller,
+                              bucket-controller (and perhaps others?) as well as by
+                              APIOperations to coordinate Recipe activity. Note that
+                              formation-controller uses FormationState, not ResourceState.
+                              See RecipeStatus for more details on the use of ResourceState
+                              by recipe-controller. \n The awkwardness here is due
+                              to APIOperations' need for a consistent type across
+                              resources to allow flexibility to Recipe authors. If
+                              and when APIOperations are deprecated, the scope of
+                              ResourceState will be reduced. \n ResourceState should
+                              be considered deprecated and is not be used in any newly
+                              developed packages."
+                            enum:
+                            - new
+                            - prepared
+                            - running
+                            - watching
+                            - skipped
+                            - failing
+                            - failed
+                            - completed
+                            - OK
+                            - Error
+                            - ""
+                            type: string
+                          type:
+                            enum:
+                            - cdb
+                            - api
+                            - primitive
+                            - ""
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  type: object
+                nullable: true
+                type: array
+              operation_groups:
+                items:
+                  properties:
+                    build_template:
+                      properties:
+                        api_template:
+                          nullable: true
+                          properties:
+                            action:
+                              enum:
+                              - create
+                              - update
+                              - delete
+                              - ""
+                              type: string
+                            kind:
+                              type: string
+                            resource_json:
+                              type: string
+                            target:
+                              type: string
+                            wait_for_status:
+                              description: "ResourceState represents the state of
+                                various CDCP resources, such as Formations and Recipes.
+                                It is used to drive the state machines in recipe-controller,
+                                bucket-controller (and perhaps others?) as well as
+                                by APIOperations to coordinate Recipe activity. Note
+                                that formation-controller uses FormationState, not
+                                ResourceState. See RecipeStatus for more details on
+                                the use of ResourceState by recipe-controller. \n
+                                The awkwardness here is due to APIOperations' need
+                                for a consistent type across resources to allow flexibility
+                                to Recipe authors. If and when APIOperations are deprecated,
+                                the scope of ResourceState will be reduced. \n ResourceState
+                                should be considered deprecated and is not be used
+                                in any newly developed packages."
+                              enum:
+                              - new
+                              - prepared
+                              - running
+                              - watching
+                              - skipped
+                              - failing
+                              - failed
+                              - completed
+                              - OK
+                              - Error
+                              - ""
+                              type: string
+                          type: object
+                        cdb_template:
+                          nullable: true
+                          properties:
+                            command:
+                              properties:
+                                args:
+                                  type: string
+                                exec:
+                                  items:
+                                    type: string
+                                  nullable: true
+                                  type: array
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              nullable: true
+                              type: object
+                            strategy:
+                              enum:
+                              - all
+                              - one
+                              - ""
+                              type: string
+                          type: object
+                        guard:
+                          type: string
+                        primitive_template:
+                          nullable: true
+                          properties:
+                            args:
+                              additionalProperties:
+                                type: string
+                              nullable: true
+                              type: object
+                            name:
+                              type: string
+                            selector:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              nullable: true
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        type:
+                          enum:
+                          - cdb_template
+                          - api_template
+                          - primitive_template
+                          - ""
+                          type: string
+                      type: object
+                    operations:
+                      items:
+                        properties:
+                          api_spec:
+                            properties:
+                              action:
+                                enum:
+                                - create
+                                - update
+                                - delete
+                                - ""
+                                type: string
+                              kind:
+                                type: string
+                              resource_json:
+                                type: string
+                              target:
+                                type: string
+                              wait_for_status:
+                                description: "ResourceState represents the state of
+                                  various CDCP resources, such as Formations and Recipes.
+                                  It is used to drive the state machines in recipe-controller,
+                                  bucket-controller (and perhaps others?) as well
+                                  as by APIOperations to coordinate Recipe activity.
+                                  Note that formation-controller uses FormationState,
+                                  not ResourceState. See RecipeStatus for more details
+                                  on the use of ResourceState by recipe-controller.
+                                  \n The awkwardness here is due to APIOperations'
+                                  need for a consistent type across resources to allow
+                                  flexibility to Recipe authors. If and when APIOperations
+                                  are deprecated, the scope of ResourceState will
+                                  be reduced. \n ResourceState should be considered
+                                  deprecated and is not be used in any newly developed
+                                  packages."
+                                enum:
+                                - new
+                                - prepared
+                                - running
+                                - watching
+                                - skipped
+                                - failing
+                                - failed
+                                - completed
+                                - OK
+                                - Error
+                                - ""
+                                type: string
+                            type: object
+                          cdb_spec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              pod_name:
+                                type: string
+                              pod_namespace:
+                                type: string
+                            type: object
+                          nonce:
+                            type: string
+                          primitive_spec:
+                            properties:
+                              args:
+                                additionalProperties:
+                                  type: string
+                                nullable: true
+                                type: object
+                              name:
+                                type: string
+                              selector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                nullable: true
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                            type: object
+                          recipe_id:
+                            type: string
+                          result:
+                            properties:
+                              error:
+                                type: string
+                              exit_code:
+                                maximum: 2
+                                minimum: 0
+                                type: integer
+                              stderr:
+                                type: string
+                              stdout:
+                                type: string
+                            type: object
+                          status:
+                            description: "ResourceState represents the state of various
+                              CDCP resources, such as Formations and Recipes. It is
+                              used to drive the state machines in recipe-controller,
+                              bucket-controller (and perhaps others?) as well as by
+                              APIOperations to coordinate Recipe activity. Note that
+                              formation-controller uses FormationState, not ResourceState.
+                              See RecipeStatus for more details on the use of ResourceState
+                              by recipe-controller. \n The awkwardness here is due
+                              to APIOperations' need for a consistent type across
+                              resources to allow flexibility to Recipe authors. If
+                              and when APIOperations are deprecated, the scope of
+                              ResourceState will be reduced. \n ResourceState should
+                              be considered deprecated and is not be used in any newly
+                              developed packages."
+                            enum:
+                            - new
+                            - prepared
+                            - running
+                            - watching
+                            - skipped
+                            - failing
+                            - failed
+                            - completed
+                            - OK
+                            - Error
+                            - ""
+                            type: string
+                          type:
+                            enum:
+                            - cdb
+                            - api
+                            - primitive
+                            - ""
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  type: object
+                nullable: true
+                type: array
+              template:
+                type: string
+            type: object
+          status:
+            description: RecipeStatus represents the controller's view of the state
+              of a Recipe. This status is generally intended to provide information
+              to Recipe API consumers.
+            properties:
+              details:
+                description: An arbitrary human-readable description of the state
+                  of the Recipe.
+                type: string
+              start_timestamp:
+                description: The time at which the recipe entered the "running" state.
+                format: date-time
+                nullable: true
+                type: string
+              state:
+                description: The current "state" of the Recipe. Unlike Formation.Status.State,
+                  this field is reliable for external systems. StateFailed and StateCompleted
+                  are the only terminal states.
+                enum:
+                - new
+                - prepared
+                - running
+                - watching
+                - skipped
+                - failing
+                - failed
+                - completed
+                - OK
+                - Error
+                - ""
+                type: string
+              termination_timestamp:
+                description: The time at which the recipe entered a terminal state.
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/manifests/recipetemplates.couchdb.databases.cloud.ibm.com.crd.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/manifests/recipetemplates.couchdb.databases.cloud.ibm.com.crd.yaml
@@ -1,0 +1,366 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: recipetemplates.couchdb.databases.cloud.ibm.com
+spec:
+  group: couchdb.databases.cloud.ibm.com
+  names:
+    kind: RecipeTemplate
+    listKind: RecipeTemplateList
+    plural: recipetemplates
+    shortNames:
+    - rt
+    singular: recipetemplate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              template_definitions:
+                items:
+                  properties:
+                    arguments:
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                    lock_strategy:
+                      description: LockStrategy defines the locking strategy for a
+                        given Recipe (or RecipeTemplate). Recipe locks semantics follow
+                        an extended rwlock pattern. See plumbing/pkg/controllers/recipes
+                        for more information.
+                      enum:
+                      - write
+                      - read
+                      - noop
+                      - ""
+                      type: string
+                    on_failure_templates:
+                      items:
+                        properties:
+                          api_template:
+                            nullable: true
+                            properties:
+                              action:
+                                enum:
+                                - create
+                                - update
+                                - delete
+                                - ""
+                                type: string
+                              kind:
+                                type: string
+                              resource_json:
+                                type: string
+                              target:
+                                type: string
+                              wait_for_status:
+                                description: "ResourceState represents the state of
+                                  various CDCP resources, such as Formations and Recipes.
+                                  It is used to drive the state machines in recipe-controller,
+                                  bucket-controller (and perhaps others?) as well
+                                  as by APIOperations to coordinate Recipe activity.
+                                  Note that formation-controller uses FormationState,
+                                  not ResourceState. See RecipeStatus for more details
+                                  on the use of ResourceState by recipe-controller.
+                                  \n The awkwardness here is due to APIOperations'
+                                  need for a consistent type across resources to allow
+                                  flexibility to Recipe authors. If and when APIOperations
+                                  are deprecated, the scope of ResourceState will
+                                  be reduced. \n ResourceState should be considered
+                                  deprecated and is not be used in any newly developed
+                                  packages."
+                                enum:
+                                - new
+                                - prepared
+                                - running
+                                - watching
+                                - skipped
+                                - failing
+                                - failed
+                                - completed
+                                - OK
+                                - Error
+                                - ""
+                                type: string
+                            type: object
+                          cdb_template:
+                            nullable: true
+                            properties:
+                              command:
+                                properties:
+                                  args:
+                                    type: string
+                                  exec:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                nullable: true
+                                type: object
+                              strategy:
+                                enum:
+                                - all
+                                - one
+                                - ""
+                                type: string
+                            type: object
+                          guard:
+                            type: string
+                          primitive_template:
+                            nullable: true
+                            properties:
+                              args:
+                                additionalProperties:
+                                  type: string
+                                nullable: true
+                                type: object
+                              name:
+                                type: string
+                              selector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                nullable: true
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                            type: object
+                          type:
+                            enum:
+                            - cdb_template
+                            - api_template
+                            - primitive_template
+                            - ""
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    operation_templates:
+                      items:
+                        properties:
+                          api_template:
+                            nullable: true
+                            properties:
+                              action:
+                                enum:
+                                - create
+                                - update
+                                - delete
+                                - ""
+                                type: string
+                              kind:
+                                type: string
+                              resource_json:
+                                type: string
+                              target:
+                                type: string
+                              wait_for_status:
+                                description: "ResourceState represents the state of
+                                  various CDCP resources, such as Formations and Recipes.
+                                  It is used to drive the state machines in recipe-controller,
+                                  bucket-controller (and perhaps others?) as well
+                                  as by APIOperations to coordinate Recipe activity.
+                                  Note that formation-controller uses FormationState,
+                                  not ResourceState. See RecipeStatus for more details
+                                  on the use of ResourceState by recipe-controller.
+                                  \n The awkwardness here is due to APIOperations'
+                                  need for a consistent type across resources to allow
+                                  flexibility to Recipe authors. If and when APIOperations
+                                  are deprecated, the scope of ResourceState will
+                                  be reduced. \n ResourceState should be considered
+                                  deprecated and is not be used in any newly developed
+                                  packages."
+                                enum:
+                                - new
+                                - prepared
+                                - running
+                                - watching
+                                - skipped
+                                - failing
+                                - failed
+                                - completed
+                                - OK
+                                - Error
+                                - ""
+                                type: string
+                            type: object
+                          cdb_template:
+                            nullable: true
+                            properties:
+                              command:
+                                properties:
+                                  args:
+                                    type: string
+                                  exec:
+                                    items:
+                                      type: string
+                                    nullable: true
+                                    type: array
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                nullable: true
+                                type: object
+                              strategy:
+                                enum:
+                                - all
+                                - one
+                                - ""
+                                type: string
+                            type: object
+                          guard:
+                            type: string
+                          primitive_template:
+                            nullable: true
+                            properties:
+                              args:
+                                additionalProperties:
+                                  type: string
+                                nullable: true
+                                type: object
+                              name:
+                                type: string
+                              selector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                nullable: true
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                            type: object
+                          type:
+                            enum:
+                            - cdb_template
+                            - api_template
+                            - primitive_template
+                            - ""
+                            type: string
+                        type: object
+                      type: array
+                    versions:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/couchdb-operator-certified/2.2.3/metadata/annotations.yaml
+++ b/operators/couchdb-operator-certified/2.2.3/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: v2.2
+  operators.operatorframework.io.bundle.channels.v1: stable,v2.2
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: couchdb-operator-certified
+  com.redhat.openshift.versions: v4.8-v4.10


### PR DESCRIPTION
This release updates the v2.2.2 metadata to include support for OCP 4.10 The images deployed are identical to v2.2.2