### PR TITLE
Delete operators/falco-certified directory

### DIFF
--- a/operators/falco-certified/ci.yaml
+++ b/operators/falco-certified/ci.yaml
@@ -1,1 +1,0 @@
-cert_project_id: 5f63854469d76c83e0e47baf


### PR DESCRIPTION
Delete operators/falco-certified directory in support of ISVISSUE-401.