### PR TITLE
operator citrix-ingress-controller-operator (1.26.7)

### DIFF
--- a/operators/citrix-cpx-with-ingress-controller-operator/1.26.7/manifests/citrix-cpx-with-ingress-controller-operator.clusterserviceversion.yaml
+++ b/operators/citrix-cpx-with-ingress-controller-operator/1.26.7/manifests/citrix-cpx-with-ingress-controller-operator.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ metadata:
               "required": false
             },
             "cic": {
-              "image": "quay.io/citrix/citrix-k8s-ingress-controller@sha256:2d44399ae59cd6d73bdc1c1fcd387c11e272841cb97333c782cacb7ff1987d01",
+              "image": "quay.io/citrix/citrix-k8s-ingress-controller@sha256:a421389bfd544644c68d70fae122029e8a26524fb45215ffbe09322a5ee44f38",
               "pullPolicy": "IfNotPresent",
               "required": true,
               "resources": {}
@@ -336,7 +336,7 @@ spec:
                 - name: RELATED_IMAGE_CPX
                   value: quay.io/citrix/citrix-k8s-cpx-ingress@sha256:f9acb4582ab535a30289f51182cf51fbb951368316accdfbd3a054d7b753be1d
                 - name: RELATED_IMAGE_CIC
-                  value: quay.io/citrix/citrix-k8s-ingress-controller@sha256:2d44399ae59cd6d73bdc1c1fcd387c11e272841cb97333c782cacb7ff1987d01
+                  value: quay.io/citrix/citrix-k8s-ingress-controller@sha256:a421389bfd544644c68d70fae122029e8a26524fb45215ffbe09322a5ee44f38
                 - name: RELATED_IMAGE_EXPORTER
                   value: quay.io/citrix/citrix-adc-metrics-exporter@sha256:2508c3a1780b281f43487c0ed1c115003687683d5856b26324a0832b1216fd58
                 image: registry.connect.redhat.com/citrix/citrix-k8s-cpx-ingress-controller@sha256:a33ec045d02f2807f23d6d654a19e3e076b6fa07935a85bd8c6b17770a40f300
@@ -436,7 +436,7 @@ spec:
   relatedImages:
   - image: quay.io/citrix/citrix-k8s-cpx-ingress@sha256:f9acb4582ab535a30289f51182cf51fbb951368316accdfbd3a054d7b753be1d
     name: cpx
-  - image: quay.io/citrix/citrix-k8s-ingress-controller@sha256:2d44399ae59cd6d73bdc1c1fcd387c11e272841cb97333c782cacb7ff1987d01
+  - image: quay.io/citrix/citrix-k8s-ingress-controller@sha256:a421389bfd544644c68d70fae122029e8a26524fb45215ffbe09322a5ee44f38
     name: cic
   - image: quay.io/citrix/citrix-adc-metrics-exporter@sha256:2508c3a1780b281f43487c0ed1c115003687683d5856b26324a0832b1216fd58
     name: exporter


### PR DESCRIPTION


Fix incorrect hash for citrix-k8s-ingress-controller container.