### PR TITLE
operator calisti-operator (1.12.0)

### DIFF
--- a/operators/calisti-operator/1.12.0/manifests/calisti-operator.clusterserviceversion.yaml
+++ b/operators/calisti-operator/1.12.0/manifests/calisti-operator.clusterserviceversion.yaml
@@ -332,7 +332,7 @@ spec:
         ```
         $ kubectl create ns supertubes-control-plane
         ```
-    4. Add a secret within the supertubes-control-plane namespace. Get your credentials from [here](https://calisti.app/download), step 2
+    4. Add a secret within the supertubes-control-plane namespace. Get your credentials from [here](https://cloud.calisti.app/download), step 2
 
         ```bash
         $ kubectl create secret docker-registry smm-registry.eticloud.io-pull-secret --docker-server=registry.eticloud.io --docker-username=<your-username> \


### PR DESCRIPTION
https://calisti.app/download does not exist anymore, adding correct link.