### PR TITLE
Add link to Github pages documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Red Hat certified operators production catalog
 Production catalog for Red Hat Certified Operator Bundles
 
+See our [documentation](https://redhat-openshift-ecosystem.github.io/operator-pipelines/) to
+find out more about Certified operators and contribution.
+
+
 # Operator bundle submission
 A new operator bundle submission needs to follow a predefined directory
 structure that is described below in this section. The new submission is


### PR DESCRIPTION
The link contains a documentation for all certified, marketplace and community operators.