### PR TITLE
operator splunk-operator (2.1.1)

### DIFF
--- a/operators/splunk-operator/2.1.1/manifests/splunk-operator.clusterserviceversion.yaml
+++ b/operators/splunk-operator/2.1.1/manifests/splunk-operator.clusterserviceversion.yaml
@@ -874,7 +874,7 @@ spec:
                             fieldPath: 'metadata.annotations[''olm.targetNamespaces'']'
                       - name: RELATED_IMAGE_SPLUNK_ENTERPRISE
                         value: >-
-                          splunk/splunk@sha256:c952e7fc25815bec35282a829f50c9fd52ac9c43f5586163f1cad834d1c779d4
+                          splunk/splunk@sha256:922272eef9399ca68f1aa914d0ce3e48162017b8085b3432d1209324df101eed
                       - name: OPERATOR_NAME
                         value: splunk-operator
                       - name: POD_NAME


### PR DESCRIPTION
fixed latest splunk image sha value


Name: splunk-operator
Version: 2.1.1

Signed-off-by: vivekr-splunk <94569031+vivekr-splunk@users.noreply.github.com>