### PR TITLE
Ignore FBC related directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # MacOS related artifacts
 .DS_Store
+
+# FBC related
+bin/


### PR DESCRIPTION
Part of FBC onboarding is downloading OPM tool to bin/ - this PR is to avoid accidentally push this folder with changes.