### PR TITLE
operator infinibox-operator-certified (v2.8.0)

### DIFF
--- a/operators/infinibox-operator-certified/v2.8.0/manifests/csidriver.infinidat.com_infiniboxcsidrivers.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/csidriver.infinidat.com_infiniboxcsidrivers.yaml
@@ -1,0 +1,207 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: infiniboxcsidrivers.csidriver.infinidat.com
+spec:
+  group: csidriver.infinidat.com
+  names:
+    kind: InfiniboxCsiDriver
+    listKind: InfiniboxCsiDriverList
+    plural: infiniboxcsidrivers
+    singular: infiniboxcsidriver
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: InfiniboxBoxDriver is the Schema for the infiniboxcsidrivers
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InfiniboxCsiDriverSpec defines the desired state of InfiniboxCsiDriver
+            properties:
+              Infinibox_Cred:
+                description: Cred is the ibox credentials used by the csi driver to
+                  authenticate with the ibox.
+                properties:
+                  SecretName:
+                    description: SecretName is the Secret that holds the ibox credentials
+                    type: string
+                  hostname:
+                    description: Hostname is the host name of the ibox device
+                    type: string
+                  inbound_secret:
+                    type: string
+                  inbound_user:
+                    type: string
+                  outbound_secret:
+                    type: string
+                  outbound_user:
+                    type: string
+                  password:
+                    description: Password is the ibox password used for authentication
+                      to the ibox
+                    type: string
+                  username:
+                    description: Username is the ibox username used for authentication
+                      to the ibox
+                    type: string
+                type: object
+              csiDriverName:
+                type: string
+              csiDriverVersion:
+                type: string
+              e2etesting:
+                description: E2eTesting defaults to false, set to true to enable e2e
+                  testing
+                type: boolean
+              images:
+                description: Images are the various container images that the csi
+                  driver is composed of.
+                properties:
+                  attachersidecar:
+                    type: string
+                  attachersidecar_pull_policy:
+                    type: string
+                  csidriver:
+                    type: string
+                  csidriver_pull_policy:
+                    type: string
+                  kube-rbac-proxy:
+                    type: string
+                  kube-rbac-proxy_pull_policy:
+                    type: string
+                  livenesssidecar:
+                    type: string
+                  livenesssidecar_pull_policy:
+                    type: string
+                  provisionersidecar:
+                    type: string
+                  provisionersidecar_pull_policy:
+                    type: string
+                  registrarsidecar:
+                    type: string
+                  registrarsidecar_pull_policy:
+                    type: string
+                  resizersidecar:
+                    type: string
+                  resizersidecar_pull_policy:
+                    type: string
+                  snapshottersidecar:
+                    type: string
+                  snapshottersidecar_pull_policy:
+                    type: string
+                type: object
+              instanceCount:
+                type: integer
+              logLevel:
+                description: LogLevel determines the logging verbosity of the csi
+                  driver container
+                type: string
+              replicaCount:
+                type: integer
+              volumeNamePrefix:
+                description: VolumeNamePrefix is the prefix used for the volumes created
+                  on the ibox
+                type: string
+            type: object
+          status:
+            description: InfiniboxCsiDriverStatus defines the observed state of InfiniboxCsiDriver
+            properties:
+              conditions:
+                description: Conditions store the status conditions of the Memcached
+                  instances
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinibox-operator-certified.clusterserviceversion.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinibox-operator-certified.clusterserviceversion.yaml
@@ -372,4 +372,3 @@ spec:
       name: csi-node-driver-registrar-f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1-annotation
   version: 2.8.0
   replaces: infinibox-operator-certified.v2.7.0
-  

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinibox-operator-certified.clusterserviceversion.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinibox-operator-certified.clusterserviceversion.yaml
@@ -1,0 +1,375 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "csidriver.infinidat.com/v1alpha1",
+          "kind": "InfiniboxCsiDriver",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "infinibox-operator-certified",
+              "app.kubernetes.io/instance": "infiniboxcsidriver-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "infiniboxcsidriver",
+              "app.kubernetes.io/part-of": "infinibox-operator-certified"
+            },
+            "name": "infiniboxcsidriver-sample"
+          },
+          "spec": {
+            "Infinibox_Cred": {
+              "SecretName": "infinibox-creds",
+              "hostname": "ibox0000",
+              "inbound_secret": "0.0000000000000",
+              "inbound_user": "iqn.2020-06.com.csi-driver-iscsi.infinidat:commonout",
+              "outbound_secret": "0.0000000000000",
+              "outbound_user": "iqn.2020-06.com.csi-driver-iscsi.infinidat:commonin",
+              "password": "my-pool-admin-passwd",
+              "username": "my-pool-admin"
+            },
+            "csiDriverName": "infinibox-csi-driver",
+            "csiDriverVersion": "v2.8.0",
+            "e2etesting": false,
+            "images": {
+              "attachersidecar": "registry.k8s.io/sig-storage/csi-attacher@sha256:4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af",
+              "attachersidecar_pull_policy": "IfNotPresent",
+              "csidriver": "registry.connect.redhat.com/infinidat/infinibox-csidriver-certified@sha256:aa08be793dbc1a829443ee2c0322e99236bddc67f22b4b718bc69e351852bd8e",
+              "csidriver_pull_policy": "Always",
+              "kube-rbac-proxy": "gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f",
+              "kube-rbac-proxy_pull_policy": "IfNotPresent",
+              "livenesssidecar": "registry.k8s.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932",
+              "livenesssidecar_pull_policy": "IfNotPresent",
+              "provisionersidecar": "registry.k8s.io/sig-storage/csi-provisioner@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f",
+              "provisionersidecar_pull_policy": "IfNotPresent",
+              "registrarsidecar": "registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1",
+              "registrarsidecar_pull_policy": "IfNotPresent",
+              "resizersidecar": "registry.k8s.io/sig-storage/csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0",
+              "resizersidecar_pull_policy": "IfNotPresent",
+              "snapshottersidecar": "registry.k8s.io/sig-storage/csi-snapshotter@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771",
+              "snapshottersidecar_pull_policy": "IfNotPresent"
+            },
+            "instanceCount": 1,
+            "logLevel": "debug",
+            "replicaCount": 1,
+            "volumeNamePrefix": "csi"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    createdAt: "2023-08-11T18:49:32Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.31.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    certified: "true"
+    categories: Storage
+    containerImage: registry.connect.redhat.com/infinidat/infinibox-csidriver-certified@sha256:aa08be793dbc1a829443ee2c0322e99236bddc67f22b4b718bc69e351852bd8e
+    repository: https://github.com/Infinidat/infinibox-csi-driver
+    support: Infinidat
+  name: infinibox-operator-certified.v2.8.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - kind: InfiniboxCsiDriver
+        name: infiniboxcsidrivers.csidriver.infinidat.com
+        version: v1alpha1
+  description: "Infinidat InfiniBox Container Storage Interface (CSI) Driver is a\n    CNCF-compliant Kubernetes integration for InfiniBox storage systems, offering\n    advanced enterprise functionality for petabyte-scale Kubernetes deployments including\n    Red Hat OpenShift.\n \n## Features and Benefits\n  \n* **Multi-protocol flexibility** - manage\n    Kubernetes Persistent Volumes attached via block and file protocols,\n    including Fibre Channel, iSCSI, and NFS, with all Kubernetes PV access modes\n    \n* **Multi-petabyte scalability** - support hundreds of thousands of PVs per InfiniBox\n    system and control multiple InfiniBox arrays within a single Kubernetes cluster\n    \\ \n* **Advanced enterprise features** - manage native InfiniBox snapshots and\n    clones, including restoring from snapshots, and import PVs created outside of\n    InfiniBox CSI Driver\n  \n## Required Parameters\n  \n* `hostname` - IP address\n    or hostname of the InfiniBox management interface\n* `username` / `password` -\n    InfiniBox credentials\n* `SecretName` - secret name, to be used in the StorageClass\n    to define a specific InfiniBox for persistent volumes\n\n## Optional Parameters\n*\n    `inbound_user` / `inbound_secret` / `outbound_user` / `outbound_secret` - credentials \n    for iSCSI CHAP authentication\n\n    \n## Installation Instructions\n \n1. Create *infinidat-csi* namespace to install operator into.\n    \n2. Delete the following *clusterrolebindings*, if they exist, before installing operator\n     * infinidat-csi-operator-infinidat-csi-attacher\n     * infinidat-csi-operator-infinidat-csi-controller                     \n     * infinidat-csi-operator-infinidat-csi-driver                     \n     * infinidat-csi-operator-infinidat-csi-node                               \n     * infinidat-csi-operator-infinidat-csi-provisioner                        \n     * infinidat-csi-operator-infinidat-csi-resizer           \n     * infinidat-csi-operator-infinidat-csi-snapshotter \n    \n3. Install Infinidat Infinibox CSI Driver - Operator (this) into the *infinidat-csi* namespace.\n    \n4. Apply the following Security Context Constraints to the created service accounts in the *infinidat-csi* \n    namespace\n\n     * oc adm policy add-scc-to-user privileged -z infinidat-csi-operator-controller-manager\n\n     * oc adm policy add-scc-to-user privileged -z infinidat-csi-operator-infinidat-csi-driver\n\n     * oc adm policy add-scc-to-user privileged -z infinidat-csi-operator-infinidat-csi-node\n\n     * oc adm policy add-scc-to-user privileged -z infinidat-csi-operator-infinidat-csi-controller\n\n     * oc adm policy add-scc-to-user anyuid -z infinidat-csi-operator-controller-manager\n\n     * oc adm policy add-scc-to-user anyuid -z infinidat-csi-operator-infinidat-csi-driver\n\n     * oc adm policy add-scc-to-user anyuid -z infinidat-csi-operator-infinidat-csi-node\n\n     * oc adm policy add-scc-to-user anyuid -z infinidat-csi-operator-infinidat-csi-controller\n\n     * oc adm policy add-scc-to-user hostnetwork -z infinidat-csi-operator-controller-manager\n\n     * oc adm policy add-scc-to-user hostnetwork -z infinidat-csi-operator-infinidat-csi-driver\n\n     * oc adm policy add-scc-to-user hostnetwork -z infinidat-csi-operator-infinidat-csi-node\n\n     * oc adm policy add-scc-to-user hostnetwork -z infinidat-csi-operator-infinidat-csi-controller\n\n     \n5. Recreate or edit any existing storage classes, pointing to the new namespace\n\n     \n6. Install an instance of Infinidat Driver into the *infinidat-csi* namespace"
+  displayName: InfiniBox CSI Driver - Operator
+  icon:
+    - base64data: "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4wICg0MDM1YTRmLCAyMDIwLTA1LTAxKSIKICAgc29kaXBvZGk6ZG9jbmFtZT0iSW5maW5pZGF0LUxvZ28tU29saWQgdGVzdC5zdmciCiAgIGlkPSJzdmcxNSIKICAgdmVyc2lvbj0iMS4yIgogICB2aWV3Qm94PSIwIDAgNjAuMDAwMDA2IDMwIgogICBoZWlnaHQ9IjQwIgogICB3aWR0aD0iODAiPgogIDxtZXRhZGF0YQogICAgIGlkPSJtZXRhZGF0YTIxIj4KICAgIDxyZGY6UkRGPgogICAgICA8Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+CiAgICAgICAgPGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+CiAgICAgICAgPGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPgogICAgICAgIDxkYzp0aXRsZT48L2RjOnRpdGxlPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZGVmcwogICAgIGlkPSJkZWZzMTkiIC8+CiAgPHNvZGlwb2RpOm5hbWVkdmlldwogICAgIHVuaXRzPSJweCIKICAgICBpbmtzY2FwZTpwYWdlY2hlY2tlcmJvYXJkPSJmYWxzZSIKICAgICBpbmtzY2FwZTpjdXJyZW50LWxheWVyPSJzdmcxNSIKICAgICBpbmtzY2FwZTp3aW5kb3ctbWF4aW1pemVkPSIxIgogICAgIGlua3NjYXBlOndpbmRvdy15PSIyMyIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMCIKICAgICBpbmtzY2FwZTpjeT0iMjAiCiAgICAgaW5rc2NhcGU6Y3g9IjM4LjQ0Mjk1MyIKICAgICBpbmtzY2FwZTp6b29tPSIxOC42MjUiCiAgICAgc2hvd2dyaWQ9ImZhbHNlIgogICAgIGlkPSJuYW1lZHZpZXcxNyIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSIxMDM1IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTkyMCIKICAgICBpbmtzY2FwZTpwYWdlc2hhZG93PSIyIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwIgogICAgIGd1aWRldG9sZXJhbmNlPSIxMCIKICAgICBncmlkdG9sZXJhbmNlPSIxMCIKICAgICBvYmplY3R0b2xlcmFuY2U9IjEwIgogICAgIGJvcmRlcm9wYWNpdHk9IjEiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIiAvPgogIDxnCiAgICAgdHJhbnNmb3JtPSJtYXRyaXgoMC4wMzI1OTExOSwwLDAsMC4wMzI1OTExOSwwLDkuMjgyNjY1OCkiCiAgICAgaWQ9InN1cmZhY2UyNzk1Ij4KICAgIDxwYXRoCiAgICAgICBpZD0icGF0aDEwIgogICAgICAgZD0iTSAxODQwLjk4ODMsMzUwLjg1MTU2IEggMCBWIDAgaCAxODQwLjk4ODMgdiAzNTAuODUxNTYiCiAgICAgICBzdHlsZT0iZmlsbDojMmI3ZDgyO2ZpbGwtb3BhY2l0eToxO2ZpbGwtcnVsZTpub256ZXJvO3N0cm9rZTpub25lIiAvPgogICAgPHBhdGgKICAgICAgIGlkPSJwYXRoMTIiCiAgICAgICBkPSJtIDE1My42NTYyNSw5OS4zNDM3NSBoIC0yNS42OTE0MSB2IDE2MC4wMTk1MyBoIDI1LjY5MTQxIHogbSAxMDMuOTQ1MzEsMTYwLjAxOTUzIHYgLTk0LjI2NTYyIGMgMCwtMTMuODM5ODUgLTAuNjAxNTYsLTI1LjUzMTI1IC0xLjgwMDc4LC0zNS4wMzkwNyAyLjE4NzUsMy45Mzc1IDQuODc1LDcuNTQyOTcgOC4wNzAzMSwxMC44NTE1NyAwLjU4MjAzLDAuNjIxMDkgMy4wNzgxMywyLjk5NjA5IDcuNDUzMTMsNy4xMzY3MSBsIDExOC41NzgxMiwxMTEuMzE2NDEgaCAxNC4zNDM3NSBWIDk5LjM0Mzc1IGggLTIzLjkwNjI1IHYgODcuNzU3ODEgYyAwLDE2LjMzOTg1IDAuNzk2ODgsMjkuNDgwNDcgMi40MTc5NywzOS4zODI4MSAtNi4xNjAxNSwtOC4yNSAtMTIuMDQ2ODcsLTE0Ljk4NDM3IC0xNy42MjEwOSwtMjAuMTQ0NTMgTCAyNDkuODE2NDEsOTkuMzQzNzUgaCAtMTYuMTI1IHYgMTYwLjAxOTUzIHogbSAyNTIuMDY2NDEsMCB2IC02NC41IGggNjguOTk2MDkgViAxNzMuNDcyNjYgSCA1MDkuNjY3OTcgViAxMjEuMDY2NDEgSCA2MzAuNjIxMDkgViA5OS4zNDM3NSBIIDQ4My45NzI2NiBWIDI1OS4zNjMyOCBaIE0gNjk5LjkxNDA2LDk5LjM0Mzc1IGggLTI1LjY5MTQgdiAxNjAuMDE5NTMgaCAyNS42OTE0IHogbSAxMDMuOTIxODgsMTYwLjAxOTUzIHYgLTk0LjI2NTYyIGMgMCwtMTMuODM5ODUgLTAuNTgyMDMsLTI1LjUzMTI1IC0xLjc3NzM1LC0zNS4wMzkwNyAyLjE4MzYsMy45Mzc1IDQuODc1LDcuNTQyOTcgOC4wNzAzMiwxMC44NTE1NyAwLjU4MjAzLDAuNjIxMDkgMy4wNzgxMiwyLjk5NjA5IDcuNDUzMTIsNy4xMzY3MSBsIDExOC41NzQyMiwxMTEuMzE2NDEgaCAxNC4zMzU5NCBWIDk5LjM0Mzc1IGggLTIzLjg5NDUzIHYgODcuNzU3ODEgYyAwLDE2LjMzOTg1IDAuNzk2ODcsMjkuNDgwNDcgMi40MTQwNiwzOS4zODI4MSAtNi4xNzE4OCwtOC4yNSAtMTIuMDM5MDYsLTE0Ljk4NDM3IC0xNy42MTcxOSwtMjAuMTQ0NTMgTCA3OTYuMDc0MjIsOTkuMzQzNzUgSCA3NzkuOTQ1MzEgViAyNTkuMzYzMjggWiBNIDEwNTUuOTE4LDk5LjM0Mzc1IGggLTI1LjY5MTQgdiAxNjAuMDE5NTMgaCAyNS42OTE0IHogbSA4MC4wMzksMCB2IDE2MC4wMTk1MyBoIDg0LjgxNjQgYyAyNy4yOTMsMCA0Ni45ODQ0LC00LjE0MDYyIDU5LjE0NDYsLTEyLjQwMjM0IDIxLjMxMjUsLTE0LjQ5MjE5IDMxLjk2MDksLTM3LjMwODYgMzEuOTYwOSwtNjguNTQ2ODggMCwtMTQuMjY1NjIgLTIuODM1OSwtMjcuMjUzOSAtOC41MTE3LC0zOS4wNTQ2OSAtNS42NzE5LC0xMS43ODkwNiAtMTMuNSwtMjAuOTc2NTYgLTIzLjQ0OTIsLTI3LjYxNzE4IC0xMi4zNDc3LC04LjI1MzkxIC0zMi4wNDMsLTEyLjM5ODQ0IC01OS4xNDQ2LC0xMi4zOTg0NCB6IG0gMTMyLjU5NzcsMzMuODQzNzUgYyAxMS4zNjMzLDguOTIxODcgMTcuMDM1MSwyMy45Mjk2OSAxNy4wMzUxLDQ1LjA4NTk0IDAsMjEuOTUzMTIgLTUuNjcxOCwzNy40MDIzNCAtMTcuMDM1MSw0Ni4zMjgxMiAtMTAuMzYzMyw4LjI5Mjk3IC0yNy40NjA5LDEyLjQyOTY5IC01MS4zNjcyLDEyLjQyOTY5IGggLTU1LjUzNTIgViAxMjAuNzQ2MDkgaCA1NS41MzUyIGMgMjMuNzAzMSwwIDQwLjgxNjQsNC4xNjQwNyA1MS4zNjcyLDEyLjQ0MTQxIG0gMTAzLjk2MDksMTI2LjE3NTc4IDE5LjY5MTQsLTM5LjM5NDUzIGggMTA0LjI0NjEgbCAxOS42OTUzLDM5LjM5NDUzIGggMjguNDAyNCBMIDE0NTguNzkzLDk5LjM0Mzc1IGggLTI3LjQ1MzIgbCAtODQuMjIyNiwxNjAuMDE5NTMgeiBNIDE0NDQuNDk2MSwxMTcuNjQwNjMgMTQ4NiwxOTkuNTI3MzQgaCAtODMuMDMxMiB6IG0gMjgwLjQxOCwzLjQyNTc4IFYgOTkuMzQzNzUgaCAtMTY2LjkzMzYgdiAyMS43MjI2NiBoIDcwLjQ2NDggdiAxMzguMjk2ODcgaCAyNS42ODM2IFYgMTIxLjA2NjQxIGggNzAuNzg1MiIKICAgICAgIHN0eWxlPSJmaWxsOiNmZmZmZmY7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiIC8+CiAgPC9nPgo8L3N2Zz4K"
+      mediatype: "image/svg+xml"
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - csidriver.infinidat.com
+              resources:
+                - infiniboxcsidrivers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - csidriver.infinidat.com
+              resources:
+                - infiniboxcsidrivers/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - csidriver.infinidat.com
+              resources:
+                - infiniboxcsidrivers/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - privileged
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: infinidat-csi-operator-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/component: manager
+            app.kubernetes.io/created-by: infinibox-operator-certified
+            app.kubernetes.io/instance: controller-manager
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: deployment
+            app.kubernetes.io/part-of: infinibox-operator-certified
+            control-plane: controller-manager
+          name: infinidat-csi-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - arm64
+                                - ppc64le
+                                - s390x
+                            - key: kubernetes.io/os
+                              operator: In
+                              values:
+                                - linux
+                containers:
+                  - args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
+                    name: kube-rbac-proxy
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                  - args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=127.0.0.1:8080
+                      - --leader-elect
+                    command:
+                      - /manager
+                    image: registry.connect.redhat.com/infinidat/infinibox-operator-certified@sha256:f220f6d2e955864acd8443a858909f6bbb760003774a266e1855ed33df0e7e9a
+                    imagePullPolicy: Always
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    env:
+                      - name: CSI_OPERATOR_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: infinidat-csi-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - clusterserviceversions
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: infinidat-csi-operator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - csi
+    - nas
+    - san
+    - storage
+    - infinidat
+    - infinibox
+  links:
+    - name: Infinidat
+      url: https://infinidat.com
+  maintainers:
+    - email: info@infinidat.com
+      name: Infinidat
+  maturity: stable
+  provider:
+    name: Infinidat
+    url: https://infinidat.com
+  relatedImages:
+    - image: registry.connect.redhat.com/infinidat/infinibox-operator-certified@sha256:f220f6d2e955864acd8443a858909f6bbb760003774a266e1855ed33df0e7e9a
+      name: manager
+    - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
+      name: csi-provisioner-d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f-annotation
+    - image: registry.k8s.io/sig-storage/livenessprobe@sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932
+      name: livenessprobe-406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932-annotation
+    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
+      name: kube-rbac-proxy-d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f-annotation
+    - image: registry.k8s.io/sig-storage/csi-attacher@sha256:4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af
+      name: csi-attacher-4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af-annotation
+    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
+      name: kube-rbac-proxy
+    - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771
+      name: csi-snapshotter-714aa06ccdd3781f1a76487e2dc7592ece9a12ae9e0b726e4f93d1639129b771-annotation
+    - image: registry.k8s.io/sig-storage/csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
+      name: csi-resizer-2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0-annotation
+    - image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1
+      name: csi-node-driver-registrar-f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1-annotation
+  version: 2.8.0
+  replaces: infinibox-operator-certified.v2.7.0
+  

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: infinidat-csi-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: infinidat-csi-operator
+    control-plane: controller-manager
+  name: infinidat-csi-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-attacher_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-attacher_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-attacher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-attacher_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-attacher_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-attacher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: infinidat-csi-operator-infinidat-csi-attacher
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-controller
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,183 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodeinfos
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - delete
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - delete
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - list
+  - watch
+  - delete
+  - get
+  - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: infinidat-csi-operator-infinidat-csi-controller
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-controller
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-controller_v1_serviceaccount.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-controller_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-controller

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-node_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-node_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,81 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-node
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumesclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: infinidat-csi-operator-infinidat-csi-node
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-node
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-node_v1_serviceaccount.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-node_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-node

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,81 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-provisioner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: infinidat-csi-operator-infinidat-csi-provisioner
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-controller
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-resizer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-resizer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: infinidat-csi-operator-infinidat-csi-resizer
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-controller
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter-lease_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter-lease_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-snapshotter-lease
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter-lease_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter-lease_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-snapshotter-lease
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: infinidat-csi-operator-infinidat-csi-snapshotter-lease
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-controller
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-snapshotter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-infinidat-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: infinidat-csi-operator-infinidat-csi-snapshotter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: infinidat-csi-operator-infinidat-csi-snapshotter
+subjects:
+- kind: ServiceAccount
+  name: infinidat-csi-operator-infinidat-csi-controller
+  namespace: infinidat-csi

--- a/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/manifests/infinidat-csi-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: infinidat-csi-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: infinidat-csi-operator
+  name: infinidat-csi-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/infinibox-operator-certified/v2.8.0/metadata/annotations.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: infinibox-operator-certified
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.13
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/operators/infinibox-operator-certified/v2.8.0/tests/scorecard/config.yaml
+++ b/operators/infinibox-operator-certified/v2.8.0/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Add back the infinibox-operator-certified v2.8.0 operator bundle, but with a "replaces" clause so that v2.7.0 will remain in the bundle indexes. Requested in support case 03608988.