### PR TITLE
Cleanup invalid 'redis-enterprise-operator-aplpha-cert' folder

### DIFF
--- a/operators/redis-enterprise-operator-aplpha-cert/ci.yaml
+++ b/operators/redis-enterprise-operator-aplpha-cert/ci.yaml
@@ -1,1 +1,0 @@
-cert_project_id: 5e60969e3754a4b12df6ca0a


### PR DESCRIPTION
Cleanup the `redis-enterprise-operator-aplpha-cert` directory which doesn't refer to any valid operator (seems to have been introduced during [repo seeding](https://github.com/redhat-openshift-ecosystem/certified-operators/commit/0e64118d5d5113c3c36177ff26c3cff23935ff2b) but was left untouched since).

The actual Redis Enterprise Operator directory is maintained at [redis-enterprise-operator-cert](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/redis-enterprise-operator-cert).