### PR TITLE
operator seldon-operator-certified (1.12.0)

### DIFF
--- a/operators/seldon-operator-certified/1.12.0/metadata/annotations.yaml
+++ b/operators/seldon-operator-certified/1.12.0/metadata/annotations.yaml
@@ -9,4 +9,4 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
-  com.redhat.openshift.versions: "v4.8"
+  com.redhat.openshift.versions: "v4.8-v4.11"


### PR DESCRIPTION
We would like to get this change in to already released 1.12.0 Seldon Core operator to prevent this version being a default one on new OpenShift versions without us testing it properly first.

Every later version of seldon core operator we have added have upper limit of supported OpenShift version.

This is mainly to be safe when OpenShift 4.12 comes out with K8s 1.25 as SC 1.12 will definitely not run on it.


Signed-off-by: Rafal Skolasinski <r.j.skolasinski@gmail.com>