### PR TITLE
Add Github workflow that control labels using comments

### DIFF
--- a/.github/workflows/pr-label-command.yml
+++ b/.github/workflows/pr-label-command.yml
@@ -1,0 +1,12 @@
+name: Github pull request labels
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  skip-test-labeler:
+    uses: redhat-openshift-ecosystem/github-workflows/.github/workflows/label-command.yml@main


### PR DESCRIPTION
The new workflow allows user to control a pipeline trigger in case of failure and allow them to skip certain static checks that are not strictly required for certification.

JIRA: ISV-4206