### PR TITLE
operator ibm-storage-odf-operator (1.4)

### DIFF
--- a/operators/ibm-storage-odf-operator/1.4.0/manifests/flashsystem-csi-cr_v1_configmap.yaml
+++ b/operators/ibm-storage-odf-operator/1.4.0/manifests/flashsystem-csi-cr_v1_configmap.yaml
@@ -15,8 +15,8 @@ data:
       # controller is a statefulSet with ibm-block-csi-controller container
       # and csi-provisioner, csi-attacher, csi-snapshotter and livenessprobe sidecars.
       controller:
-        repository: stg-artifactory.xiv.ibm.com:5030/ibm-block-csi-driver-controller-amd64
-        tag: "latest"
+        repository: quay.io/ibmcsiblock/ibm-block-csi-driver-controller
+        tag: "1.11.0"
         imagePullPolicy: IfNotPresent
         affinity:
           nodeAffinity:
@@ -33,8 +33,8 @@ data:
       # node is a daemonSet with ibm-block-csi-node container
       # and csi-node-driver-registrar and livenessprobe sidecars.
       node:
-        repository: stg-artifactory.xiv.ibm.com:5030/ibm-block-csi-driver-node-amd64
-        tag: "latest"
+        repository: quay.io/ibmcsiblock/ibm-block-csi-driver-node
+        tag: "1.11.0"
         imagePullPolicy: IfNotPresent
         affinity:
           nodeAffinity:


### PR DESCRIPTION
the published yaml incorrectly references an internal IBM artifactory to host the CSI binaries, but in fact they are hosted on quay.io for public use