### PR TITLE
operator sriov-fec (v2.7.1)

### DIFF
--- a/operators/sriov-fec/v2.7.1/manifests/sriov-fec-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriov-fec-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: sriov-fec-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/sriov-fec/v2.7.1/manifests/sriov-fec-manager-config_v1_configmap.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriov-fec-manager-config_v1_configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    # SPDX-License-Identifier: Apache-2.0
+    # Copyright (c) 2021 Intel Corporation
+
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: bab0ab5c.intel.com
+kind: ConfigMap
+metadata:
+  name: sriov-fec-manager-config

--- a/operators/sriov-fec/v2.7.1/manifests/sriov-fec-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriov-fec-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: sriov-fec-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/sriov-fec/v2.7.1/manifests/sriov-fec-webhook-service_v1_service.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriov-fec-webhook-service_v1_service.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: sriov-fec-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/sriov-fec/v2.7.1/manifests/sriov-fec.clusterserviceversion.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriov-fec.clusterserviceversion.yaml
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "sriovfec.intel.com/v2",
+          "kind": "SriovFecClusterConfig",
+          "metadata": {
+            "name": "acc100SampleConfig",
+            "namespace": "vran-acceleration-operators"
+          },
+          "spec": {
+            "acceleratorSelector": {
+              "deviceID": "someDevice",
+              "driver": "someDriver",
+              "maxVirtualFunctions": 2,
+              "pciAddress": "somePciAddress",
+              "vendorID": "someVendor"
+            },
+            "drainSkip": false,
+            "nodeSelector": {
+              "expectedLabel1": "valueOfExpectedLabel1",
+              "expectedLabelN": "valueOfExpectedLabelN"
+            },
+            "physicalFunction": {
+              "bbDevConfig": {
+                "acc100": {
+                  "downlink4G": {
+                    "aqDepthLog2": 4,
+                    "numAqsPerGroups": 16,
+                    "numQueueGroups": 0
+                  },
+                  "downlink5G": {
+                    "aqDepthLog2": 4,
+                    "numAqsPerGroups": 16,
+                    "numQueueGroups": 4
+                  },
+                  "maxQueueSize": 1024,
+                  "numVfBundles": 16,
+                  "pfMode": true,
+                  "uplink4G": {
+                    "aqDepthLog2": 4,
+                    "numAqsPerGroups": 16,
+                    "numQueueGroups": 0
+                  },
+                  "uplink5G": {
+                    "aqDepthLog2": 4,
+                    "numAqsPerGroups": 16,
+                    "numQueueGroups": 4
+                  }
+                }
+              },
+              "pfDriver": "pci-pf-stub",
+              "vfAmount": 2,
+              "vfDriver": "vfio-pci"
+            },
+            "priority": 100
+          }
+        },
+        {
+          "apiVersion": "sriovfec.intel.com/v2",
+          "kind": "SriovFecClusterConfig",
+          "metadata": {
+            "name": "n3000SampleConfig",
+            "namespace": "vran-acceleration-operators"
+          },
+          "spec": {
+            "acceleratorSelector": {
+              "deviceID": "someDevice",
+              "driver": "someDriver",
+              "maxVirtualFunctions": 2,
+              "pciAddress": "somePciAddress",
+              "vendorID": "someVendor"
+            },
+            "drainSkip": false,
+            "nodeSelector": {
+              "expectedLabel1": "valueOfExpectedLabel1",
+              "expectedLabelN": "valueOfExpectedLabelN"
+            },
+            "physicalFunction": {
+              "bbDevConfig": {
+                "n3000": {
+                  "downlink": {
+                    "bandwidth": 3,
+                    "loadBalance": 128,
+                    "queues": {
+                      "vf0": 16,
+                      "vf1": 16,
+                      "vf2": 0,
+                      "vf3": 0,
+                      "vf4": 0,
+                      "vf5": 0,
+                      "vf6": 0,
+                      "vf7": 0
+                    }
+                  },
+                  "flrTimeout": 610,
+                  "networkType": "FPGA_5GNR",
+                  "pfMode": true,
+                  "uplink": {
+                    "bandwidth": 3,
+                    "loadBalance": 128,
+                    "queues": {
+                      "vf0": 16,
+                      "vf1": 16,
+                      "vf2": 0,
+                      "vf3": 0,
+                      "vf4": 0,
+                      "vf5": 0,
+                      "vf6": 0,
+                      "vf7": 0
+                    }
+                  }
+                }
+              },
+              "pfDriver": "pci-pf-stub",
+              "vfAmount": 2,
+              "vfDriver": "vfio-pci"
+            },
+            "priority": 100
+          }
+        },
+        {
+          "apiVersion": "sriovfec.intel.com/v2",
+          "kind": "SriovFecNodeConfig",
+          "metadata": {
+            "name": "acc100-worker",
+            "namespace": "vran-acceleration-operators"
+          },
+          "spec": {
+            "drainSkip": false,
+            "physicalFunctions": [
+              {
+                "bbDevConfig": {
+                  "acc100": {
+                    "downlink4G": {
+                      "aqDepthLog2": 4,
+                      "numAqsPerGroups": 16,
+                      "numQueueGroups": 0
+                    },
+                    "downlink5G": {
+                      "aqDepthLog2": 4,
+                      "numAqsPerGroups": 16,
+                      "numQueueGroups": 4
+                    },
+                    "maxQueueSize": 1024,
+                    "numVfBundles": 16,
+                    "pfMode": true,
+                    "uplink4G": {
+                      "aqDepthLog2": 4,
+                      "numAqsPerGroups": 16,
+                      "numQueueGroups": 0
+                    },
+                    "uplink5G": {
+                      "aqDepthLog2": 4,
+                      "numAqsPerGroups": 16,
+                      "numQueueGroups": 4
+                    }
+                  }
+                },
+                "pci_addr": "somePciAddress",
+                "pf_driver": "pci-pf-stub",
+                "vf_amount": 2,
+                "vf_driver": "vfio-pci"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "sriovfec.intel.com/v2",
+          "kind": "SriovFecNodeConfig",
+          "metadata": {
+            "name": "n3000-worker",
+            "namespace": "vran-acceleration-operators"
+          },
+          "spec": {
+            "drainSkip": false,
+            "physicalFunctions": [
+              {
+                "bbDevConfig": {
+                  "n3000": {
+                    "downlink": {
+                      "bandwidth": 3,
+                      "loadBalance": 128,
+                      "queues": {
+                        "vf0": 16,
+                        "vf1": 16,
+                        "vf2": 0,
+                        "vf3": 0,
+                        "vf4": 0,
+                        "vf5": 0,
+                        "vf6": 0,
+                        "vf7": 0
+                      }
+                    },
+                    "flrTimeout": 610,
+                    "networkType": "FPGA_5GNR",
+                    "pfMode": true,
+                    "uplink": {
+                      "bandwidth": 3,
+                      "loadBalance": 128,
+                      "queues": {
+                        "vf0": 16,
+                        "vf1": 16,
+                        "vf2": 0,
+                        "vf3": 0,
+                        "vf4": 0,
+                        "vf5": 0,
+                        "vf6": 0,
+                        "vf7": 0
+                      }
+                    }
+                  }
+                },
+                "pci_addr": "somePciAddress",
+                "pf_driver": "pci-pf-stub",
+                "vf_amount": 2,
+                "vf_driver": "vfio-pci"
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Networking
+    containerImage: registry.connect.redhat.com/intel/sriov-fec-operator@sha256:db8c83f7b36b911fdf98978b882c9d82be707764223aa6908abfba4b48c7186e
+    createdAt: "2023-08-16"
+    description: An operator for Intel Wireless FEC Accelerator to orchestrate and
+      manage the resources/devices exposed by a range of Intel's vRAN FEC acceleration
+      devices/hardware within the OpenShift cluster.
+    operators.operatorframework.io/builder: operator-sdk-v1.25.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/smart-edge-open/sriov-fec-operator
+    support: Intel Corporation
+  name: sriov-fec.v2.7.1
+  namespace: placeholder
+spec:
+  relatedImages:
+    - name: sriov-fec-daemon
+      image: registry.connect.redhat.com/intel/sriov-fec-daemon@sha256:e4e2464213db805366fadeeae63d82b83db5e1b6456a606611f84db4295baa45
+    - name: sriov-fec-labeler
+      image: registry.connect.redhat.com/intel/n3000-labeler@sha256:ca8966a90b29beb99a23a22e27e120c6f57b91a90dabbb69670b053ee6d79992
+    - name: sriov-network-device-plugin
+      image: registry.redhat.io/openshift4/ose-sriov-network-device-plugin@sha256:d112012b93db88465e43efbacdb9d96a923febbfbc939e69e6db2b8e0f74c14c
+    - name: sriov-fec-operator
+      image: registry.connect.redhat.com/intel/sriov-fec-operator@sha256:db8c83f7b36b911fdf98978b882c9d82be707764223aa6908abfba4b48c7186e
+    - name: kube-rbac-proxy
+      image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:8307f2210206acdcb87f2a44952d5464f059fe6f763b6b11d24739d58c804057
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: SriovFecClusterConfig is the Schema for the sriovfecclusterconfigs
+        API
+      displayName: SriovFecClusterConfig
+      kind: SriovFecClusterConfig
+      name: sriovfecclusterconfigs.sriovfec.intel.com
+      resources:
+      - kind: SriovFecNodeConfig
+        name: node
+        version: v2
+      specDescriptors:
+      - description: Selector describes target accelerator for this spec
+        displayName: Accelerator Selector
+        path: acceleratorSelector
+      - description: Skips drain process when true; default false. Should be true
+          if operator is running on SNO
+        displayName: Drain Skip
+        path: drainSkip
+      - description: Selector describes target node for this spec
+        displayName: Node Selector
+        path: nodeSelector
+      - description: Physical function (card) config
+        displayName: Physical Function
+        path: physicalFunction
+      - description: Higher priority policies can override lower ones.
+        displayName: Priority
+        path: priority
+      statusDescriptors:
+      - description: Indicates the synchronization status of the CR
+        displayName: Sync Status
+        path: syncStatus
+      version: v2
+    - description: SriovFecNodeConfig is the Schema for the sriovfecnodeconfigs API
+      displayName: SriovFecNodeConfig
+      kind: SriovFecNodeConfig
+      name: sriovfecnodeconfigs.sriovfec.intel.com
+      resources:
+      - kind: SriovFecNodeConfig
+        name: node
+        version: v1
+      specDescriptors:
+      - description: Skips drain process when true; default false. Should be true
+          if operator is running on SNO
+        displayName: Drain Skip
+        path: drainSkip
+      - description: List of PhysicalFunctions configs
+        displayName: Physical Functions
+        path: physicalFunctions
+      statusDescriptors:
+      - description: Provides information about FPGA inventory on the node
+        displayName: Inventory
+        path: inventory
+      version: v2
+  description: "The vRAN Dedicated Accelerator ACC100, based on Intel eASIC technology
+    is designed to offload and accelerate the computing-intensive process of forward
+    error correction (FEC) for 4G/LTE and 5G technology, freeing up processing power.
+    Intel eASIC devices are structured ASICs, an intermediate technology between FPGAs
+    and standard application-specific integrated circuits (ASICs). It allows the optimization
+    of data plane performance to reduce total cost of ownership while maintaining
+    a high degree of flexibility.  The Intel ACC100 and ACC200 plays a key role in
+    accelerating 5G and network functions virtualization (NFV) adoption for ecosystem
+    partners such as telecommunications equipment manufacturers (TEMs) virtual network
+    functions (VNF) vendors, system integrators and telcos, to bring scalable and
+    high-performance solutions to market. The Intel ACC100 includes a variant that
+    is design to be Network Equipment Building System (NEBS)-friendly, and features
+    a Root-of-Trust device that helps protect systems from FPGA host security exploits.
+    This document explains how the ACC100 resource can be used on the Intel© platform
+    for accelerating network functions and edge application workloads. We use LTE/5G
+    Forward Error Correction (FEC) as an example workload that accelerates the 5G
+    or 4G L1 base station network function. The same concept and mechanism is applicable
+    for application acceleration workloads like AI and ML on eASIC for Inference applications.
+    The ACC100 supports the O-RAN adopted DPDK BBDev API - an API which Intel contributed
+    to the opensource community to enable choice and TTM for FEC acceleration solutions.
+    The FlexRAN software reference architecture supports the ACC100 which enables
+    users to quickly evaluate and build platforms for the wide range of vRAN networks.
+    Reduces platform power, E2E latency and Intel® CPU core count requirements as
+    well as increases cell capacity than existing programmable accelerator. Accelerates
+    both 4G and 5G data concurrently.\tLowers development cost using commercial off
+    the shelf (COTS) servers. Accommodates space-constrained implementations via a
+    low-profile PCIe card form factor. Enables a variety of flexible FlexRAN deployments
+    from small cell to macro to Massive MIMO networks. Supports extended temperature
+    for the most challenging of RAN deployment scenario’s."
+  displayName: SR-IOV Operator for Wireless FEC Accelerators
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI0LjMuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA3MiAzMCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNzIgMzA7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojMDA2OEI1O30KPC9zdHlsZT4KPGc+Cgk8cmVjdCB4PSIxLjgiIHk9IjIuMSIgY2xhc3M9InN0MCIgd2lkdGg9IjQuOTYiIGhlaWdodD0iNC45NiIvPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTYuNjMsMjcuOVYxMC4wNmgtNC43VjI3LjlINi42M3ogTTM3Ljc4LDI4LjA4di00LjM3Yy0wLjY5LDAtMS4yNi0wLjA0LTEuNy0wLjExCgkJYy0wLjQ4LTAuMDgtMC44Ni0wLjI0LTEuMS0wLjQ5Yy0wLjI1LTAuMjUtMC40MS0wLjYxLTAuNDktMS4wN2MtMC4wNy0wLjQ0LTAuMTEtMS4wMi0wLjExLTEuNzJ2LTYuMjRoMy40di00LjAyaC0zLjRWMy4xMWgtNC43CgkJdjE3LjI0YzAsMS40NSwwLjEzLDIuNjksMC4zOCwzLjY4YzAuMjUsMC45NywwLjY3LDEuNzcsMS4yNSwyLjM3YzAuNTgsMC42LDEuMzYsMS4wMywyLjI5LDEuMjljMC45NSwwLjI2LDIuMTUsMC4zOSwzLjU4LDAuMzkKCQlIMzcuNzh6IE02NC43MSwyNy45VjEuNzRoLTQuN1YyNy45SDY0LjcxeiBNMjUuMTUsMTEuODJDMjMuODQsMTAuNDEsMjIsOS43LDE5LjY4LDkuN2MtMS4xMiwwLTIuMTYsMC4yMy0zLjA4LDAuNjkKCQljLTAuOTIsMC40Ni0xLjcxLDEuMS0yLjMzLDEuOWwtMC4yNiwwLjMzbDAtMC4zdi0yLjI2SDkuMzdWMjcuOWg0LjY3di05LjVsMCwwLjY2YzAtMC4xMSwwLTAuMjIsMC0wLjMyCgkJYzAuMDUtMS42NywwLjQ2LTIuOTEsMS4yNC0zLjdjMC44My0wLjg0LDEuODMtMS4yNywyLjk4LTEuMjdjMS4zNiwwLDIuMzksMC40MiwzLjA4LDEuMjNjMC42NywwLjgsMS4wMSwxLjk1LDEuMDIsMy40MmwwLDB2MC4wNAoJCWMwLDAsMCwwLjAxLDAsMC4wMWgwbDAsOS40M2g0Ljc0VjE3Ljc3QzI3LjExLDE1LjIzLDI2LjQ1LDEzLjIzLDI1LjE1LDExLjgyeiBNNTcuNTYsMTguOTRjMC0xLjI4LTAuMjMtMi40OS0wLjY4LTMuNjEKCQljLTAuNDUtMS4xMS0xLjA5LTIuMS0xLjg5LTIuOTVjLTAuOC0wLjg0LTEuNzgtMS41MS0yLjkxLTEuOThDNTAuOTYsOS45NCw0OS43LDkuNyw0OC4zNSw5LjdjLTEuMjgsMC0yLjUsMC4yNS0zLjYyLDAuNzMKCQljLTEuMTMsMC40OS0yLjEyLDEuMTUtMi45NSwxLjk4Yy0wLjgzLDAuODMtMS41LDEuODItMS45OCwyLjk1Yy0wLjQ5LDEuMTItMC43MywyLjM0LTAuNzMsMy42MmMwLDEuMjgsMC4yMywyLjUsMC43LDMuNjIKCQljMC40NiwxLjEzLDEuMTEsMi4xMiwxLjkzLDIuOTRjMC44MiwwLjgzLDEuODIsMS41LDIuOTgsMS45OGMxLjE2LDAuNDksMi40NSwwLjczLDMuODIsMC43M2MzLjk4LDAsNi40Ni0xLjgxLDcuOTQtMy41bC0zLjM4LTIuNTgKCQljLTAuNzEsMC44NS0yLjQsMS45OS00LjUyLDEuOTljLTEuMzMsMC0yLjQyLTAuMzEtMy4yNC0wLjkxYy0wLjgzLTAuNjEtMS40LTEuNDQtMS43LTIuNDhsLTAuMDUtMC4xN2gxNC4wMVYxOC45NHogTTQzLjU5LDE3LjMxCgkJYzAtMS4zMSwxLjUtMy41OSw0LjczLTMuNTljMy4yMywwLDQuNzMsMi4yOCw0LjczLDMuNThMNDMuNTksMTcuMzF6Ii8+Cgk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNzAuMDYsMjUuNjVjLTAuMDktMC4yMS0wLjIyLTAuMzktMC4zNy0wLjU1Yy0wLjE2LTAuMTYtMC4zNC0wLjI4LTAuNTUtMC4zN2MtMC4yMS0wLjA5LTAuNDQtMC4xNC0wLjY4LTAuMTQKCQljLTAuMjQsMC0wLjQ3LDAuMDUtMC42OCwwLjE0Yy0wLjIxLDAuMDktMC4zOSwwLjIyLTAuNTUsMC4zN2MtMC4xNiwwLjE2LTAuMjgsMC4zNC0wLjM3LDAuNTVjLTAuMDksMC4yMS0wLjE0LDAuNDQtMC4xNCwwLjY4CgkJYzAsMC4yNCwwLjA1LDAuNDcsMC4xNCwwLjY4YzAuMDksMC4yMSwwLjIyLDAuMzksMC4zNywwLjU1YzAuMTYsMC4xNiwwLjM0LDAuMjgsMC41NSwwLjM3YzAuMjEsMC4wOSwwLjQ0LDAuMTQsMC42OCwwLjE0CgkJYzAuMjQsMCwwLjQ3LTAuMDUsMC42OC0wLjE0YzAuMjEtMC4wOSwwLjM5LTAuMjIsMC41NS0wLjM3YzAuMTYtMC4xNiwwLjI4LTAuMzQsMC4zNy0wLjU1YzAuMDktMC4yMSwwLjE0LTAuNDQsMC4xNC0wLjY4CgkJQzcwLjIsMjYuMDksNzAuMTUsMjUuODYsNzAuMDYsMjUuNjV6IE02OS43OCwyNi44OGMtMC4wNywwLjE3LTAuMTgsMC4zMy0wLjMxLDAuNDZjLTAuMTMsMC4xMy0wLjI4LDAuMjMtMC40NiwwLjMxCgkJYy0wLjE3LDAuMDctMC4zNiwwLjExLTAuNTYsMC4xMWMtMC4yLDAtMC4zOC0wLjA0LTAuNTYtMC4xMWMtMC4xNy0wLjA3LTAuMzMtMC4xOC0wLjQ2LTAuMzFjLTAuMTMtMC4xMy0wLjIzLTAuMjgtMC4zMS0wLjQ2CgkJYy0wLjA3LTAuMTctMC4xMS0wLjM2LTAuMTEtMC41NmMwLTAuMiwwLjA0LTAuMzgsMC4xMS0wLjU2YzAuMDctMC4xNywwLjE4LTAuMzMsMC4zMS0wLjQ2YzAuMTMtMC4xMywwLjI4LTAuMjMsMC40Ni0wLjMxCgkJYzAuMTctMC4wNywwLjM2LTAuMTEsMC41Ni0wLjExYzAuMiwwLDAuMzgsMC4wNCwwLjU2LDAuMTFjMC4xNywwLjA3LDAuMzMsMC4xOCwwLjQ2LDAuMzFjMC4xMywwLjEzLDAuMjMsMC4yOCwwLjMxLDAuNDYKCQljMC4wNywwLjE3LDAuMTEsMC4zNiwwLjExLDAuNTZDNjkuODksMjYuNTIsNjkuODUsMjYuNzEsNjkuNzgsMjYuODh6IE02OC43OSwyNi40N2MwLjE0LTAuMDIsMC4yNS0wLjA3LDAuMzQtMC4xNQoJCWMwLjA5LTAuMDksMC4xMy0wLjIyLDAuMTMtMC4zOWMwLTAuMTktMC4wNi0wLjM0LTAuMTctMC40NGMtMC4xMS0wLjEtMC4yOS0wLjE1LTAuNTMtMC4xNWgtMC43N3YxLjk5aDAuMzZ2LTAuODFoMC4yN2wwLjUsMC44MQoJCWgwLjM4TDY4Ljc5LDI2LjQ3eiBNNjguNTksMjYuMThjLTAuMDYsMC0wLjExLDAuMDEtMC4xNywwLjAxaC0wLjI3di0wLjU2aDAuMjdjMC4wNiwwLDAuMTEsMCwwLjE3LDBjMC4wNiwwLDAuMTEsMC4wMSwwLjE1LDAuMDMKCQljMC4wNSwwLjAyLDAuMDgsMC4wNSwwLjExLDAuMDhjMC4wMywwLjA0LDAuMDQsMC4wOSwwLjA0LDAuMTVzLTAuMDEsMC4xMi0wLjA0LDAuMTVjLTAuMDMsMC4wNC0wLjA2LDAuMDctMC4xMSwwLjA4CgkJQzY4LjcsMjYuMTYsNjguNjUsMjYuMTcsNjguNTksMjYuMTh6Ii8+CjwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - namespaces
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/finalizers
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - sriovfec.intel.com
+          resources:
+          - sriovfecclusterconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sriovfec.intel.com
+          resources:
+          - sriovfecclusterconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - sriovfec.intel.com
+          resources:
+          - sriovfecnodeconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sriovfec.intel.com
+          resources:
+          - sriovfecnodeconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: controller-manager
+      deployments:
+      - label:
+          control-plane: controller-manager
+        name: sriov-fec-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:8307f2210206acdcb87f2a44952d5464f059fe6f763b6b11d24739d58c804057
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  runAsNonRoot: true
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: SRIOV_FEC_DAEMON_IMAGE
+                  value: registry.connect.redhat.com/intel/sriov-fec-daemon@sha256:e4e2464213db805366fadeeae63d82b83db5e1b6456a606611f84db4295baa45
+                - name: SRIOV_FEC_LABELER_IMAGE
+                  value: registry.connect.redhat.com/intel/n3000-labeler@sha256:ca8966a90b29beb99a23a22e27e120c6f57b91a90dabbb69670b053ee6d79992
+                - name: SRIOV_FEC_NETWORK_DEVICE_PLUGIN_IMAGE
+                  value: registry.redhat.io/openshift4/ose-sriov-network-device-plugin@sha256:d112012b93db88465e43efbacdb9d96a923febbfbc939e69e6db2b8e0f74c14c
+                - name: SRIOV_FEC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                image: registry.connect.redhat.com/intel/sriov-fec-operator@sha256:db8c83f7b36b911fdf98978b882c9d82be707764223aa6908abfba4b48c7186e
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+              serviceAccountName: controller-manager
+              terminationGracePeriodSeconds: 10
+              topologySpreadConstraints:
+              - labelSelector:
+                  matchLabels:
+                    control-plane: controller-manager
+                maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - ACC100
+  - vRAN
+  - ORAN
+  links:
+  - name: SRIOV-FEC source code
+    url: https://github.com/smart-edge-open/sriov-fec-operator
+  maturity: alpha
+  provider:
+    name: Intel Corporation
+    url: https://builders.intel.com/docs/networkbuilders/intel-vran-dedicated-accelerator-acc100-product-brief.pdf
+  version: 2.7.1
+  skips:
+  - sriov-fec.v2.6.0
+  - sriov-fec.v2.6.1
+  - sriov-fec.v2.7.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: sriov-fec-controller-manager
+    failurePolicy: Fail
+    generateName: vsriovfecclusterconfig.kb.io
+    rules:
+    - apiGroups:
+      - sriovfec.intel.com
+      apiVersions:
+      - v2
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - sriovfecclusterconfigs
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-sriovfec-intel-com-v2-sriovfecclusterconfig

--- a/operators/sriov-fec/v2.7.1/manifests/sriovfec.intel.com_sriovfecclusterconfigs.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriovfec.intel.com_sriovfecclusterconfigs.yaml
@@ -1,0 +1,795 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: sriovfecclusterconfigs.sriovfec.intel.com
+spec:
+  group: sriovfec.intel.com
+  names:
+    kind: SriovFecClusterConfig
+    listKind: SriovFecClusterConfigList
+    plural: sriovfecclusterconfigs
+    shortNames:
+    - sfcc
+    singular: sriovfecclusterconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.syncStatus
+      name: SyncStatus
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovFecClusterConfig is the Schema for the sriovfecclusterconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovFecClusterConfigSpec defines the desired state of SriovFecClusterConfig
+            properties:
+              drainSkip:
+                type: boolean
+              nodes:
+                description: List of node configurations
+                items:
+                  properties:
+                    nodeName:
+                      description: Name of the node
+                      type: string
+                    physicalFunctions:
+                      description: List of physical functions (cards) configs
+                      items:
+                        description: PhysicalFunctionConfig defines a possible configuration
+                          of a single Physical Function (PF), i.e. card
+                        properties:
+                          bbDevConfig:
+                            description: BBDevConfig is a config for PF's queues
+                            properties:
+                              acc100:
+                                description: ACC100BBDevConfig specifies variables
+                                  to configure ACC100 with
+                                properties:
+                                  downlink4G:
+                                    properties:
+                                      aqDepthLog2:
+                                        maximum: 4
+                                        minimum: 4
+                                        type: integer
+                                      numAqsPerGroups:
+                                        maximum: 16
+                                        minimum: 16
+                                        type: integer
+                                      numQueueGroups:
+                                        maximum: 8
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - aqDepthLog2
+                                    - numAqsPerGroups
+                                    - numQueueGroups
+                                    type: object
+                                  downlink5G:
+                                    properties:
+                                      aqDepthLog2:
+                                        maximum: 4
+                                        minimum: 4
+                                        type: integer
+                                      numAqsPerGroups:
+                                        maximum: 16
+                                        minimum: 16
+                                        type: integer
+                                      numQueueGroups:
+                                        maximum: 8
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - aqDepthLog2
+                                    - numAqsPerGroups
+                                    - numQueueGroups
+                                    type: object
+                                  maxQueueSize:
+                                    maximum: 1024
+                                    minimum: 1024
+                                    type: integer
+                                  numVfBundles:
+                                    maximum: 16
+                                    minimum: 16
+                                    type: integer
+                                  pfMode:
+                                    type: boolean
+                                  uplink4G:
+                                    properties:
+                                      aqDepthLog2:
+                                        maximum: 4
+                                        minimum: 4
+                                        type: integer
+                                      numAqsPerGroups:
+                                        maximum: 16
+                                        minimum: 16
+                                        type: integer
+                                      numQueueGroups:
+                                        maximum: 8
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - aqDepthLog2
+                                    - numAqsPerGroups
+                                    - numQueueGroups
+                                    type: object
+                                  uplink5G:
+                                    properties:
+                                      aqDepthLog2:
+                                        maximum: 4
+                                        minimum: 4
+                                        type: integer
+                                      numAqsPerGroups:
+                                        maximum: 16
+                                        minimum: 16
+                                        type: integer
+                                      numQueueGroups:
+                                        maximum: 8
+                                        minimum: 0
+                                        type: integer
+                                    required:
+                                    - aqDepthLog2
+                                    - numAqsPerGroups
+                                    - numQueueGroups
+                                    type: object
+                                required:
+                                - downlink4G
+                                - downlink5G
+                                - maxQueueSize
+                                - numVfBundles
+                                - pfMode
+                                - uplink4G
+                                - uplink5G
+                                type: object
+                              n3000:
+                                description: N3000BBDevConfig specifies variables
+                                  to configure N3000 with
+                                properties:
+                                  downlink:
+                                    properties:
+                                      bandwidth:
+                                        minimum: 0
+                                        type: integer
+                                      loadBalance:
+                                        minimum: 0
+                                        type: integer
+                                      queues:
+                                        properties:
+                                          vf0:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf1:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf2:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf3:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf4:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf5:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf6:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf7:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                        - vf0
+                                        - vf1
+                                        - vf2
+                                        - vf3
+                                        - vf4
+                                        - vf5
+                                        - vf6
+                                        - vf7
+                                        type: object
+                                    required:
+                                    - bandwidth
+                                    - loadBalance
+                                    - queues
+                                    type: object
+                                  flrTimeout:
+                                    minimum: 0
+                                    type: integer
+                                  networkType:
+                                    enum:
+                                    - FPGA_5GNR
+                                    - FPGA_LTE
+                                    type: string
+                                  pfMode:
+                                    type: boolean
+                                  uplink:
+                                    properties:
+                                      bandwidth:
+                                        minimum: 0
+                                        type: integer
+                                      loadBalance:
+                                        minimum: 0
+                                        type: integer
+                                      queues:
+                                        properties:
+                                          vf0:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf1:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf2:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf3:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf4:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf5:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf6:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                          vf7:
+                                            maximum: 32
+                                            minimum: 0
+                                            type: integer
+                                        required:
+                                        - vf0
+                                        - vf1
+                                        - vf2
+                                        - vf3
+                                        - vf4
+                                        - vf5
+                                        - vf6
+                                        - vf7
+                                        type: object
+                                    required:
+                                    - bandwidth
+                                    - loadBalance
+                                    - queues
+                                    type: object
+                                required:
+                                - downlink
+                                - flrTimeout
+                                - networkType
+                                - pfMode
+                                - uplink
+                                type: object
+                            type: object
+                          pciAddress:
+                            description: PCIAdress is a Physical Functions's PCI address
+                              that will be configured according to this spec
+                            pattern: ^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[01][a-fA-F0-9]\.[0-7]$
+                            type: string
+                          pfDriver:
+                            description: PFDriver to bound the PFs to
+                            type: string
+                          vfAmount:
+                            description: VFAmount is an amount of VFs to be created
+                            minimum: 0
+                            type: integer
+                          vfDriver:
+                            description: VFDriver to bound the VFs to
+                            type: string
+                        required:
+                        - bbDevConfig
+                        - pciAddress
+                        - pfDriver
+                        - vfAmount
+                        - vfDriver
+                        type: object
+                      type: array
+                  required:
+                  - nodeName
+                  - physicalFunctions
+                  type: object
+                type: array
+            required:
+            - nodes
+            type: object
+          status:
+            description: SriovFecClusterConfigStatus defines the observed state of
+              SriovFecClusterConfig
+            properties:
+              lastSyncError:
+                type: string
+              syncStatus:
+                description: Indicates the synchronization status of the CR
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: SriovFecClusterConfig is the Schema for the sriovfecclusterconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovFecClusterConfigSpec defines the desired state of SriovFecClusterConfig
+            properties:
+              acceleratorSelector:
+                description: Selector describes target accelerator for this spec
+                properties:
+                  deviceID:
+                    type: string
+                  driver:
+                    pattern: (pci-pf-stub|pci_pf_stub|igb_uio|vfio-pci)
+                    type: string
+                  maxVirtualFunctions:
+                    type: integer
+                  pciAddress:
+                    pattern: ^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[01][a-fA-F0-9]\.[0-7]$
+                    type: string
+                  vendorID:
+                    type: string
+                type: object
+              drainSkip:
+                description: Skips drain process when true; default false. Should
+                  be true if operator is running on SNO
+                type: boolean
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: Selector describes target node for this spec
+                type: object
+              physicalFunction:
+                description: Physical function (card) config
+                properties:
+                  bbDevConfig:
+                    description: BBDevConfig is a config for PF's queues
+                    properties:
+                      acc100:
+                        description: ACC100BBDevConfig specifies variables to configure
+                          ACC100 with
+                        properties:
+                          downlink4G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          downlink5G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          maxQueueSize:
+                            maximum: 1024
+                            minimum: 1024
+                            type: integer
+                          numVfBundles:
+                            maximum: 16
+                            minimum: 1
+                            type: integer
+                          pfMode:
+                            enum:
+                            - false
+                            type: boolean
+                          uplink4G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          uplink5G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                        required:
+                        - downlink4G
+                        - downlink5G
+                        - numVfBundles
+                        - uplink4G
+                        - uplink5G
+                        type: object
+                      acc200:
+                        description: ACC200BBDevConfig specifies variables to configure
+                          ACC200 with
+                        properties:
+                          downlink4G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          downlink5G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          maxQueueSize:
+                            maximum: 1024
+                            minimum: 1024
+                            type: integer
+                          numVfBundles:
+                            maximum: 16
+                            minimum: 1
+                            type: integer
+                          pfMode:
+                            enum:
+                            - false
+                            type: boolean
+                          qfft:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          uplink4G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                          uplink5G:
+                            properties:
+                              aqDepthLog2:
+                                maximum: 12
+                                minimum: 1
+                                type: integer
+                              numAqsPerGroups:
+                                maximum: 16
+                                minimum: 1
+                                type: integer
+                              numQueueGroups:
+                                maximum: 8
+                                minimum: 0
+                                type: integer
+                            required:
+                            - aqDepthLog2
+                            - numAqsPerGroups
+                            - numQueueGroups
+                            type: object
+                        required:
+                        - downlink4G
+                        - downlink5G
+                        - numVfBundles
+                        - qfft
+                        - uplink4G
+                        - uplink5G
+                        type: object
+                      n3000:
+                        description: N3000BBDevConfig specifies variables to configure
+                          N3000 with
+                        properties:
+                          downlink:
+                            properties:
+                              bandwidth:
+                                minimum: 0
+                                type: integer
+                              loadBalance:
+                                minimum: 0
+                                type: integer
+                              queues:
+                                properties:
+                                  vf0:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf1:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf2:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf3:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf4:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf5:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf6:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf7:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - vf0
+                                - vf1
+                                - vf2
+                                - vf3
+                                - vf4
+                                - vf5
+                                - vf6
+                                - vf7
+                                type: object
+                            required:
+                            - bandwidth
+                            - loadBalance
+                            - queues
+                            type: object
+                          flrTimeout:
+                            minimum: 0
+                            type: integer
+                          networkType:
+                            enum:
+                            - FPGA_5GNR
+                            - FPGA_LTE
+                            type: string
+                          pfMode:
+                            enum:
+                            - false
+                            type: boolean
+                          uplink:
+                            properties:
+                              bandwidth:
+                                minimum: 0
+                                type: integer
+                              loadBalance:
+                                minimum: 0
+                                type: integer
+                              queues:
+                                properties:
+                                  vf0:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf1:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf2:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf3:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf4:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf5:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf6:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                  vf7:
+                                    maximum: 32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - vf0
+                                - vf1
+                                - vf2
+                                - vf3
+                                - vf4
+                                - vf5
+                                - vf6
+                                - vf7
+                                type: object
+                            required:
+                            - bandwidth
+                            - loadBalance
+                            - queues
+                            type: object
+                        required:
+                        - downlink
+                        - flrTimeout
+                        - networkType
+                        - uplink
+                        type: object
+                    type: object
+                  pfDriver:
+                    description: PFDriver to bound the PFs to
+                    pattern: (pci-pf-stub|pci_pf_stub|igb_uio|vfio-pci)
+                    type: string
+                  vfAmount:
+                    description: VFAmount is an amount of VFs to be created
+                    minimum: 1
+                    type: integer
+                  vfDriver:
+                    description: VFDriver to bound the VFs to
+                    type: string
+                required:
+                - bbDevConfig
+                - pfDriver
+                - vfAmount
+                - vfDriver
+                type: object
+              priority:
+                description: Higher priority policies can override lower ones.
+                type: integer
+            required:
+            - physicalFunction
+            type: object
+          status:
+            description: SriovFecClusterConfigStatus defines the observed state of
+              SriovFecClusterConfig
+            properties:
+              lastSyncError:
+                type: string
+              syncStatus:
+                description: Indicates the synchronization status of the CR
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/sriov-fec/v2.7.1/manifests/sriovfec.intel.com_sriovfecnodeconfigs.yaml
+++ b/operators/sriov-fec/v2.7.1/manifests/sriovfec.intel.com_sriovfecnodeconfigs.yaml
@@ -1,0 +1,979 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: sriovfecnodeconfigs.sriovfec.intel.com
+spec:
+  group: sriovfec.intel.com
+  names:
+    kind: SriovFecNodeConfig
+    listKind: SriovFecNodeConfigList
+    plural: sriovfecnodeconfigs
+    shortNames:
+    - sfnc
+    singular: sriovfecnodeconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Configured")].reason
+      name: Configured
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovFecNodeConfig is the Schema for the sriovfecnodeconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovFecNodeConfigSpec defines the desired state of SriovFecNodeConfig
+            properties:
+              drainSkip:
+                type: boolean
+              physicalFunctions:
+                description: List of PhysicalFunctions configs
+                items:
+                  description: PhysicalFunctionConfig defines a possible configuration
+                    of a single Physical Function (PF), i.e. card
+                  properties:
+                    bbDevConfig:
+                      description: BBDevConfig is a config for PF's queues
+                      properties:
+                        acc100:
+                          description: ACC100BBDevConfig specifies variables to configure
+                            ACC100 with
+                          properties:
+                            downlink4G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 4
+                                  minimum: 4
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 16
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            downlink5G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 4
+                                  minimum: 4
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 16
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            maxQueueSize:
+                              maximum: 1024
+                              minimum: 1024
+                              type: integer
+                            numVfBundles:
+                              maximum: 16
+                              minimum: 16
+                              type: integer
+                            pfMode:
+                              type: boolean
+                            uplink4G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 4
+                                  minimum: 4
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 16
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            uplink5G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 4
+                                  minimum: 4
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 16
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                          required:
+                          - downlink4G
+                          - downlink5G
+                          - maxQueueSize
+                          - numVfBundles
+                          - pfMode
+                          - uplink4G
+                          - uplink5G
+                          type: object
+                        n3000:
+                          description: N3000BBDevConfig specifies variables to configure
+                            N3000 with
+                          properties:
+                            downlink:
+                              properties:
+                                bandwidth:
+                                  minimum: 0
+                                  type: integer
+                                loadBalance:
+                                  minimum: 0
+                                  type: integer
+                                queues:
+                                  properties:
+                                    vf0:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf1:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf2:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf3:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf4:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf5:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf6:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf7:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - vf0
+                                  - vf1
+                                  - vf2
+                                  - vf3
+                                  - vf4
+                                  - vf5
+                                  - vf6
+                                  - vf7
+                                  type: object
+                              required:
+                              - bandwidth
+                              - loadBalance
+                              - queues
+                              type: object
+                            flrTimeout:
+                              minimum: 0
+                              type: integer
+                            networkType:
+                              enum:
+                              - FPGA_5GNR
+                              - FPGA_LTE
+                              type: string
+                            pfMode:
+                              type: boolean
+                            uplink:
+                              properties:
+                                bandwidth:
+                                  minimum: 0
+                                  type: integer
+                                loadBalance:
+                                  minimum: 0
+                                  type: integer
+                                queues:
+                                  properties:
+                                    vf0:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf1:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf2:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf3:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf4:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf5:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf6:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf7:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - vf0
+                                  - vf1
+                                  - vf2
+                                  - vf3
+                                  - vf4
+                                  - vf5
+                                  - vf6
+                                  - vf7
+                                  type: object
+                              required:
+                              - bandwidth
+                              - loadBalance
+                              - queues
+                              type: object
+                          required:
+                          - downlink
+                          - flrTimeout
+                          - networkType
+                          - pfMode
+                          - uplink
+                          type: object
+                      type: object
+                    pciAddress:
+                      description: PCIAdress is a Physical Functions's PCI address
+                        that will be configured according to this spec
+                      pattern: ^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[01][a-fA-F0-9]\.[0-7]$
+                      type: string
+                    pfDriver:
+                      description: PFDriver to bound the PFs to
+                      type: string
+                    vfAmount:
+                      description: VFAmount is an amount of VFs to be created
+                      minimum: 0
+                      type: integer
+                    vfDriver:
+                      description: VFDriver to bound the VFs to
+                      type: string
+                  required:
+                  - bbDevConfig
+                  - pciAddress
+                  - pfDriver
+                  - vfAmount
+                  - vfDriver
+                  type: object
+                type: array
+            required:
+            - physicalFunctions
+            type: object
+          status:
+            description: SriovFecNodeConfigStatus defines the observed state of SriovFecNodeConfig
+            properties:
+              conditions:
+                description: Provides information about device update status
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inventory:
+                description: Provides information about FPGA inventory on the node
+                properties:
+                  sriovAccelerators:
+                    items:
+                      properties:
+                        deviceID:
+                          type: string
+                        driver:
+                          type: string
+                        maxVirtualFunctions:
+                          type: integer
+                        pciAddress:
+                          type: string
+                        vendorID:
+                          type: string
+                        virtualFunctions:
+                          items:
+                            properties:
+                              deviceID:
+                                type: string
+                              driver:
+                                type: string
+                              pciAddress:
+                                type: string
+                            required:
+                            - deviceID
+                            - driver
+                            - pciAddress
+                            type: object
+                          type: array
+                      required:
+                      - deviceID
+                      - driver
+                      - maxVirtualFunctions
+                      - pciAddress
+                      - vendorID
+                      - virtualFunctions
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Configured")].reason
+      name: Configured
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: SriovFecNodeConfig is the Schema for the sriovfecnodeconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovFecNodeConfigSpec defines the desired state of SriovFecNodeConfig
+            properties:
+              drainSkip:
+                description: Skips drain process when true; default false. Should
+                  be true if operator is running on SNO
+                type: boolean
+              physicalFunctions:
+                description: List of PhysicalFunctions configs
+                items:
+                  properties:
+                    bbDevConfig:
+                      description: BBDevConfig is a config for PF's queues
+                      properties:
+                        acc100:
+                          description: ACC100BBDevConfig specifies variables to configure
+                            ACC100 with
+                          properties:
+                            downlink4G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            downlink5G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            maxQueueSize:
+                              maximum: 1024
+                              minimum: 1024
+                              type: integer
+                            numVfBundles:
+                              maximum: 16
+                              minimum: 1
+                              type: integer
+                            pfMode:
+                              enum:
+                              - false
+                              type: boolean
+                            uplink4G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            uplink5G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                          required:
+                          - downlink4G
+                          - downlink5G
+                          - numVfBundles
+                          - uplink4G
+                          - uplink5G
+                          type: object
+                        acc200:
+                          description: ACC200BBDevConfig specifies variables to configure
+                            ACC200 with
+                          properties:
+                            downlink4G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            downlink5G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            maxQueueSize:
+                              maximum: 1024
+                              minimum: 1024
+                              type: integer
+                            numVfBundles:
+                              maximum: 16
+                              minimum: 1
+                              type: integer
+                            pfMode:
+                              enum:
+                              - false
+                              type: boolean
+                            qfft:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            uplink4G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                            uplink5G:
+                              properties:
+                                aqDepthLog2:
+                                  maximum: 12
+                                  minimum: 1
+                                  type: integer
+                                numAqsPerGroups:
+                                  maximum: 16
+                                  minimum: 1
+                                  type: integer
+                                numQueueGroups:
+                                  maximum: 8
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - aqDepthLog2
+                              - numAqsPerGroups
+                              - numQueueGroups
+                              type: object
+                          required:
+                          - downlink4G
+                          - downlink5G
+                          - numVfBundles
+                          - qfft
+                          - uplink4G
+                          - uplink5G
+                          type: object
+                        n3000:
+                          description: N3000BBDevConfig specifies variables to configure
+                            N3000 with
+                          properties:
+                            downlink:
+                              properties:
+                                bandwidth:
+                                  minimum: 0
+                                  type: integer
+                                loadBalance:
+                                  minimum: 0
+                                  type: integer
+                                queues:
+                                  properties:
+                                    vf0:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf1:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf2:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf3:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf4:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf5:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf6:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf7:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - vf0
+                                  - vf1
+                                  - vf2
+                                  - vf3
+                                  - vf4
+                                  - vf5
+                                  - vf6
+                                  - vf7
+                                  type: object
+                              required:
+                              - bandwidth
+                              - loadBalance
+                              - queues
+                              type: object
+                            flrTimeout:
+                              minimum: 0
+                              type: integer
+                            networkType:
+                              enum:
+                              - FPGA_5GNR
+                              - FPGA_LTE
+                              type: string
+                            pfMode:
+                              enum:
+                              - false
+                              type: boolean
+                            uplink:
+                              properties:
+                                bandwidth:
+                                  minimum: 0
+                                  type: integer
+                                loadBalance:
+                                  minimum: 0
+                                  type: integer
+                                queues:
+                                  properties:
+                                    vf0:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf1:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf2:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf3:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf4:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf5:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf6:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                    vf7:
+                                      maximum: 32
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - vf0
+                                  - vf1
+                                  - vf2
+                                  - vf3
+                                  - vf4
+                                  - vf5
+                                  - vf6
+                                  - vf7
+                                  type: object
+                              required:
+                              - bandwidth
+                              - loadBalance
+                              - queues
+                              type: object
+                          required:
+                          - downlink
+                          - flrTimeout
+                          - networkType
+                          - uplink
+                          type: object
+                      type: object
+                    pciAddress:
+                      description: PCIAdress is a Physical Functions's PCI address
+                        that will be configured according to this spec
+                      pattern: ^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[01][a-fA-F0-9]\.[0-7]$
+                      type: string
+                    pfDriver:
+                      description: PFDriver to bound the PFs to
+                      pattern: (pci-pf-stub|pci_pf_stub|igb_uio|vfio-pci)
+                      type: string
+                    vfAmount:
+                      description: VFAmount is an amount of VFs to be created
+                      minimum: 0
+                      type: integer
+                    vfDriver:
+                      description: VFDriver to bound the VFs to
+                      type: string
+                  required:
+                  - bbDevConfig
+                  - pciAddress
+                  - pfDriver
+                  - vfAmount
+                  - vfDriver
+                  type: object
+                type: array
+            required:
+            - physicalFunctions
+            type: object
+          status:
+            description: SriovFecNodeConfigStatus defines the observed state of SriovFecNodeConfig
+            properties:
+              conditions:
+                description: Provides information about device update status
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inventory:
+                description: Provides information about FPGA inventory on the node
+                properties:
+                  sriovAccelerators:
+                    items:
+                      properties:
+                        deviceID:
+                          type: string
+                        driver:
+                          type: string
+                        maxVirtualFunctions:
+                          type: integer
+                        pciAddress:
+                          type: string
+                        vendorID:
+                          type: string
+                        virtualFunctions:
+                          items:
+                            properties:
+                              deviceID:
+                                type: string
+                              driver:
+                                type: string
+                              pciAddress:
+                                type: string
+                            required:
+                            - deviceID
+                            - driver
+                            - pciAddress
+                            type: object
+                          type: array
+                      required:
+                      - deviceID
+                      - driver
+                      - maxVirtualFunctions
+                      - pciAddress
+                      - vendorID
+                      - virtualFunctions
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/sriov-fec/v2.7.1/metadata/annotations.yaml
+++ b/operators/sriov-fec/v2.7.1/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020-2023 Intel Corporation
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: sriov-fec
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10


### PR DESCRIPTION
Fixes ISVISSUE-462

Summary:
* Adds v2.6.0 and v2.6.1 to CSV `spec.skips[]` field