### PR TITLE
operator vcp-operator (v1.4.0)

### DIFF
--- a/operators/vcp-operator/v1.4.0/manifests/installer.venafi.com_venafiinstalls.yaml
+++ b/operators/vcp-operator/v1.4.0/manifests/installer.venafi.com_venafiinstalls.yaml
@@ -1,0 +1,924 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: vcp-operator
+  name: venafiinstalls.installer.venafi.com
+spec:
+  group: installer.venafi.com
+  names:
+    categories:
+      - venafi
+    kind: VenafiInstall
+    listKind: VenafiInstallList
+    plural: venafiinstalls
+    shortNames:
+      - vi
+    singular: venafiinstall
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: Status
+          type: string
+        - jsonPath: .status.lastSync
+          name: Last Sync
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            VenafiInstall is an object for installing Venafi components onto a Kubernetes
+            cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                VenafiInstallSpec defines the desired state of
+                VenafiInstall.
+              properties:
+                approverPolicyEnterprise:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                awsPrivateCAIssuer:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                certManager:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                certManagerApproverPolicy:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                certManagerCSIDriver:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                certManagerCSIDriverSPIFFE:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    trustDomain:
+                      description: The trust domain for this CSI driver.
+                      type: string
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  required:
+                    - trustDomain
+                  type: object
+                certManagerIstioCSR:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    runtimeConfigMapName:
+                      description: |-
+                        RuntimeConfigMapName is the name of the ConfigMap containing the
+                        istio-csr runtime configuration.
+                      type: string
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    trustDomain:
+                      description: The trust domain for istio-csr.
+                      type: string
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  required:
+                    - runtimeConfigMapName
+                    - trustDomain
+                  type: object
+                firefly:
+                  properties:
+                    acceptTOS:
+                      description: |-
+                        AcceptTOS accepts the components TOS. This is not required for every
+                        component.
+
+                        Currently just firefly requires this be set to true
+                      type: boolean
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    clientID:
+                      description: ClientID for the Firefly deployment
+                      type: string
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  required:
+                    - clientID
+                  type: object
+                globals:
+                  properties:
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    customChartRepository:
+                      description: Set the repository the images will be pulled from
+                      type: string
+                    customImageRegistry:
+                      description: Set the registry the images will be pulled from
+                      type: string
+                    enableDefaultApprover:
+                      description: Enable the default approver
+                      type: boolean
+                    imagePullSecretNames:
+                      description: |-
+                        Secrets to use when pulling images, these must already exist in the
+                        namespace being deployed into
+                      items:
+                        type: string
+                      type: array
+                    namespace:
+                      description: Namespace to deploy into
+                      type: string
+                    openSource:
+                      description: Use open-source images and helm repositories
+                      type: boolean
+                    region:
+                      default: US
+                      description: |-
+                        Region is used to determine the registry to pull the Venafi component
+                        images from.
+                      enum:
+                        - EU
+                        - US
+                        - Custom
+                      type: string
+                    useFIPSImages:
+                      description: Use FIPS compliant imaged
+                      type: boolean
+                    vcpRegion:
+                      description: |-
+                        VCPRegion is used by Venafi Kubernetes Agent for deciding on the default
+                        region to use for connecting to VCP
+                      enum:
+                        - EU
+                        - US
+                      type: string
+                    vpcRegion:
+                      description: |-
+                        Deprecated: this field was a typo, it is kept for backwards
+                        compatibility
+                      enum:
+                        - EU
+                        - US
+                      type: string
+                  type: object
+                openshiftRoutes:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                trustManager:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                venafiConnection:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                venafiEnhancedIssuer:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+                venafiKubernetesAgent:
+                  properties:
+                    chartRepository:
+                      description: The Repository to pull the components chart from
+                      type: string
+                    chartRepositoryAuthenticationSecretRef:
+                      description: |-
+                        If the chart repository requires authentication then a secret can be
+                        referenced here.
+
+                        For OCI registries the secret key should be ".dockerconfigjson" and
+                        contain a docker_config.json file.
+
+                        For HTTP(s) registries the "username" and "password" keys should be set
+                        within the secret.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    clientID:
+                      description: ClientID for the Venafi Kubernetes Agent
+                      type: string
+                    imageRegistry:
+                      description: The registry to pull images from
+                      type: string
+                    install:
+                      description: Install will deploy the component and all its dependencies
+                      type: boolean
+                    skip:
+                      description: |-
+                        By default the operator will error if a dependency is not deployed as
+                        part of the same VenafiInstall resource. You can explicitly ignore
+                        a dependency by setting "skip" to true.
+                      type: boolean
+                    values:
+                      description: |-
+                        Values contains the configuration for the component, this configuration
+                        is the same as both the Helm chart and the
+                        "venctl component kubernetes manifest generate" command.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    version:
+                      description: |-
+                        The version of the component to deploy, this should be a semantic version
+                        starting with a "v" prefix
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: |-
+                VenafiInstallStatus defines the observed state of the
+                VenafiInstall.
+              properties:
+                components:
+                  items:
+                    properties:
+                      app_version:
+                        type: string
+                      chart:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                      revision:
+                        type: string
+                      status:
+                        type: string
+                      updated:
+                        format: date-time
+                        type: string
+                    required:
+                      - app_version
+                      - chart
+                      - name
+                      - namespace
+                      - revision
+                      - status
+                      - updated
+                    type: object
+                  type: array
+                lastSync:
+                  format: date-time
+                  type: string
+                lock:
+                  description: 'Deprecated: use components field instead'
+                  properties:
+                    dependencies:
+                      items:
+                        description: 'Deprecated: the ComponentLock has replaced this struct'
+                        properties:
+                          name:
+                            type: string
+                          repository:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                          - name
+                          - repository
+                          - version
+                        type: object
+                      type: array
+                    digest:
+                      type: string
+                    generated:
+                      type: string
+                  required:
+                    - dependencies
+                    - digest
+                    - generated
+                  type: object
+                namespace:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
+              type: object
+              x-kubernetes-map-type: atomic
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/vcp-operator/v1.4.0/manifests/vcp-operator-metrics_v1_service.yaml
+++ b/operators/vcp-operator/v1.4.0/manifests/vcp-operator-metrics_v1_service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: vcp-operator
+    app.kubernetes.io/name: vcp-operator
+  name: vcp-operator-metrics
+spec:
+  ports:
+    - name: metrics
+      port: 9402
+      protocol: TCP
+      targetPort: 9402
+  selector:
+    app: vcp-operator
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operators/vcp-operator/v1.4.0/manifests/vcp-operator.clusterserviceversion.yaml
+++ b/operators/vcp-operator/v1.4.0/manifests/vcp-operator.clusterserviceversion.yaml
@@ -1,0 +1,903 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "installer.venafi.com/v1alpha1",
+          "kind": "VenafiInstall",
+          "metadata": {
+            "name": "install-venafi-enhanced-issuer"
+          },
+          "spec": {
+            "certManager": {
+              "install": true
+            },
+            "globals": {
+              "imagePullSecretNames": [
+                "venafi"
+              ]
+            },
+            "venafiConnection": {
+              "install": true
+            },
+            "venafiEnhancedIssuer": {
+              "install": true
+            }
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Security
+    createdAt: "2024-12-09T09:42:11Z"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.operatorframework.io/builder: operator-sdk-unknown
+    operators.operatorframework.io/project_layout: unknown
+    containerImage: registry.venafi.cloud/public/venafi-images/vcp-operator@sha256:f0a0665f771878c88b6af52c5856c457130d73fe8c4cdd33872869e854841059
+  name: vcp-operator.v1.4.0
+  namespace: placeholder
+  labels:
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - kind: VenafiInstall
+        name: venafiinstalls.installer.venafi.com
+        displayName: VenafiInstall
+        version: v1alpha1
+        description: |-
+          VenafiInstall is an object for installing Venafi components onto a Kubernetes
+          cluster
+  description: |
+    Venafi Control Plane Operator for Red Hat OpenShift simplifies deployment of Venafi's enterprise components and dependencies.
+
+    The enterprise components include:
+    - Enterprise cert-manager: An enhanced version of cert-manager designed for application certificate management within your clusters.
+    - Venafi Enhanced Issuer: Enables seamless certificate enrollment for your clusters directly from the Venafi Control Plane.
+    - Venafi Firefly: A high-performance, lightweight issuer for certificates, centrally managed by the Venafi Control Plane.
+    - Venafi Kubernetes Agent: Provides real-time visibility into certificates and Kubernetes resources directly within the Venafi Control Plane.
+  displayName: Venafi Control Plane Operator
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+                - roles
+                - rolebindings
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+                - escalate
+                - bind
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+                - services
+                - configmaps
+                - secrets
+                - namespaces
+                - pods
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+                - podmonitors
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitor
+                - podmonitor
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingwebhookconfigurations
+                - mutatingwebhookconfigurations
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+                - verticalpodautoscalers
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+                - podsecuritypolicies
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - cronjobs
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - cert-manager.io
+              resources:
+                - certificates
+                - certificaterequests
+                - clusterissuers
+                - issuers
+                - signers
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - policy.cert-manager.io
+              resources:
+                - certificaterequestpolicies
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - jetstack.io
+              resources:
+                - venafiissuers
+                - venaficlusterissuers
+                - venaficonnections
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+            - apiGroups:
+                - installer.venafi.com
+              resources:
+                - venafiinstalls
+                - venafiinstalls/status
+              verbs:
+                - create
+                - update
+                - delete
+                - patch
+                - get
+                - list
+                - watch
+          serviceAccountName: vcp-operator
+      deployments:
+        - label:
+            app.kubernetes.io/name: vcp-operator
+          name: vcp-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: vcp-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app: vcp-operator
+                  app.kubernetes.io/name: vcp-operator
+                  app.kubernetes.io/version: v1.4.0
+              spec:
+                containers:
+                  - args:
+                      - --log-level=1
+                      - --metrics-bind-address=:9402
+                      - --readiness-probe-bind-address=:6060
+                    env:
+                      - name: XDG_CACHE_HOME
+                        value: /tmp/.cache
+                      - name: XDG_CONFIG_HOME
+                        value: /tmp/.config
+                    image: registry.venafi.cloud/public/venafi-images/vcp-operator@sha256:f0a0665f771878c88b6af52c5856c457130d73fe8c4cdd33872869e854841059
+                    imagePullPolicy: IfNotPresent
+                    name: vcp-operator
+                    ports:
+                      - containerPort: 9402
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 6060
+                      initialDelaySeconds: 3
+                      periodSeconds: 7
+                    resources:
+                      limits:
+                        cpu: "1"
+                        memory: 512Mi
+                      requests:
+                        cpu: 500m
+                        memory: 512Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    volumeMounts:
+                      - mountPath: /tmp
+                        name: temp-dir
+                dnsPolicy: ClusterFirst
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: vcp-operator
+                volumes:
+                  - emptyDir: {}
+                    name: temp-dir
+      permissions:
+        - rules:
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - update
+          serviceAccountName: vcp-operator
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - cert-manager
+    - venafi
+    - vcp-operator
+  links:
+    - name: Documentation
+      url: https://docs.venafi.cloud/
+  maturity: stable
+  minKubeVersion: 1.24.0
+  provider:
+    name: Venafi
+    url: https://venafi.com
+  version: 1.4.0
+  replaces: vcp-operator.v1.3.1
+  relatedImages:
+    - name: vcp-operator
+      image: registry.venafi.cloud/public/venafi-images/vcp-operator@sha256:f0a0665f771878c88b6af52c5856c457130d73fe8c4cdd33872869e854841059
+  icon:
+    - mediatype: image/png
+      base64data: |
+        iVBORw0KGgoAAAANSUhEUgAAAyAAAAKbCAYAAAANCu5qAAAACXBIWXMAAJnKAACZygHjkaQiAAAg
+        AElEQVR4nOydCZhcRdX+h32VfQdBIIBEk5mu6hkCiKOCC7iBOi4kZKarOwOJRgUXxC2oaFxQUZFP
+        BLcPRUFxgz+ogCtuiAiIoIAgfOz7HgIh53+qJ6hAlknSt97qOu/veX6P35pnut5T51b3vbeqR4L7
+        rgR/EaW0QBv1/XsIIYRAkVG/ocyctPEKO+q31n6+0wo76neWlvMr6T76b+23wrbcS6Xph1bOWkP/
+        ndGV8M16bTxyJf2YNN3HV1z/Wf03Tlwpm/70lTL4M/VvOXeFDf78lVqbNN33evQPOVoVSmmRno6+
+        8BJCyLKQUD9k8QsVf4kuVv65cvrb9d+6e4Vt+gcz6OWUlmPwH+6R4d5n6X+zEP7HUEor0M2TqQMb
+        oBcXhBCyNLRf/Q7fLymlSWz17/rExP8V/I+hlFZjcFPBawtCCFki7ceD+EMopTYM7oL/TP5QD/A/
+        iFJajcH/GLi2IISQpSJN90F4n6SUprHlRv8z+WdNXF8XKQ/A/yhKaecN/lFpTtkEuL4ghJAlol9A
+        /g7vk5TSBLp5Mty70ZMbQPCn4P8wSmklNnwTtLYghJAlIjPq/fD+SClNY/DfeXoTiFukof8wSmlF
+        unMBawtCCFkq2p+Ow/dHSmkiD3h6E5jTs6p+M7k+gz+OUtpx3QJp7rElYH1BCCGLRYaGVtPedAu+
+        P1JKKzf422TO4OqLbwbBHQP/AymlVfmWxOsLQghZIosOpkP3RUppEt2nl9wMRvp2EW6FR2mp/ibh
+        2oIQQpaKLkj+N4O+SClNYaOvd+kNIbjfwv9ISmkVLpRQ2yHR2oIQQpaIjPp1ufsmpVZ0f112U2i5
+        UfwfSimtxODemWBtQQghS0X70cHwfkgpTWPwRyy7KUwd2ED/Dx+C/7GU0ir8U4K1BSGELBXtRWdl
+        0A8ppVUb3GMy3L/V+BpDcKfC/2BKaUXWJlS8tiCEkCUSD0bVXjQf3wsppQk8a/zNgTtTUFqw7qgK
+        1xaEELJUtA/NxPdBSmkSG+71428O8UyQprsB/kdTSqvwkgrXFoQQslQk+F9n0AcppVUb/L0yNGWd
+        5W0Qc+F/OKW0Imu7V7S2IISQJSIj9Wfq+uJxfA+klFZu8Ccuf5No9e8K/8MppdUY3JwK1haEELJU
+        dEFyJLz/UUpTufeKNYqm/0MGfzyltNMGf2WH1xWEELJMtP9cAu9/lNLqDf5q6elZZUUbBV8Uo7RU
+        R/ykDq8tCCFkiUijbyK871FKE+k+uOLNYtRvyDNBKC3U4I7p4NqCEEKWSuw58L5HKU3hQmnUd1q5
+        htH038zgg1BKO23w13RoXUEIIctE+85V8L5HKU2gO3flG0bLvQj/QSillTjiXQfWFYQQslR0LTEF
+        3u8opak8eOWbRk/PKvGX0gw+DKW00wb3iQ6sLQghZKnoOuJz8H5HKa3eePbHqF+3U43j/fAPRCmt
+        QHfDCu9SQQgh40CGhlbTXnMLvt9RSis3+BM61zym926rzWMB/ENRSjtvy03pWLMghJCnoAuSl8D7
+        HKU0jTPq/Z1uIOfAPxSltAo/29FmQQgh/4X2mK9l0OcopVUb3OWdbyAt/zr4B6OUdt7gb5Y5Pat2
+        vGkQQswjw4Nrt58JR/c5Smn1Bn9E55vI0MQ19R+/Hf7hKKWdt+X26XjTIISYhz9eUmrE4B6T4f6t
+        qmkkTf9Z+AeklHbe4I+vpGkQQkyjveUMeH+jlKbw+xU2kvpzM/iAlNLOe7vMGVy9suZBCDGHTB3Y
+        QJru4Qz6G6W0cmuvrLahBPdH/IeklHbcUNu30uZBCDGFLkga8L5GKa3e4G6VUb9GxQ3FHwr/oJTS
+        Kvxypc2DEGIKXZT8LIO+Rimt2hSHGrdvqQb/EPzDUko7rLuz8l8wCCEmkOYeW/L8MEqNOOqfnaax
+        BP91+IellHbe4F+epIkQQopG+8lb4f2MUprC36VrLKH2/Aw+MKW0834zWSMhhBQL3xel1IytxM3F
+        X5nBh6aUdtYHZdrk9ZI2E0JIUUizNkF7ycIM+hmltFLdwzLcu1HiBuOOwn9wSmnHDfU3Jm0mhJCi
+        kOA/BO9jlNLqDf7r6RvMcP9W7VMP0R+eUtph3Y+SNxRCSDFoH7kK38copZXbqA9imkzwZ8I/PKW0
+        swb/qBzSvymkqRBCuhqZUd8L3sMopdUb3LXS07MKptEEfyB8ACilnbflRiFNhRDS1Wj/+CK8f1FK
+        qzf49+MazZzB1fWPuAk+CJTSzhrcL2CNhRDSlcRzhHRRcge8f1FKqzW+gjG9d1tswwnuGPhAUEo7
+        a/CPS2tgO2hzIYR0FdKsvRLeuyilCczgXVEZ9dvztFNKi/Qd6P5CCOkeJPjvZNC3KKVV23KvQPeb
+        Ntp0fgIfDEppZw3+InRvIYR0BzJ1YAPtGQ/B+xaltFqDvzm+goHuOW0k1F8LHxBKaQXWdkf3F0JI
+        /mivaOD7FaW0et1H0P3m37RfPGu6W/CDQintsEej+wshJH+0V5yXQb+ilFZpfD90uPdZ6H7zJPSP
+        mgsfGEppZw3+Gtg+34SQrkBCbRu+C0qpCX+K7jdPQxr1ndrfjPCDQyntpKG2J7q/EELyRYJ7F7xP
+        UUqrt+Vfh+43i0Wa7lz44FBKO2vwJ6B7CyEkX7RPXALvU5TSao1n/MyesBa63ywWabjXwweIUtpZ
+        g7sr26ZDCIEijb6J8B5FKU3hJ9H9ZonI0MQ19RvSbRkMEqW0kwZ/ILq/EELyg+9/UmrFzHfFlOA+
+        gR8kSmlHDf4MdG8hhORF3KBC+8N18P5EKa1Y90t0v1kmMup31j92IX6wKKUddL4c0r8pur8QQvJB
+        +8ILMuhNlNKqDW4qut+MCwn+fPhgUUo77aHo3kIIyQe91p+UQV+ilFbrPTLq10X3m3Ehof7GDAaM
+        UtpJg7sA3VsIIXkgw4NrS1yYoPsSpbRag/8cut+Mm/bL6E1/O3zQKKWddGF8xBLdXwgheOJ5ABn0
+        JEpp1Tb6etH9ZrnQb0zHwgeNUtph3QfRvYUQgkf7wQ/w/YhSWqnB/x7da5YbCfXdhC+jU1qWwV8d
+        d75B9xdCCA6ZOWlj7QWPwPsRpbRaQz2g+80KEbftgg8epbSzhtqe6N5CCMGhfeBQeB+ilFasu19m
+        TVwf3W9WCP0AB+MHkFLaUYM/Cd1bCCE4tAf8Gt6HKKXVGvyJ6F6zwvBkdEoLNPgHuvZXEULISiGt
+        gR2Fj1dTWr4t59H9ZqXgyeiUFukwurcQQtIjwX8og/5DKa3S4P6I7jUrjTTqO2nDehw+mJTSTvor
+        dG8hhKQlbkAhTffPDPoPpbRKu/Xl86eiX0DOgQ8mpbSzjvpno3sLISQdOu9fAO87lNJqDf5emTZ5
+        PXS/6Qj6TepV8AGllHbW4D+G7i2EkHTovP8avO9QSqu1m04+XxYyNLSafqh/wQeVUtpB3S0yZ3B1
+        dH8hhFRP/EW0vS0nvO9QSis11J+L7jcdRb9RvR8+qJTSztpyr0D3FkJI9UjDT4f3G0pp1Zb3fqcM
+        92+lX0IezWBwKaWdMvgz0L2FEFI9OtfPh/cbSmnVHozuNZWgH+z0DAaXUtopg3ss/riA7i2EkOqQ
+        UNuBu1lSWrjB3yHDg2uj+00l6Id7IXyAKaWd9h3o3kIIqQ6d4x/IoM9QSqs0uE+ge01ltPcQD/4K
+        +CBTSjtnnNM6t9H9hRDSecbO/vBXwfsMpbQ64x3OUb8zut9Uin7Deht8oCmlnTXU9kX3FkJI55GG
+        fx68v1BKq/an6F5TOTLcu5F+0AczGGxKaef8Abq3EEI6j/DsD0rLt+EOQveaJEjTfQU+2JTSDuoW
+        SGtgR3RvIYR0Dhn1Gwp/MKS0bIO/Wef6Guh+kwQJ9Rp8wCmlnTX4uejeQgjpHDqvZ8L7CqW0ao9G
+        95qk6Af+UwaDTintlCVv4UeIQXRe/xneVyilFeoWxG220b0mKRLqAT/wlNKOGtwIurcQQlYeadYm
+        w/sJpbRag/shutckR4amrKMf/C744FNKO6i7GN1bCCErj87nL+L7CaW0Uhv1/dG9BoJ++OPgg08p
+        7ayhtie6txBCVpyxHwj93fBeQimtzuCvl6Gh1dD9BoKM+mfrICyEh0Ap7aTfRPcWQsiKo3N4OIM+
+        QimtVHcUutdA0UE4Dx+CcYObIy3nKe2IzdpkdF8hhKw4Evyv4dclSmmVzpfmHluiew2UePhJBkHY
+        Nrj/h64DQggheKSnZxUJtX2lUd+P0iQGfyR8HWRPPqkQnz/TgbgugzDsGtxjMuq3RtcCIYQQQmwh
+        Tfc/8HWQNVtuCjr3LIjPocHDsG5w70TXASGEEELsIEMT19Q14J3wNZApuVvlv5FRv5kOyDx8KIYN
+        7nJ0HRBCCCHEDtLyr4Ovf8xZa6BzzwodlK/hQzFuy3l0HRBCCCHEBtJ0P4KvfSwZt9ce9euic88K
+        CfUaPBjzus+j64AQQggh5SOH9G8q7d2Y0GsfU34SnXuW6Dez32cQjmHdnTJ7wlroOiCEEEJI2ei6
+        4634dY8hg39cGvWd0LlniTRr0+ABmbf2GnQdEEIIIaRsdM3xJ/yax5DBn4nOPFvauyEEdys8JNO6
+        H6HrgBBCCCHlIs3a7vj1jjVrL0PnnjW6AP4IPiTDxjNBhvu3QtcBIYQQQspEgp8LX+9YMvhrZE7P
+        qujcs0ZCbRsdqEfhYVm24d6OrgNCCCGElEdcCEvT3QBf69jycHTuXYEO1OkZhGXZy9A1QAghhJDy
+        kEZ9vwzWOYZ0D0tzyibo3LsCLc5BfGDGbfT1ouuAEEIIIWWhC+JvwNc4tvwyOvOuQgfssgxCs+xx
+        6BoghBBCSDnIrInrS/APZLDGsWOrvw+de1chLTcKD82ywd/BM0EIIYQQ0imk4afD1zeWDO4CdOZd
+        RzwqXgfuLnh4th1C1wEhhBBCykCa7pcZrG3sGOpvRGfelWihfhoenmWDPwddA4QQQgjpfqQ1sKOu
+        LRbC1zZmdLfE8/XQuXclMup3bh8dDw/RqHHsR/326DoghBBCSHeja4oPw9c1lgz+Q+jMuxoJ7v/B
+        Q7Rs8O9H1wAhhBBCupexsz/8v+BrGivGQ6VbA9uhc+9qpFHfHx6kZYO7Vnp6VkHXASGEEEK6E579
+        kXzt9l105l1PXPxK8FfAw7Rsy70IXQeEEEII6U50QXwqfC1jyYZ/HjrzItDCnQUP07bfRNcAIYQQ
+        QroPGfUbSvAPZbCWMaK7GJ15MXBLXrRunsyctDG6DgghhBDSXeiXj8Pw6xhDNvx0dOZFoYP6KXio
+        lg1uFroGCCGEENJd6Prhj/A1jB1vl+HBtdGZF4WE2g7tt/rx4do0+IvQNUAIIYSQ7kFa/c+Br18s
+        ya13q0Ga7nvwcC3b6u9D1wAhhBBCugNdEB8LX7tYMfhHZXrvtujMi0Rabh94wJYN/nPoGiCEEEJI
+        /sicwdXbp3Gj1y5WDP4UdOZFEx8Fgods1bgRAJ8tJIQQQsgykFB/FXzdYssBdOZFE9/uzyBkuwY3
+        FV0DhBBCCMkbXS/8EL5msWLwv0fnXTwyNHFN3tJD6n6JrgFCCCGE5IsM92/VficBvmYxYqi/EZ25
+        CfRb9Rx42Kat7Y6uAUIIIYTkiTTdUfi1ihlvklG/BjpzE0ijb/P24Xj40K36KXQNEEIIISQ/pKdn
+        FQn+6gzWKlZ8HzpzU+iAfy2D0I3q7pTZE9ZC1wAhhBBC8kJCbV/8OsWIwT8izT22RGduChnxk+DB
+        m7b2BnQNEEIIISQvpOm+jV+jWNF9BZ23SeIL0fjwzXoeOn9CCCGE5IMc0r8pH5FPKA+IxiANdxA8
+        fLsulJG+XdA1QAghhJA80HXZ2zNYnxiRu5LCkKGh1TSAf+KLwKru4+gaIIQQQkgeSHCX49cmVqy9
+        Bp23aST4I/BFYNTg7+DL6IQQQgiRGfW94OsSO/5L5gyujs7cNDJ1YANpuvsyKAabtvzr0DVACCGE
+        ECwS/FfhaxIrBvcudN6kp/0y+ufhxWDV4H6Gzp8QQgghOMZ+DPYPwtckNtRxnrIJOnOiSGtgR/0S
+        siCDorDoQmnWJqBrgBBCCCEYdC1waAbrERsG9wV03uS/kODPgBeFVYOfi86fEEIIIRh0LfAn+FrE
+        gsE/zh1IM0OD2RteGFYN/jYZmrgmugYIIYQQkhYJ9Rp8HWJG9yN03mQx6EL49/jiMGqovxGdPyGE
+        EELSIsF9Cb4GsWKoPR+dN1kM0nCvhxeHWXkgDiGEEGIJmTVxfe5Emsw/o/MmS4AHE4IN9eeia4AQ
+        QgghadBr/0z42sOKwU1F502WgoZ0OLxIzOo+j86fEEIIIWnQ6/7F+LWHCW/ku7aZI2GvZ2hQ92RQ
+        LPYM/l6ZNnk9dA0QQgghpFqk5abA1x1WDP5IdN5kHGhYn4IXi11b6PwJIYQQUi16vf9aBmuO8g3+
+        ITmkf1N03mQcSGtgOw3sUXjRWDS4v6DzJ4QQQkh1yHDvRu2FMXrNYUI+3t5V6EL4VHzRmHUAnT8h
+        hBBCqkHXWG/LYK1RvvHgwWZtAjpvshxIy3l44dj1a+j8CSGEEFIN+gXk8gzWGhb8PjprsgJocL/K
+        oHgM6h6W5pRN0PmnRr/0viK+KEY74Ix6PzpPQkpBRryDz+lut1HfH51jLuhYDOLXGUZsuX3QeZMV
+        QFr+1fDisevh6PxTI83atAzGvRR/js6TkFLQBfQ5Gczp7rblX4fOMRf4iHsig78InTVZQaSnZxUN
+        8Ep4EVk0+Kvj+KNrICUyNGUd4RbQnbPV/xx0poR0O9Ia2FHaz5FnMKe71eDuktkT1kJnmQMy6jfT
+        enoEnokFW/5N6LzJSiA8pRNno74fOv/U6Of+Mnzcy/E4dJ6EdDu6WJybwVzucrkL0RPol7F34fOw
+        oLtBv+ytgc6brAQa4Loa5J34YjJocD9E558amVHfCz7u5XhPnL/oTAnpVuLJydqHb81gLne3oV5D
+        Z5kDMqdnVf1Cew08Dxu+G5036QDagI/JoJgM6hbE2//o/FPDx/46aa2BzpOQbkXnzxvwc7jrvQyd
+        Yy7ote3lGeRhQHd/PGcFnTfpAHLY5C000Hn4ojJo8HPR+adGP/d74ONeisFdiM6TkG5F59DP4XO4
+        2w3ubegcc0HXUWfD87AhHz8uCV0IfzWDorJn8HfI8ODa6PxTIqG2TfvuD3rsS7HlPDpTQroNCfXd
+        dP4shM/f7na+NPo2R2eZA9Ko78TNDFKoa4dRvzM6b9JBNNBnc/KgtPcYDbe97KDBn4TOk5BuQxcy
+        n4bP3W43+DPQOeaCjsWx8DxseBo6a1IBOoF+nEFxGdRdjM4+NdJwr8ePeyEG/5DMnLQxOlNCuoW4
+        ZazOndvhc7fbbblXoLPMgfYW83ErYnQeFmz4PdB5kwqIJ0rCi8uqobYnOv+UjO0+4++Aj3spBj8b
+        nSkh3YIuYqbD52y3G3cP4zaobbSemvA8LBjcL9BZkwrRgH8LLzKbfhOdfWp00Xx8BuNehsFfYe1g
+        S0JWFF7nOuIn0TnmQjyRO4M8LHgAOmtSIdJwB2VQZBadL8P9W6HzT4mEWj2DcS/HUHs+OlNCckca
+        fRPhc7UER/wkdJY5wLOtEhm375/Tsyo6b1Ih8VfU9q+p6GKz6QfQ+adGP/NlGYx7KfLlPEKWgV7f
+        Tshgrna7f0DnmAtaT9/KII/yDW4EnTVJgAY9A15sNr3J2jO12ryPyGDcyzC4x6Q1sB06U0JyRaYO
+        bNA+xAw9V7vfQ9FZ5kDcglivYY9kkEfp3hjfG0XnTRLQ3iEk+JszKDqLDqHzT0n7EMzgH81g3Msw
+        uGPQmRKSKzpHDofP0a7XzeMp1GPotev9+DwMGNy70FmThGiTOQpedCZ1v0RnnxptLj/Ej3sx3m7t
+        YEtCxsPY48XuHxnM0e42+G+hs8wBmTO4utbT/8HzKF53P7/wGiMGzlvVIBt9vej8U6IXtAPhY16W
+        w+hMCckNnRcHZDA3u99GfT90ljkgzdpr4FlYMPhj0VkTADwpFqX7Cjr7lLR/SWq6W/DjXor2DrYk
+        ZFnoQuYc/NzscuMv/kNDq6GzzAEdj5/D8yjd+Hg232u0iUzv3Vbi9rDoIrRm+6W2PbZE558SvbB9
+        Bj7uJTmjvhc6U0JyQUb6dtG++jh8Xna97iPoLHNAQv25Oh4L8XkUbvBfR2dNgMQCgBehRYN/Pzr7
+        lEiztruwoXewftyp6EwJyQWdE8fB52S3G7/ADfc+C51lDugXsZPheVjQ2OPo5Cm0F4b85Si9cRcy
+        Y9vO6ef+DXzcSzHeup7euy06U0LQyKyJ6+t8uBc+J7tedzY6yxyQ5pRNtJ4ewudRuqw30tNeGJ6F
+        L0aDBjcVnX1K9MvuNPiYl2TwH0JnSgga7aOz4HOxBFv+1egsc4A7hCYy+BeisyYZII36ILwYLRr8
+        RejsU9I+fyZuI4se91IM/jZuyUusowvGv8LnYrcb78gbOyR3cSzaMOUGeB7l+yd01iQjtCB+l0FR
+        2jPU9kRnnxK+jN5pa9PQmRKCIm4Zi5+DBci7qW2k4V4Pz8KCOs7orElGSKi/Fl6UFg3+O+jsU6J1
+        tpvwZfQO1o+7EJ0pISh4yGkndAtkpP5MdJY5oPV0AT6Pwg3u2ninCZ01yQiZ07OqLoavgBenNYN7
+        zFrzj6fBw8e9JBv+eehMCUmNNOo7tRfP6PnX7Qb/Y3SWOSAj3sGzsOFb0FmTDJGWG82gOO0Z/Fx0
+        9imRln8TfMxLMvgz0JkSkhqt++Phc68Eg385Ossc4JEEKXR3yrTJ66GzJhmy6CXhm/BFaszg77Y0
+        KeP2w+0XqNHjXopxG+1RvzM6V0JSITMnbax1/wB87nW97gaefK71dNjkLXQs5uHzKF33QXTWJGMk
+        uHfhi9SgLTeKzj4l+pk/BR/zkgz+c+hMCUmFXqfeC59zZfgBdJY5oPU0J4MsSvdBGfWbobMmGSNh
+        r2foZLwrg2K1ZXCXS0/PKuj8UxF/sRe+jN5JH4wHaKFzJaRq4nax2i//L4M5193G9w95mOkTd+Rv
+        hudRvO7T6KxJFxC35MMXq0Fb7qXo7FOidXY+fMzL8t3oTAmpGq3z4QzmWgl+H51lDsQDgTPIomyD
+        f4Rfdsm4kEP6N+XztRB/is4+JdxzvePeyMPESOnogvEvGcy17tfYD15LQuvpj/AsSjf4k9A5ky5C
+        i+az8KK1aKOvF519KsYepeCt7w57MDpXQqqCBw92yOCv58vn7XoahGdRvG6BtPp3RWdNughpDWyn
+        xTMfX7zWdF9BZ58S/bwfx495QQZ/ETpTQqpC+8XZ8DlWhO4odJY5wIMsk3gaOmfShcTFcAbFa8v4
+        rOSo3xqdfSrah4nFbWTR416SofZ8dK6EdBoJ9d3YKzrRH9xj2iO2QeeJRkb6dmE9JbDlPDpr0oWM
+        7VTEk2aTG/yH0dmnRC+IP4OPeVn+AJ0pIZ0mPkeewdzqfoP7LjrLHOBBlilqzf8EnTPpYrSITocX
+        sTXjNsiWDiZs1l4DH/OSjL/qjfTtgs6VkE4hjb7Npekehs+tEmzU90PniYYHWSartUF01qSLiS9F
+        C89rSG/wh6GzTwVfRq+iftyX0LkS0im4NXyn+oK/2tJ5U0sivgMDz6J8/4DOmRRAvI2WQTHbMrh/
+        yJyeVdHZpyI+dgYf86J086S5x5boXAlZWWTWxPW1nu/Ez6kifAc6TzQ8yDKVtVeisyYFwK3qOIGr
+        Jr54L9x1rbMG/zF0roSsLFrHR8DnUgkG/5A0p2yCzhONhPoh8CxKN/grLP2ASipGgrsAXtTWDO4X
+        6NxTIk33bfiYF6W7T7/YbYjOlZAVZdHjmdfj51IBBn8COs8c0L54MTyL4q1NQ+dMCkJa7hX4ojbo
+        jHo/OvtU6GfdCz7epRncO9G5ErKi6EKmAZ9DpTjiJ6HzRKNfwl4Iz6F04w8Go34NdNakIOKLa/zl
+        ADKZT0FnnxJdMF8IH/OidLfI8ODa6FwJWV7a15zgLsfPoRJ056LzzAG9nv4Yn0XhBjcLnTMpEGn5
+        N8GL25rBPxpPpUdnnwr9zMPwMS/Nhm+icyVkeZGGOwg+d0ox1F+FzhONtPp35cGDVdeZu1WGpqyD
+        zpoUiAwNraYT+Bp4kVsz+GPR2adCZk9Yq93E0GNelO7vfCGQdBtau7/Dz50ivC5eu9F5oonvwGSQ
+        ReG6o9A5k4LRIjsUX+TWdPfLcO9G6OxToV9AjsGPeWE23EHoXAkZL1qzL4DPmVIM/gh0nmh4kGUK
+        3X2W1ikEQPsX6qa/CV/s5nwPOvtUSKht0370DD/m5RjchehcCRkvOv/Pgc+ZEuTWu210LI6GZ1G6
+        wc9F50wMoMV2OLzYrRkfSzL0MrF+5tPhY16ajfogOldCloU0+nq1XhfC50sJcuvduJXzujoOd8Cz
+        KNn4RfewyVugsyYGWDShb4MXvT1b6OxTIS23TwbjXZjubHSuhCwLCe5U/FwpwoXS6n8OOk80Og5v
+        ySCLsg3uM+iciSG06N4DL3pz2nqZWJvaX/BjXpQLJdRr6FwJWRIy6nfWef9YBnOlBM9D54mGG+ck
+        MPhHZHrvtuisiSFk1sT1eVsTMtkPRGefCl0sB/h4l2Zw30XnSsiSkKb7CnyOlCK33o0HWb4BnkPp
+        8jE/gkAXM3PgxW/N4P6Izj0VY1vy8lG/DhvvgjwXnS0hT0VG/fZan/MzmCMlyK13e9pPavwhgyzK
+        deycsh3ROROD6AVjQy3Ce+CTwJ57o7NPRdxZI4PxLsvgT0HnSshTkeC+BJ8bpcitd+N7hC+C51C6
+        wX8VnTMxjBbhR+GTwJrB/RCdeyrav4rymfAO6xbISN8u6GwJeQJpDWzXfpYcPjcKkFvvtuFWzlWr
+        15FQ3w2dMzGMHNK/qU70B/CTwZQLpdE3EZ19KrTRfS+DMS/L4E9C50rIE0hwX4DPiVLkM/nx/cHn
+        CrdyrrjO3KnonAmJvzQcC58M5nQno3NPRTy/Aj/ehRmf3Q21HdDZEiLD/VvxlBmyunYAACAASURB
+        VOoOOuInoTNFo/X0DXgOZbuQdUayQJp7bMkLSGLj4wqhtg06+1To570UPualGfzx6FwJ0Vr8LHwu
+        FKM7F50nmrglrHAzg2oN/gx0zoT8G218n4dPCnt+Ep17KrglbxW6eTLqt0ZnS+zS/vGq/c4Cei4U
+        Ysu9Ap0pGh2HT8FzKN2W8+icCfk3fIkQobtfZk7aGJ19ChZtyXszfswLM/hj0dkSu2gNfhI+B4rR
+        1kG1i0OGezfScbgPn0XJurPRORPyNHQxcyJ+cpjzfejcUxE/awbjXZoPSqNvc3S2xB7tDUzijyj4
+        OVCGDd9EZ4pGeI1IUWfPQ+dMyNMY2zLVPwqfIKZ0d8q0yeuhs09BvNvDHdcqMLhj0NkSe+hc/hi8
+        9ksxHtg6PLg2OlMkuv5YlwfXVl5n56NzJmSJaIF+HT5JrBn8bHTuqeB2nVUYH1nguQEkHbHe+KhM
+        RzVzJ3xJxOtgBjmUbcu9CJ0zIUtEmrUJ7QNq0BPFlO4GGZq4Jjr7FEhrYEfWVwXyLghJiC4W58Jr
+        vhTjS/yH9G+KzhSJjPo1dCz+Bc+iZIP/PTpnQpaJLhC/DZ8s9hxG554KXSx/N4PxLsv4aBvfBSEJ
+        0MXiZnz3o5O6z6MzRaPjMIzPoXgPQOdMyDKJp3TrgubxDCaMHYO/0soOKDKj3g8f7xINfi46W1I+
+        umD+NLzWi9Et0C90O6MzRSI9PatIcJfjsyjY4P4SxxmdNSHjIh5UA5801my4g9C5p0I/72/g412e
+        D8phk7dAZ0vKJZ47w3M/Ourp6EzRxOteBjkUbu016JwJGTfS6u/Twl2InziGDO5CdO6p0EXMgfDx
+        LtHgPoHOlpSLztvj4TVeki03BZ0pGu1Zf4TnULaXWXm6ghSEFu4PMpg8tgy1fdG5p2Dstru/Aj7e
+        5flgPJ0anS8pj0XbtPOw2k4Z/K/RmaKJ1zt4DqXb8q9D50zIcsO7IBDPQ+eeCr0AH5bBeJcnT0cn
+        FaC19WV4bZdkqL8KnSkaHYfz4DmUbHy3hnc/SLcivAsCaBq1PdG5pyAevKUN8lb4eBenm6c1tA06
+        X1IOMtz7LK2t+fjaLsTg/mF9YcjNSJI4hM6ZkBVGQr0mvAuS2h+gc0+FftajMxjvEv0sOltSDjyg
+        tsO23Cg6UzQ6Dt+H51CyvPtBSkB4FyS1C2XET0LnnoJ4doU03cMZjHlhunkyvXdbdL6k+5GRvl10
+        MfMYvqYLMfjbZGjKOuhckUiztju3+q/Yhns9OmdCVhq+C4LQfRudeyp0cfMl/HiXKA84IyuPzs9T
+        8bVcku6D6EzR6JePU/A5FO3fePeDFIPwLkhi3QIJ9d3Quacgfk7+GlZJDc2LOxeh8yXdi87N53Ju
+        dnROPhzv+qJzRSKN+k68o1a1tTegcyakY/AuCMDgv47OPRV6Yf4RfLyL1J2MzpZ0L9qDzsTXcFF+
+        EZ0pmtiTMsihXOP29rz7QUpDgvshfHKZ0i2QZm0COvcUSMvtgx/vAo2/NBq5k0Y6i9bP3vD6Lcl4
+        J2mkbxd0rkhkpP5M4W5qFddZ/Y3onAnpONwRC9FM/Ino3FOhi+UL4ONdpqehsyXdB+cj52Gn0TH4
+        YgY5lCvvfpCS4V2Q5A3lUQm1HdC5p0CatVfCx7tM465qDp0v6R7iIXkZ1G1ZtpxH54pEhvu34o6H
+        Fcu7H6RkeBcEoY3djKSnZxX9vH/Gj3eBBn8OOl/SHcjQ0GrtMwTQNVuWZ6FzRaPXsU9nkEO58u4H
+        sQDvgqTWzsnW8Rcc/HgXavAvROdL8kf7+wi8Vstzb3SuSOSQ/k21/zyQQQ7l2vJvQudMSOXwLgjE
+        T6FzT8GiX1//kcF4l2dwF6DzJXkjw4Nr60LxenitluXP0bmi0Zr6WAY5lOxV8dqJzpmQJPAuSHIf
+        tLJ/vDR8M4PxLtPgX47Ol+SL1scR8BotzVDbF50rEhn1G+o43APPoWwPRudMSDJ4FwRgcMegc0+B
+        XrDW0M/7L/h4l+llfE6YLA4Jez1Dv4DclkGNlmNwf0TnikbH4Wh4DmXLux/EHrwLklp3n8yctDE6
+        9xRobb0NP96FymeFyWKIP3DAa7M0Q/1V6FyRyKyJ6+uX2jvgOZRscFPROROSHN4FgTSbOejcUyCj
+        fl3+GltVDfmr410mdMYkH+SwyVtI090Pr82y/Jv1u406Bu/JIIeCdX/n3Q9iFt4FSe49Mty7ETr3
+        FGhzPSqD8S7T4Gah8yX5oF9KT4DXZGkav9Mo0yavp+NwOzyHoq1NQ+dMCAwZ8ZP04vU4fiIa0spd
+        kKkDGwhfXqzK2+P4ojMmeGTUP1t7ymMZ1GQ5Bn+NzBlcHZ0tEh2Hd8NzKNm4W6TxGiMkNprT4ZPR
+        ksHfa+ZdkKb/KHy8SzX4D6PzJXi0Fs6C12JphnpA54qkffeDj9BWa8O9Hp0zIXCk1b+rNN0C+IS0
+        pJW7IDzAqkLdw9Ia2A6dMcERD6fE12FpuhtkaOKa6GyRCO9+VF1jf7X+fhEh/0YvZKfgJ6Uhbd0F
+        OQ4+3uX6ZXS+BENcwGgfuSiDGizL4Gejs0XCux9JauxAdM6EZIM0axP4HHFq3QfRuacg/kqvn3c+
+        frxL1C2QUH8uOmOSHu3XI/j6K8y48B7166KzRSK8+1G1f5aenlXQOROSFbqYOTmDyWnHeBfEyo5Y
+        wZ8EH+9SDf5MdL4kLTI0ZZ32o0Lo2ivN4I9EZ4uEdz+SeAA6Z0KyQ0b99tp8HslgghrSyF2QUb8z
+        77BVaKjti86YpCP2DXjNlWb8QWjUb4jOFonw7kfFNeYu5N0PQpaATpIvwiepJS3dBWm6b8PHu1jd
+        xXyp0QaLDh28D19zhRn8h9DZIuHdjwQ26vuhcyYkW2TUb93eXQc9UU1p5C5IPHOm6Rfix7tQQ/2N
+        6IxJ9WjWX4bXWnG6++OOfehskQjvflRrcBegMyYke3SyfBY+WS1p6y7I9+DjXa7XyewJa6EzJtUh
+        zdrufJSxAoM7Bp0tEt79SOIL0DkTkj3S6Nu8/YsQfsIa0tBdkOAfx493sR6OzphUh86dczKoscKM
+        j7NN2QSdLRLh3Y+qa+xcdMaEdA16oZuLn7SGDP5uKy9A6uc9DT7epRrcXdYfJSkVadZeBq+vEg3+
+        w+hskbTvfjT97fAcSjbU9kTnTEjX0D7Bmi86Jm5SNl6ClEbfRN4FqVL3eXTGpLPIqF9D58yV+Noq
+        TEMHwi4J4d2PinVnozMmpOuIC2L85DVk8A/Ex9/QuaeAO2JVWUfuMR5OWBaa6zvgdVWkNh59XRIy
+        a+L6fPejcgfQORPSdcRHgtqPdOAnsB2Dn4vOPQXS6t+1fYo3eryLlc8cl0J72934Sz28porzHiub
+        fywJHYMPZJBDyf4AnTEhXYt+AXlvBpPYkg9Kc48t0bmnQBdV38pgvMu1Ud8fnTFZefTL5FfgtVSm
+        70Nni2TsB0Z/dwY5lOpCafT1onMmpGvh9nwI3afRuadARvp24ZaiFRrfGRj1a6BzJiuOjHjH96Wq
+        0N0pUwc2QOeLRMfgI/gcivY0dMaEdD3C548T6+ZJa2A7dO4p0MXVKfjxLtjgZ6MzJiuG9PSsovn9
+        Gl5DZfoedL5IFm0yw632KzM+XlzbHZ0zIV2PDA+urZPqRvykNmTwx6NzT4E26Qm8C1JpHd3NbXm7
+        E50b0+D1U6LB3yFhr2eg80Wi4/BJeA4lG/wp6IwJKQZpuTfDJ7Ut50uo7YDOPQXarL+ewXiX7HHo
+        jMnyIaN+XZ0X12dQO+UZ3LvQ+SKR4f6ttLYegudQqu0f1GoT0DkTUgztfeib7p/wyW3J4E9C554C
+        ra2deRekyjrSsW31PwedMxk/Ovc/Bq+bEo13P2ZNXB+dLxIdg8/BcyjZ4E9EZ0xIcUjDT4dPblO6
+        BXG7WnTuKdCm/VX8eBftWeiMyfiQRn2n9ntg+Jopz+CPQOeLREJtG62th+E5FKvO25H6M9E5E1Ic
+        MqdnVZ1kl+AnuSXdN9C5p0BaAzvq4uBR/HgXbMu9FJ0zWTaa1ffhtVKk7pb4aBs6XyQS3JfwORTt
+        p9AZE1Isukg8MINJbkg7u2nER87w4120V8nsCWuhcyZLRjN6cQZ1UqbBvQ2dL5L4TqHEdwvROZRq
+        8A/EQ0PRORNSLO2tIZv+D/DJbsngv4POPQUy6rcXXiCr9t3onMnikaGJa0rT/T2DGinP4G+WoSnr
+        oDNGwsdcq64xNwedMSHFI6G2L3yyWzIeRNbq70PnnoL4Ah98vEs2/ko3vXdbdM7k6Wg+H4DXR7m+
+        BZ0vkvguITf6qFBu7UxIOnTSnQef9LY08RIx74IkMLhT0TmTJ9N+B4ovB1dV7/9n/dFDHYfT4DmU
+        7eHojAkxg4RaXSfdwgwmvh0b9UF07inQBcMX4GNdtgut1FK3IMH/OIO6KNUWOl8k0qxNbt9Fx+dQ
+        qjdZf7yPkOQId2tJ7W/QmadAGn2bS9Pdn8F4l2twl8ezfdBZk/jlo/4qeD2UanD/kDmDq6MzRqJf
+        Ps6B51C2pr/gEgJBL5y78bnSxDbq+6NzT4F+AfkIfKxL1/iuQDkQfznVHK6F10Kx1l6DzhiJtNw+
+        +AyK9irrX3AJgSHBfz2DJmDH4C+N57Ggc6+a+EKfftbb4ONdtO4+GfVbo7O2DL9oV2hwF8ZdG9EZ
+        I9Ex+C08h6KtvQGdMSFmae8tHvwj+EZgyIZ7PTr3FOhnfQd8rEs3+K+ic7aKLl4m8MTzKmu7ti86
+        YyRaX6+EZ1CyRn4MJCRr+NJwck3c9pXhwbW1yV+fwXiX7EJdqO2Jztoi2jf/Xwb5l2nwP0HniyQu
+        jLW+/gLPoWwPQOdMiHn40jDAhm+ic09B/JzwsS7fP8vQ0GrorC0hLf+6DHIv1YXSch6dMRJp1qZl
+        kEO5BncBOmNCyCJ0Un4U3hRseaOFrf/inR4J/soMxrt0Z6KztoLMmri+NN0NGWRepsF/B50xkri7
+        nY7BNfAcyvYF6JwJIYvQprehBHdXBo3BkiYOP5JQf20GY1247j4JtW3QWVtAx/s4fN6FGndlHPXP
+        RmeMRMdgFjyHonVnozMmhDwFnZzvwTcHQwZ/h0wd2ACdewr0s/4ePt7l+010zqUzdoCrW5BB1mUa
+        /AnojJG0t3WOd8fROZTrQhnxDp0zIeQpsPkhdB9E556CeHI3fqwN2Kjvh866VOJ7NhLft0FnXKzu
+        YWkNbIfOGYnwR8CqPQ2dMSFkCegEnZlBkzCkuy9uAoDOPQUS3M/w4124wV8ddx9DZ10iwm2lq/aj
+        6IyRyHDvRjp/784ghzKNj/eF+m7onAkhS6D9AlzcJhbdLCwZ/OfQuacg7mwj8RY4erzL92h01qWh
+        fXF7nacPZJBtmbYX3lM2QeeMRJru4/AcSja4L6EzJoQsg3hQHrxZWDL4R3WBszM69xTo5z0dPt6l
+        Gw8WNf4ib6fRMf0xPNeSDe5d6IyRyPTebbXGHoLnUKx8vI+QrkB6elbRSfs7fNMwZPDfQueeAmn1
+        79q+FY4e7+J1v4zzGJ13CfAHmcq9Sb8wr4vOGYn2/69mkEPBuo+gMyaEjBMJtefjm4YpzRy+pZ/1
+        yxmMtwUPRmfd7cRd6oQbc1SrkUNZl0S8W8kfZSo07jY56jdE50wIWQ7iftnw5mHLn6MzT0E8r4KP
+        GyQwuFtl5qSN0Xl3M/G5cXiOJRvcP+JhpeickWgvPBOeQ8k23NvRGRNClhMZ8ZO0OT4ObyC2fDE6
+        9xTo5/xkBmNdvsbPVVgZpOH3YP+r2tpr0DkjkZbbB59B0V4nsyeshc6ZELICSNN9I4MmYslLZE7P
+        qujcqybueMMtJxMYF9AtNwWdd7chQxPXlOAuh+dXtr+z/p6S1thvM8ihXIObis6YELKCSKjtoF9C
+        5sEbiSVb/k3o3FOgi+Mj4GNtw8vighqddzehY3Z0BrmVbNyOe290zkgk1F+bQQ7lGvylFn7MI6Ro
+        dCIfC28mlgzuWgu3jdu/MvPMmVR+AJ13tyDN2u7trYzxmRWs+zY6ZyTxvRetsSvwORRsy70UnTMh
+        ZCWJL7LqovgueEOxZPCz0bmngL8CJqunR6TRNxGdd+7EX0yFW5BX7Xwr5x4tCR2DmRnkULDul+iM
+        CSEdQif1e/BNxZBx68CpAxugc0+BftZfw8fbgsH/no8kLJ14IB48p+J1H0fnjESmTV5P5+LN+ByK
+        dSHfeyOkIGR4cG29cNyQQXOxY/AfQueeAv2sAzL2TDh+zEu35d6MzjtXZKRvl/aJyeiMyvZ262cy
+        aI19MIMcyjX476AzJoR0mHhgFLy5WDL4B/RivTU69xTEk+Dh421Cd7+M1J+Jzjs3Fj169St8PsU7
+        E501Emn0ba5z8L4McijT4B+VZm0COmdCSIeRoaHVdJL/Dd5kbPlldO4pkNbAdjycMJXubHTeuSHB
+        zcLnUrjBXymjfg101ki0zr4Az6Fsv4jOmBBSEdLyr86gyRjSLYgHQqJzT4EuUObix9uIof5GdN65
+        oIvi7dt3htCZlO8B6KyR6JzbbewXengOZRqfGBju3wqdMyGkQnSy/wbebExp4xdrCXs9Qz/rLfjx
+        NmDc5KDRtzk68xzQsTgHnkfpBn8+Omc02tt+BM+hbI9GZ0wIqRhp+D2ELw2n9sXo3FMg3J4yoe4b
+        6LzRSHAj+BwKN/jHZcQ7dNZIpFEfhOdQtrdb2TWSEPPohP9BBk3HkpdY2EJ17D0j99cMxtuGhg/r
+        io9r8HyjBAZ/EjprJNLTs4qOw5/gOZQsd/cjxA5jz7O6x+CNx5LBjaBzT4F+1gPgY23Hf8VH39CZ
+        IxD+iFK9hnbyWxJ6rTwEnkPJBnetDE1cE50zISQhOvG/BG8+trwxHmKFzj0F+ll/msF42zD4E9F5
+        p0Yafjp83C0Y/PvRWSMZOz9Lv+SjcyjbIXTOhJDEyGGTt+Ce5ok1ckGXZm1yewcw9HjbcKGO98vQ
+        madCQm0bnUd3ZzDupXujjPp10XkjkeDem0EOJfuH+IgbOmdCCABtAB/IoAnZ0dBWg/oF5GT4eNvx
+        Rhnu3QidedWMPY/vzs5gvMs31A9B542kfehg8PfCcyjZhn8eOmdCCAgZmrKOXtBvgDciSwZ/Ajr3
+        FEhzjy15PkPSuir+ZWH9nIfCx9mE7mILm2Ysjdin8TkUbHDfRWdMCAEjoR7gzciUboG0+p+Dzj0F
+        +lk/iB9vQzbq+6MzrwoZ7n0Wv9AmMtT2ReeNREb9s3noYJX1pWM70rcLOmdCCJj4S5c2hT/Dm5Il
+        g/8xOvcUxGfIeYctpTrWo35DdO6dpt2jgvsFfnwNyF+m492PM+E5lO1x6IwJIZmgDfclGTQlW7bc
+        i9C5p0BC/Y3wsTalOxmdeaeRhns7flwt6B6Od5rQeSPRa+EL8TkU7T0y6jdD50wIyQhtvD/JoDlZ
+        8pJ4cB869xTw1+vEFvQoVvvMorgwRo+pDT+AzhvJ2NMA7uIMcijZd6NzJoRkhjRru/NwwuS20Lmn
+        IL7zwtpK6k0yc9LG6NxXlkWPh/4mg/E0oPtnPPcCnTkSafgmPoeivc56jRFClgC3Tk1s8LeV+Mz+
+        4tDPejx8vC0Z/FfRma8s2o+Ogo+jFVv+1ei8kcisievrnLkZnkPZHozOmRCSKe1Dvpr+wQwalR2D
+        n4vOPQXSnLKJftY74ONtyZZ7BTr3FUVG/CStl0fgY2jB4H+CzhuNjsHH4DkULbd2JoQsA20WR+Ob
+        lSnnS7M2AZ17CoTnOKT29ngeCzr35UVmT1hLF4SXZjB+Fpwft51FZ45EWgM76gJ5XgZZlKuRTVcI
+        ISsBb0VDPB2dewoWbad6YQbjbcfgfojOfXnRv/kz8HGzYnCfQOeNRsfhdHgOJduFPYgQAkIbxgx4
+        07JmqD0fnXsK9HPuqZ93IXy8TVlroHMfL9Ko7yfBP44fMwu6W2TqwAbozJHIjPpewn5UnXHzkUbf
+        RHTOhJAuIW4Pqxenv8KblyntPCOrC8xT8ONtyOAf6IbH/GS4dyP9W6+Hj5cVg5uKzhwJ78imqDF/
+        PDpnQkiXoc3jAHjzsucwOvcUxPcS9AvXfRmMtx2DuyD3c2d0sfId+DhZMbjfSk/PKujMkegYjMBz
+        KFp3fze+g0YIyQBt0D/DNzFT3iTTJq+Hzj0F+lnfncF42zL4I9G5Lwn9+4bh42PF+IhbqNXRmSNp
+        v+sY+y06i6J1R6FzJoR0KdLo6+Xz2IkN/kPo3FMgQxPX1AvU3+HjbcngH81x4SnDvc/iHbGkdXAC
+        OnM0Wm8fgedQtjfKqF8XnTMhpIvRRvK1DJqZId3DukjcAZ17CvTzvhg/3ub8mwxNWQed/RMseg7/
+        FxmMiw2Du0sXhpuhc0cirYHt9EvYQ/AsSrbhp6NzJoR0Oe1mzcMJ0xr8t9C5p0I/64/h421O92l0
+        7k+gC+L34sfDkMEfhs4cjdbcqfAcyvbPVjZUIYRUjDbsORk0NUvGbSH3RueeAmnUd+IhYImNj1Vm
+        cDCYjHgn7YM4MxgTE7qLc9+IoGp0HPYWbrtbrY36IDpnQkghxEc2uD1mau0sFvQL7jH48TZmnM8z
+        J20My3zUr6t/w5XwcbDjQmn456HyzgFuu5tC9z10zoSQwpBmbRq+uZmzhc49BXHnL10Y/F8G423L
+        4L4Lyzz4k+Cf35LBn4LKOhd0HA6F51C282Wkbxd0zoSQwoh7xrfPEsA3OTsGf1s8nA2dfQr08w7B
+        x9umyb/kSsO9PoPPbcl7ZLh/q9Q550S826fjcHsGWZRrcJ9A50wIKRRpuSnC52dTN/XPoHNPhX7e
+        s+Djbc32bkC13ZNlPFJ/ZnsnJvTntuXMVPnmijTd5zPIoWRvl1G/ITpnQkjBaCP/dgbNzo7BPSah
+        /lx07imI2w8Ld1wD6P4qw4NrV57vnMHV2ydwwz+vIeM7D0beJVsS0uib2D4DB51F2R6KzpkQUjjc
+        Qx2hOxedeyq0tt6PH2+TfjZBth/L4HMa0i2QUK9VnWvu6Fj8FJ9F0f4t/riAzpkQYgDuWoSw9kp0
+        7ilon5Ae/BX48TbnwiprLG7N2V4Q4z+nIfM57wWF8N2y6g3+JeicCSFGkFkT19emczO88Vky+Gtk
+        9oS10NmnQELt+cJ3jRDG57i37niejb7N9d++KYPPZ0h3g4S9ntHpLLuJ9vbxTX8dPouCDf5MdM6E
+        EGNIqAd487Nm8Eeic0+Fftavw8fbosH9opOnGI/tnsfT7pPbcAd1KsNuRcfhaHgOJRvfT2z1Pwed
+        MyHEGO1DnZr+T/AmaMngH5BQ2wadfQrkkP5N9fPeAR9ziwb3zo7l2PSHwz+POd3ZncqvWxnbbY3v
+        KlbsceicCSFG0Qa0t/BRmcS6b6BzT4UuhGfgx9ugcceght9jpfMb8U7/rUfgn8eScdHdGtixE/Ov
+        m4kncsOzKNng744/EqFzJoQYRhvRGfBmaMuFEmp7onNPAQ+/BBr81TJ1YIMVzi7s9Qz9d66Cfw57
+        vruTc7AbkZZ7UQY5lG1wb0PnTAgxjoz6nfkrZ3L/bGVv//iMMffwh3naCucW/CkZ/P22DO5y7cdr
+        dHL+dRvx87fHAZ1F0bq/W68zQkgmaFP6JL4pGjP4w9C5p0IXFJ+Aj7ddl/sU7fj/k8Hfbc34KOze
+        Vcy/biK+v5RBFmUb/MvRORNCSJuxxy3cLfDGaMn4DG6jb3N09imQUb+uLiyuhY+5RePdzZbz486q
+        WZusveBh+N9tzy9XOQe7ARnu30rr9d4MsijX4M9H50wIIU9Cm9Oh8OZoTzOLDmnU989gvG0az6AZ
+        9RsuM6OxHyL+Dv97zenu1Hw2SzEPc0aCOxWfRcm6BTLiJ6FzJoSQJxHfSdCFyqX4JmnI4B/vxG5F
+        3YJ+5h/Ax9ys7kdxU4Cl5hP8t/B/p0EbfnqqOZgr0nL7CHdkrFj3P+icCSFksUio7YtvksYM7sJO
+        HhyXM4v29n8APuZWDX72ErPR/x3877Ppr5b1xbB0+OJ5AuOjbYdN3gKdNSGELBFtVt+HN0trBjcD
+        nXsq9PO+Az7eVo27kS1mC2j9n9W5Ex7E+dKs7Y6YhznBF88T2HBvR+dMCCFLJR6CJU03D94wLRnc
+        XVaeAZc5g6vrZ74EPuZWjZsBDPdu9O889L/mBgGoLPyHkXMxB/jieZI6u4Lb7hJCugJdkBwDb5rW
+        DP4EdO6pkFZ/H88Ggdbame1DItsHRfIgUlAGV8rw4NrouYhGmu7b8CyKt/YydM6EEDIuxrZN9dfj
+        G6ch4wvpTT+Azj4VwrNnsDbc2/U/D4f/HRYdm+s884MvnieoNfdDdM6EELJcaPM6GN48rWnphfSh
+        KevoQuxq+Jjbdf4i0X+HRY9Dzz80ix7FvCyDLEp2voz07YLOmhBClov24xlxhxZ8EzVmrYHOPhXS
+        qA8KfwGltrxOZk1cHz330Ehw78ogi9L9KDpnQghZIWTEu0WPC6AbqSVvl+aUTdDZp0IXIl/KYMwp
+        TeFC7acvQc85NDK9d1tpuvszyKNkb+IXXUJIV6MXzJMyaKa21EU5OvdUyNSBDXQxcgN8zCmtXHcy
+        er7lgI7F6fgsCje4qeicCSFkpYiHF2lDuwfeUC0Z7zot5ryGUtHPfAB8zCmt0uBvlpmTNkbPNTTx
+        DhA8i/L9nfXDLQkhhSDcLSe9wV8aX9REZ58KCe5U+JhTWpUNdxB6jqGR2RPW0nn+D3gWJWtsN0VC
+        SOGM7Vji/gpvrvZ8Kzr7VMSDGPXieVsGY05ppz0NPb9yQK8hH8kgi7IN/iR0zoQQ0lGkUd8P3lzN
+        6e6LL2yis09FfG4ZP+aUdtDg7pLmHlui5xaauB2s9rN58DyKVq8Xw/1bobMmhJCOI8H/GN9kjRnc
+        qejcUxIPzoKPOaWdsuGno+dUDuhYnAfPonwPR+dMCCGVIKN+Z/0S8kgGjdaWjfr+6OxTIaG2jXDT
+        A1qG5/Fl4PjlozYtgyzKNvgr9fq8BjprQgipDGm6j8ObrT2vkuHBtdHZ9rq4MgAAIABJREFUp0Iv
+        podlMOaUrowPSqO+E3ouoWlvsx13AMPnUbaGfqQihBglHm4k8ZAjdMO1ZvDvR2efivirsfCRDdrN
+        ttyb0fMoB7RvnQDPonjdj9A5E0JIEuJzzfima033sKVfVBe9tPowftwpXW5/J3N6VkXPITQyo96v
+        c3hBBnmU7Hxp9e+KzpoQQpKw6Bfq32TQfG0Z/E/Q2adEP/O74WNO6fIY35Fr9E1Ezx00MjS0mn75
+        uBieR+kGPxedNSGEJKX969bYoUf4JmzK2mvQ2aeiff5M8Bfhx5zS8eqOQs+bHJDg3obPonhvlLDX
+        M9BZE0JIcnRxeGIGTdiaN8YXO9HZp0K/cE3mzmu0Kwzuj/FLM3rOoIlnF7XPpEDnUbot/yZ01oQQ
+        AkGaUzbRxeEd8EZszeA/h84+JfFXZfiYU7o045fkVv9z0HMlB3Q8vg/Po3SD/zW3eCaEmEab4Ux4
+        M7ZmfPSt5aags09FfKFX+M4RzVseAtfTvh4ckEEWZRvcY/HOMDprQgiB0l4cxkcP0E3ZmsFfaung
+        qUWHYD4AH3dKn2pwF8SXrtFzBE18H0Ga7gZ4HsXrPo3OmhBCsoAvpMN8Bzr7lOjnfWsGY07pf/ug
+        NGsT0HMjB3Rh/PkM8ijb4G6VUb8hOmtCCMkG/QLyVXhztmbwD0lrYEd09qlYtP3zT+HjTul/PBQ9
+        L3KAZ36ksjYNnTUhhGSFHDZ5C22Q9+AbtDXd2ejsU6JfuLZjndE8dOfyReBF22XzzI/qjY/6sd4I
+        IeTpSPCz4U3aoi3/OnT2KZGGb8LHnNo2+HtlpP5M9FzIAeGBoQl0C6TR14vOmhBCsqR9+m1wf8E3
+        a2u6W2S4dyN0/inRz30WftypWUP9EPQcyAEJtR2k/R5MBpmUrLGt1wkhZLnRZrm3uhDesK0Z/PHo
+        7FMio35r/eJ1J3zcqUHdj9D1nwvad87E51G4wd9m7QcmQghZIfQC/b/wpm3NuAtZqO2Jzj4lEupv
+        hI87tWX74NU9tkTXfg7oeBwMz8OCwY2gsyaEkK4gXqDbz0ijG7c9L7N0NkhEP/NpGYw7teMQuuZz
+        QJpTNmlvCYvPo2yDuzCetYXOmxBCugZtnofDm7dN343OPiVySP+m7Xdg8ONOSzf4b6HrPRd0zp0M
+        z6N43QIZ8Q6dNSGEdBWLtmb8K76JW9M9bO1gNP28r8SPOy3a4G+Ov/qjaz0HdDxeIHzPL0XNnYDO
+        mhBCuhJp+OfxQoW4cLlfWNsvXj/31+DjTss1+JejazwHZGjKOjoWV8PzKN3g7pJRvxk6b0II6Vqk
+        6b4Nb+YWDfWAzj4lMnVgA10YXQ8fd1qewZ+Eru9c0PH4JDwPG7bQWRNCSFcjw/1b6ZeQ+zJo6LaM
+        mwBM790WnX9KpFHfT3jHjXbWf8Uvt+jazgFp9fdpX3k0g0zKNviL+OI5IYR0AAnuXfCmbtPT0dmn
+        Jh7YlcG40yJ0CyTUno+u6RwYe6fP/xmfSeHG7dQbfg903oQQUgTti1fwl8Kbu0WDPxCdf0pk9oS1
+        WGu0IwZ3DLqec0HH433wPEzo/gedNSGEFIW03D7Cx2PSG3fvMXaKrrT6nzO2G1gG40+70/gYzNDE
+        NdG1nAMS6rvpfJoHz6R43Z188ZwQQiqAJ6SDNLido37ut8LHnXarD+qX2F3RNZwD8V0EHY/fZJBJ
+        +Tb8dHTehBBSJHLY5C10MXw3vNFbMz5X3HL7oPNPSdyGWD/3mfCxp92nsR3kloaOx1vgedjwN9a2
+        TieEkKRoo52ZQbO3Z3D/kOHBtdH5p6T9hZenpNPl8/vous0FGfXb6/y5P4NMyja4x6RZm4zOmxBC
+        iqZ9Sz/438ObvkWD/zA6/9Tohf1lwneP6Pi8UQ7p3xRds7mgXz5+lEEmBnQfR2dNCCEmkJbz7S0u
+        4Y3fmPGXtlCvofNPjX7uL8DHnuZtfEwx1PZF12ou6Bf3afBMLBgPT501cX103oQQYgYuClEXPHeh
+        DA2ths4/Jdyaly5b/gr9BNLo21znyx34TAzY8q9G500IIaaIpwtrA74JfgGw6bvR+aeGW/PSpfhn
+        brn7H3Q8Ts8gEwO6s9FZE0KISSS4qfiLgEGDf0QafRPR+adG6+1t8LGneRn8QzLqn42uzVyQUH8V
+        PBMTuoelNbAjOm9CCDGLLgDOx18MDBo3ArD2KFbcmrfpz4KPPc3HlhtF12UuxBfw9Uv6rfBMTOiO
+        QudNCCGmiQd+tX+Rh18QDBrc29D5p4Zb89J/G9wP0fWYEzoep8IzsWDcEn32hLXQeRNCiHm0KX8U
+        flGwaHz8pFmbgM4/Ndyal4790r/HluhazAVpuVfAM7Fiy70InTchhBBFhqasI033T/iFwaLB/cLi
+        Cbz65et4+NhTlPHL5wHoGswFGfUbSjwDBZ+LAd3/ovMmhBDyXyz6VTqDC4RBgz8MnX9q4qnw3JrX
+        qu7T6PrLCR2Pb+AzsaC7T7/sbY3OmxBCyFOIz2TjLxIWbV8Yt0fnnxr90juZ7x+Z8xI+f/8fdDwO
+        yCATK85E500IIWQxyEj9mbogfCCDC4VFzzP5KFbTvyWDsadpfJBb7v6HsUev3A0Z5FK+wV9kbddB
+        QgjpKrRZvwd+sbBqcCPo/BFw9x8jhvoh6FrLCf3y8RV4JhYM/nFp+D3QeRNCCFkKMurX0Kb9N/hF
+        w6LB323xGeVFvwRzE4SidSej6ywnpOVeKtwJLo3BfQGdNyGEkHGgF8d9eHGEXSxNno0goVbn+yCF
+        Gtzl+iVzXXSN5YJMHdhAa/16eC42vCn+wIHOnBBCyDjRC+RJGVw8jFqbhs4fgX72t+LHnnZWNy9u
+        NoCurZzQcfkyPhcjtvzr0HkTQghZDqQ5ZZOxw8IyuIhYM/h7pTWwHboGEOhnPwM+/rSD1hromsoJ
+        HZMXC+8uJ9Kdjc6bEELICqBfQKbiLyJGDe5nJnfFGu7dSD/7tfDxpx2oYf8ddD3lBHe9Slp7D0lr
+        YEd05oQQQlaQ9kIYfTExq81fj2VGvV8//3z8+NOV8Kr4rgO6lnJCF8WnZJCLDYM/Ap03IYSQlUCG
+        e58lcf9+9AXFovFRLIMHFEak4d4OH3+6grp5Euo1dA3lhI7Hq/C5GDH4S+NujujMCSGErCTa1N8H
+        v6iY1Z1r8lEs/cz6+b+PH3+6Ah6Krp+c0MXwZnyfLpHxzI+Wm4LOnBBCSAeQOYOra3O/BH5xsWpw
+        M9A1gIDvg3Slp6PrJjfimGSQixWPQ+dNCCGkg8STZNu/LuEvMBZ9UBr1ndA1gIDvg3SRwV/DMxee
+        jLT8m+C5WDH4m1l/hBBSINrgT4RfZKwa/PkWH8WKxBdK4eNPl1Wfj0jLeXSt5IQuhreWprsTno0V
+        gz8QnTkhhJAKGNtG0t8Ev9BYNbhZ6BpAsOh9kB/Ax58upTb9bHSd5IbwHaaUnoXOmxBCSIXwkQKo
+        D0qzNgFdAwhk5qSN+T5IpgZ/ptW7c0sibqENz8WM7n6rB7cSQogpdMHxE/xFx6jB/ULm9KyKrgEE
+        +vkHhO+DZGY8WG/KJujayAkZqT+zvYU2PBsjBvc2dOaEEEISEF+Ibp80i77wWLXh3o6uARR8HyQj
+        43sf+qUQXRM50X5ckIe3pvRPMjS0Gjp3QgghiZCmOyqDi49N48Iv1J+LrgEUOganwTOgUZ738RTi
+        uzAZ5GJEt0BGvENnTgghJCHts0GC+wv+ImRVd7HV035l1sT1tfYux2dg2m+i6yA3dD4+m3eGExr8
+        sejMCSGEAJD4TD7PBkF6NLoGUEirf1c+Zw8y+Et1sb0uugZyYtFhrX+AZ2PF4K+PP0SgcyeEEAJC
+        mu5/4Bcjqwb3WDwgEl0DKCTUX6XjsBCegy3v0S8fO6Ozzw1dEH8og2zsqHMfnTkhhBAgMty7UfsE
+        WvQFyarBXylDU9ZB1wEK/fxz4RnYcaE03EHozHND2neC3WMZ5GPD4L6LzpwQQkgGSKi/Fn5Rsu1x
+        6BpAEbck5rbQiQz+w+i8cyM+iiZN93d4NlaMj11O790WnTshhJBMEJ76i3ShNGsvQ9cAingOBQ8p
+        rNzzuN3p09Fx+WIG2dgx1AM6c0IIIRkho35rCf5u+AXKrjfG08LRdYBCWv190nQPZ5BDgbobdH5v
+        hs44N3RsXix8Bymd8RDWnp5V0LkTQgjJDL1IHAq/SJnWfQNdA0h0gTIDn0FhxjNnZtT70dnmRvvd
+        t/Yp8BlkZML440JtAjp3QgghGTJ2CrA/H3+xMu0Qug6QaP2dlEEG5dhyo+hMc0Tr7DvwbCwZ3LvQ
+        mRNCCMmY9vkMTTcPfsGyavB3yHD/Vug6QCGzJ6yli5UL4TmUYPCnoPPMEa2vqfBsbHmJ1UNXCSGE
+        LAd6gX5vBhctuwb/Y3QNIJGR+jN1HG6H59DN8rDBxSKtge0knoWCzseKcXvjVn8fOndCCCFdwNip
+        wO5i+MXLtoei6wCJhNq+WoMLMsih+4ybSfCwwaexaMtnPmKathbnonMnhBDSRcQXV7kAhF64H5JQ
+        3w1dB0i0/o6C59B9LtTaORCdXY7ouByZQT6WvMryIauEEEJWEAnuMxlcxOwa/EWWn51ub4rQdN+D
+        59BNBv8hdG45IiPe6fjMh+djx4XxLiY6d0IIIV3IolOC/5nBxcyuxk+vlqkDG/Ck6nHXyk/iY0bo
+        zHKj3ceCvxKejyWDPxGdOyGEkC5GWu5FwsO6kBfyx6VRH0TXAZL4KJrwxeFl1Im7Vg7p3xSdVY7o
+        F9j/gedjyeBvtnyoKiGEkA6hF/D/hV/ULBsXl1MHNkDXARJd1LyE7yQtSXe/tPqfg84oR/TL+/7C
+        H1DS2nAHoXMnhBBSAPGXVV0A3ga/sNn2a+g6QKNfxN6ZQQ55Ge+QNWuvRGeTI3LY5C20Zm6FZ2RK
+        9z107oQQQgqCh3flYO0N6DpAw5PSn+b70JnkyNgGBv6sDPKxY/D3yvTebdHZE0IIKYx4QB78Imfb
+        e+Ihfeg6QCJDE9fUOvx1BlngDf6MuNBGZ5Ij0nBvh+djzYZvonMnhBBSIDLqt28/b46+0JnWnWt9
+        0SnD/VvpONyAzwLqJTJt8nroLHIkvg+j9fFwBhkZ0v3Sel8ihBBSIXqxeSv+Ymfew9F1gEZCvdY+
+        rBGfBUB3pzTqO6EzyBEZHlxbx+gyfEaWjF/2ahPQ2RNCCCmYeM6ABHcB/qJnWTdPRvwkdC2g0S8h
+        rxVrOxwF95h+8XoheuxzRcfoOHhG1gzunejcCSGEGEBa/bvyEQe4f5OhKeugawGNLn6OySCLdLbc
+        m9FjnivSrL1MrH0hxfsHGRpaDZ09IYQQI0jwR2Zw8bPuF9F1gGbRbkenZ5BF9Qb/dfR450p7y92m
+        uwWekSWDf4TnzxBCCEmKzBlcXYK7EH4RtG7LvxpdC2hk1sT1pfzn/n8nsyeshR7rHFn0WOjPMsjI
+        lsG9F509IYQQg8T3EPRCNB9+IbRs8HfH3cnQtYBGhnufpeNxOzyPajK+WUJtG/QY5wrvxkK8RPvO
+        GujsCSGEGEUvREdncDE0rvsln8OOZz/450lxX4jdPP3PAfTY5op+MauXl3nmxo0QRrxDZ08IIcQw
+        7Uexmu5i+EXRusEfia6FHJBQD/AsOmqtgR7TXGk/ehfcP/AZmfNodPaEEEJI3BWrTxfAj2ZwYbRr
+        /FWy5aagayEHtBZPgOfRGT+JHsuc0ZxPySAjWwZ/Bd9FIoQQkg16YZoLvzhaN/hrZOrABuhaQBOf
+        Tdfx+Dk8j5XL8id8rG7JSMNPh2dkzfgjx4x6Pzp7Qggh5N/EX8Uknk2Bvkhal1u1tpHmlE2k6f4O
+        z2PFvEy/RG2IHsNc0bHZWbO9L4OcbBn8XHT2hBBCyNOIjwDpwmAB/EJJD0bXQg5Io76TdN/OWNfp
+        Antr9NjlyqK7W3/IICdj6pd5HnxKCCEkV/RidRz+Ymnc4O+V1sCO6FrIgfbOWPHANHQm49LdqQvs
+        Z6PHLGd0nD6Fz8mYwT8e5xE6e0IIIWSJyLTJ6+lC6p/wiyb9XdyhDF0POSDN2ht0PBZmkMlSdA/r
+        f+6NHquckZZ7af45Fulx6OwJIYSQZaILhRdxoZCBwX8MXQu5oGPxYXgeS87pcf2S9Br0GOWMDPdv
+        JcHdCs/KmnFji2mT10PnTwghhIwLXSx8CX7xtG57YetfjK6FHJCenlV0LL4Jz2TxOc1Gj0/OyJye
+        VbWf/Ayekz0XSqO+Hzp/QgghZNzE7WB1YXV9BhdR2wZ/G19qHkOGB9fWhexv4Zk82Y+ixyV3pOk+
+        mEFO9gz+BHT2hBBCyHIjjfr+8Isojf6cZ0qMoV/GNtOF1dUZZBIXeN+Kd2bQY5IzEmrP5856kNq8
+        XsJez0DnTwghhKwQunj4BvxiSlV3FLoWckGatd11TO4BZ6JfCieuiR6LnJFG3+Y6Tjfi545Fay9D
+        508IIYSsMO0D4YK/GX9BNe7YKcZ7oeshF3RMXqDOB+XBgwaXQfu9j6Y7Gz5vTOq+gs6fEEIIWWn0
+        C8jL8RdVqguLG+SQ/k3R9ZAL0vBNQA7XxR2d0J89d7RnHImfLya9UYZ7N0LnTwghhHQEXVB8PYOL
+        Kw3+TL538B90PI5NN/48aHA86FgNaC6PwueKPRfGs1bQ+RNCCCEdIz5y0v4FHn+RpS33ZnQ95MLY
+        oz7+B9WPOw8aHA8yc9LGEu8SoeeIRbnrFSGEkBLRi9yLhQcU4g3+EQn1GroeckGGpqwjwf2xwvHm
+        QYPjYNFZLQm+DNLFeB13vSKEEFIs0nQnZ3CxpXErWi44/k08K6WyO3Q8aHBc6FgdDp8XFh07sPQF
+        6PwJIYSQyuCjWDnp/hddDzkhrf7n6GLs3g6PMw8aHAcyo94vuF3JjOs+j86fEEIIqRxd5L1E+ChW
+        HoZ6QNdDTowdntmhg+940OC4iLsuSXDXwueCReOd0GmT10PXACGEEJIEvfCdCL/4UtXNk1Z/H7oe
+        ckIa7u0dGFseNDgO2u99BH8Gfh4YND56FWrPR9cAIYQQkoz4q5teAK+BX4Rp9CqZOrABuiZyQmvz
+        +JUYTx40OE4kuHdmUP82Df5YdP6EEEJIcqTlXiR8FCsPg/8Ouh5yQoaGVmufmbL8Y8mDBseJzv8p
+        wvc+QLq/x93f0DVACCGEQNCL4RfxF2PatuVG0fWQE3GXMP0SculyLOp40OA4keaUTXTM/gWveYvG
+        R68a/nnoGiCEEEJgLHoU62r4RZlK+30Qng/yJCTUdpDgbh3H2PGgwXHSPvwx+HPw9W7U4Oeia4AQ
+        QgiBExdui/aix1+crRu/DPJ9kCchLed1XB5aypjxoMHlQMfsA/A6t2rwV8jw4NroGiCEEEKyIO5F
+        D7840yc8DV0PuSGh/tolfknmQYPjRsfrBR3b5pgun8E9Fs9bQdcAIYQQkg0y6teVuBsT+iJNn3Am
+        uiZyQxdw713MOPGgwXEizT221C9rN2dQ2zYN/kPoGiCEEEKyQ2bU9+Kvo5kY/CPx0SN0TeTGk86v
+        4UGD46a9q1jTnQuva7tewnNpCCGEkCUgwX0mg4s1jcZzWniexZPQ8VhDx+Y8HZvzuaAbPzpeH4PX
+        s1Xjo1f8MYEQQghZMnFv+vYe9eiLNl2k+x5/5X8yMnPSxnGLXvTf0S1oHR3ATSagfgBdA4QQQkj2
+        LNp16NEMLtw0GvwR6Jog3YmM+u21fu6A17BVg78o3rVD1wEhhBDSFeiF88PwizddtIhpP8KxD7om
+        SHcRt3vV+vkTvH6tGreODvXd0HVACCGEdA0yZ3B1XfheCL+I00W6W2TUb42uC9I9aM2cjK9b074F
+        XQOEEEJI1yHN2u6LTphGX8hpNLhfxC+G6Log+aP10oLXq2nduXx3ixBCCFlBdNH7TvzFnP7b4Oei
+        a4LkjTT6evnDAXSO3hvfvUHXASGEENK1yJyeVdu/vKMv6vQJF0rDHYSuC5In7R3Cmu6fGdSpXYOb
+        iq4DQgghpOuR4d5n6aLmPviFnT7hPTLqd0bXBcmL9o8FTXd2BvVp2e+j64AQQggpBuEz5XkZ/KX6
+        JWRddF2QfNC6OBpel5YN/jY5bPIW6DoghBBCikIvsGfCL/L0v3Qno2uC5IHWw4u1Hhbga9Kwwb8c
+        XQeEEEJIcUijb/P2r3zoCz39r0VPPaDrgmCRUNuBhw2i56E/EV0HhBBCSLHohfZA+MWe/pdunox4
+        h64LgqF92GA8bRteh4YN7loJez0DXQuEEEJI0ehF95vwiz79rwWQv1qGezdC1wVJDw8bROsWSMM/
+        D10HhBBCSPHIqN9QF73X4y/+9L/8qQwNrYauDZIOnYOHZVB3xnUfR9cBIYQQYgZp1PeTeCYFfAFA
+        /8uj0XVB0iAtN0W/gDySQc1Z9m/xETh0LRBCCCGm0AvwFzNYBND/yEMKDSDNPbbUrG/MoN4sOz+e
+        OI+uBUIIIcQc8RwKCe4fGSwG6H+8R5q1CejaINWgc24NzfhXGdSZdd+DrgVCCCHELBJqe/L8gey8
+        TKZNXg9dG6TzCO864g3ut3zfihBCCAGjF+WPwhcF9KmLpFPRdUE6i+Y6DK8r6wb/gIz6ndG1QAgh
+        hJhH5gyurgveP8IXB/SpHo6uDdIZpNXfp4vfhzKoKdvy4M//3969ANl11/cBX8kWxi8wYBwgprwE
+        CUos7f7PlVBcQGQgCaEE8mDTAAbpnnu92GYcp2ambYqnoh1oIU1K07hDG9owpAyhFAcGpylJJm4T
+        aCCkBMyrQHgEEz94+IGNsS1b+vV/1yKR5V1pJe3u79x7P5+Z74hhwL7n/H9n9vvX3XMOAHTH6L6D
+        xb8dzC4IckhZKvfWP5+TPRucmHjF9kctvuwue57kvdmzAAAcppakSzpQEuTQtM3XY7jj3OzZ4PiM
+        7jWI0TtesudIro+F5uzseQAADhMzMxtq4b26A2VBHpiPxKWbT8meD45dDMqvdWB+pj2j9x29IHsW
+        AIBlxEVbz4m23NSB0iCHpi3/MXs2ODYxbF6aPjcyypuzZwEAOIpanF7cgdIgD84wezZYmdFL7up6
+        facDMzPlKZ/ytnMAGBP1h/dv5pcHeUDaZl8My7OyZ4MjW7zpfFC+lD4v0562udvbzgFgjIxehOct
+        6V1MudFN6d21+EjrQXNN/pxI3YBcnj0PAMAxinaut/i37tlFQg4vVh92U3o31bW5Mn0+pKb8Ueyd
+        2Zg9DwDAcag/zF+XXyZkiYL19uzZ4IGiLXvy50Jqbo2F5u9lzwMAcJwO/krJn3WgVMjhGZZXZ88H
+        94sLe+cv3nOQPRNSM/cPs+cBADhB0e89OQbl9vxiIQ/I/b8e95zs+Zh20c49LkYvusueBxldE7+V
+        PQ8AwCqpP9yH6eVClkj5Vgx3PCl7PqbV6BGv0ZaP5s+B1HX4crx8x8OyZwIAWEX1B/x/Ty8ZslTx
+        +ngsNKdlz8c0Gv2Ne/r6y+ibj/3Rzj07ex4AgFVWS+7Z9Qf9DellQ5bKO7LnY9rUc/6PO7Ducn9e
+        lz0PAMAaqRuQH68/7A90oHDIg/Oa7PmYFvVc/1gMyn0dWHMZNH8RC82m7JkAANaQdx10NG25N/q9
+        52XPx6SL4fanxehRr9nrLaNfvbojBnObs2cCAFhjo/sN6g/+z6aXD1mikJWbFbK1E7u3nVVn//+l
+        r7McnPdemz0TAMA6qT/4fzgG5a70AiJLlLJakGtRzp6RSRPz8yfV8/t76esrB1Pekz0TAMA6q0X3
+        8vwSIkumbT4wKszZMzJJ6nn9d+nrKgfnu3wtBjsfmT0TAMA6i5mZDeFvhLucX8mekUkRg7l+B9ZT
+        Rhk9ctcLOAFgesVFW8+JQbkxvZTI0uk3g+wZGXf1HD6znst70tdS7k9b9mbPBACQLAZzzw+P5u1o
+        yl0xLDuzZ2Rcxe5tT6zn8Rv56yiLacuH/GohALAo2ubX08uJLJNyY+zpPT57RsZNtOefWc/fJ/PX
+        Tw7m1tGGMHsuAICOiEs3n1ILwic6UFJkyZS/jAu2np49J+Mi9s5srJvq9+evm/xths1Ls+cCAOiY
+        6M9uqaXtzvSiIsukvGf04IDsORkH9Xz9m/z1kkNm9z9nzwQA0FHRlkvyy4osm7a5IntGui76zSvT
+        10kOndm/Gv06XPZcAAAdVjch70svLbJcDkS//Hz2jHRVXNg7vxbeuzuwTjJK2+yrf+7IngsAoONi
+        oTm7lobr08uLLFfq7oj+7LbsOemaxSdetc3X09dHDp3Vy7PnAgAYE9Hv7YpBuS+9wMhyuT6GO87N
+        npOuWHziVdtc24F1kb/LH7hnCQA4JtGWN3WgxMjy+ZgnY9U5nZ8/qW4+ru7Aesjf5Rux0Dw2ezYA
+        gDFTC8SmWiQ+0oEyI8ulba4aPXI2e1Yy1XNwZfo6yKE5EIO5n8qeCwBgTNVNyFNiUG7vQKmRZVPe
+        mD0nWaJffin//MtheXP2XAAAYy7aXtuBUiNHzquy52S9Rb/3k+5T6lrKp2L3rodmzwYAMAGiLe/M
+        LzeybEaPO23nnps9J+slhtt/qB7zbennXQ6dwTtjMPf07NkAACZE7N52Vi0ZX0kvOXKkAnhLtL0f
+        yJ6VtTa6uTkG5br08y2HZ5g9GwDAhKkFY8fBF4tlFx1ZLm35cvRnH509K2sl5neeGh6M0MW8O3s2
+        AIAJFYPyyx0oO3LkfDAu3XxK9qysttE7Jer8/U4Hzq8cmrb5Yiw0D8+eDwBgQo0e+Rpt+cP00iNH
+        K4XvmrSXwHkvTQcz+ka03zwjezYAgAkXF209pxaPG9LLjxytHF6RPSurJQZz/fTzKUvMWLksezYA
+        gClRy+2P1uxPL0BypByoeVn2rJyoaOeeXY/jng6cTzk0bfkfk/YtGwDQcaMX4KWXIDlKyl21wP9I
+        9qwcr8UXYbbNN/PPozwgbflaXZuzs+cDAJgysXfXybWI/J/0MiRHKYu1wNcinz0vxyoGOx9ZP/8X
+        0s+fHJZy3+gb0Oz5AACmVOzpPb5uQm7OL0VylHxm9C6X7HlZqbrWFeWXAAAPBElEQVRh2lQ/8zUd
+        OG/y4Lw2ez4AgCkXbe/nOlCK5Ghpmw+MvrXKnpejOfi43benny9ZYobK/4r5+ZOyZwQAYHQ/yFvS
+        y5GsoEA2b82elaMZPb0r/TzJUrPz9WjnHpc9HwAAi2L3rofWkvKJ9JIkKyiS3X10agybl3i6Widz
+        IIblhdnzAQDwANGf3VLL450dKEtypIwKftt7Ufa8HC7auZ756Wja5l9nzwcAwJJqWRmmlyVZSaG8
+        o24Yt2XPy/fUzccToi03pZ8XWWJWyp+PHgqQPSMAAMuqpeUd6aVJVpLrY7jj3PR5ac8/s26Iru3A
+        +ZAH59bYve2J2TMCAHBEccmWM6Itn+9AeZKj52NxwdbT02Zlfv6kuvm4ugPnQZZKv/xM1mwAAByT
+        xd/nHzT3pBcoOXra5qrYO7MxZ06aK9OPX5aZi/IbGTMBAHDcarm8PL1EyUrL5pvWfz7KZenHLcvN
+        w8dHT7Zb75kAADghiy+Ua8v70suUrDSvWrfZ6Pd+ss7GvR04Zjk8owcULDQ/uF6zAACwquLi8x5R
+        S81X0kuVrKR47ot27rlrPhPD7T9U/123pR+vLDMH5eVrPQMAAGuqlpod4X6Q8choY1A3CGs2C7u3
+        P6b+O76afpyy3PpfuVZrDwCwrmq5eU16uZIVltDy5ejPPnrVZ2B+56n1n/+R9OOT5fKJ0Rqt9roD
+        AKRYvB9k0Ly3AyVLVpYPxqWbT1nd9S+/04HjkqVza/R7T16t9QYA6ITF+0FGf7ueX7ZkRakbhrpx
+        WJW1H5Q35h+PLJMDMZj72dVYZwCAzgn3g4xbXnvCa96WPR04Dlk+b16NaxsAoLO8H2SscqDmZce/
+        1nPPrut9dweOQ5ZKWz4a81sesprXNwBA5xy8H+R308uXrDDlrrqR+JFjXueF5il18/HN/M8vS6Zt
+        bonhjietxTUOANA5sXvbWe4HGaOMNhJ1Q7Hi9R3sfGT9/30h/XPLcjlQ1/Sn1/IaBwDonLiwtz3c
+        DzJO+cxo43jUdV1oNtX/7TUd+LyyfH5lPa5xAIDOiX75pQ6UMVlp2uYDsXfXyUdc00F5e/rnlCOt
+        4Yfd9wEATK3F+0Ha5qr0UibHUmDfuux6ts0V6Z9PjrB25eZo556wntc4AEDnuB9kDNOWyx60jsPm
+        JXUDsj/9s8lyORBt70UZ1zgAQOcs3g/ica3jk9FG45AyG+1cr/53d6Z/LjnCmpXXZ17jAACdM/pb
+        9fSSJsdQaJs7oj+7bfQrPXXtbkr/PHKElP99tHt3AACmjvtBxjHlurr5+HT+55BlM9octnOPy76+
+        AQA6afF+kEH5UnppE5mIlPui33te9nUNANBpMZjbWovTd/PLm8jY57XZ1zMAwFioxWnYgfImMs75
+        vdg7szH7WgYAGBvRNr/VgRInMo7563jF9kdlX8MAAGMldu96aAzKX3agzImMUcpdMSxN9vULADCW
+        YjC3OdrmtvxSJzIm6TeD7OsWAGCsjV54F6O3OGcXO5Gup23+a/b1CgAwEWqx+tX0cifS5bTNtbHQ
+        nJZ9rQIATITRW5xrwfrT9JIn0s3cWjcfT8m+TgEAJkrs3v6Yugm5oQNlT6RLORD98jPZ1ycAwESq
+        Zes5i293zi99Il3JG7KvSwCAiRZt+WcdKH0iXcg1MT9/UvY1CQAw0WJmZkMtXu/tQPkTSUy5MRaa
+        x2ZfjwAAUyEuPu8RtYB9Kb8EiiSkbfZFv3lm9nUIADBVoj+7rW5CvpteBkXWP7+Yff0BAEylWsRe
+        1YEyKLJ+aZt3ZV93AABTrZayt6WXQpH1SFs+Hy/f8bDsaw4AYKrFBVtPj0H5VHo5FFnLtM0d0Z/d
+        kn29AQBQxZ7Zp8bobdDZJVFkbTJ62eDPZ19nAAAcIgZzPxVts78DZVFkddOWN2VfXwAALKEWtden
+        l0WR1Uzb/HHs3XVy9rUFAMASYu/MxhiU308vjSKrknJd9GcfnX1dAQBwBF5SKJORcldc2NuefT0B
+        ALACiy8pbJs780ukyHGm3wyyryMAAI5BDOYuSC+RIseV8pbs6wcAgOMwKnL5ZVLkGNI2H45LN5+S
+        fe0AAHAcYqHZVEvdB9NLpchK0pabYrjj3OzrBgCAE1A3IY+NtrkhvVyKHCltuTf6vV3Z1wsAAKug
+        Fry/Xzch+9JLpshyactl2dcJAACrqJa816SXTJGl0pZ3Zl8fAACsgVr2/lt62RQ5NG1zbVyw9fTs
+        awMAgDUQl2w5I9ry6fTSKTJK29wSC81Tsq8LAADWUOyZfWotfrell0+Z7rTN/vrnC7KvBwAA1kG0
+        vRfV8ncgvYTK9KZtrsi+DgAAWEe1AP6r9BIq05m2eX/sndmYfQ0AALCOYn7+pFoEP5BeRmXKUj4X
+        C83Ds+cfAIAEcfF5j6ibkL/KL6UyHSm3R392S/bcAwCQKAZzT6/F8Nv55VQmOqObzoflhdnzDgBA
+        B9Ry+NPhpnRZ05Rfzp5zAAA6pJbEN+SXVJnItM1VMTOzIXvGAQDokNFTiWpRvDq9rMpkxZvOAQBY
+        TrTnn1kL42fTS6tMRtpyszedAwBwRNH2fsCb0uXEU+6Lwdzzs+cZAIAxEMPmxYtPLUovsTK2actl
+        2XMMAMAYqRuQf5FeYmVMU347e34BABgzo6cW1SL5nvwyK2OWj8X8zlOz5xcAgDG0eFP6oPlMB0qt
+        jEPaclMMd5ybPbcAAIyxGG5/Wi2Xt6aXW+l22mZftHPPzp5XAAAmQAzLT9z/VKMOFF3pZoZlIXtO
+        AQCYIHUD8s/TS650Nf8hez4BAJgw99+U3ry7A2VXupS2fCjmtzwkez4BAJhAccmWM2JQPpVeeqUb
+        aZuvxkVbz8meSwAAJljsmX1qLZ63pJdfyd583Bl7mpI9jwAATIFaQH8s2nJvegmWrByIYfPS7DkE
+        AGCK1BL6jzpQhCUjbfMvs+cPAIApVMvob6aXYVnv/G7sndmYPXsAAEyhWGg21UL6Jx0oxbI++URc
+        sPX07LkDAGCKxeAZ3xeDcl0HyrGsacq3ot97cva8AQDATAy3z9aS+p38kixrkrbZVzcfu7LnDAAA
+        /la0vZ+L0dORssuyrH6GZSF7vgAA4EGiLa9PL8uyumnLv82eKwAAWFLMzGyopfXd6aVZVmvz8Yex
+        d9fJ2XMFAADLiku2nFHL6yfTy7OcYMrnYve2s7LnCQAAjqoW1yfWEvuN/BItx7n5+Hb0Z7dkzxEA
+        AKxYDMuzapm9J79MyzFuPu6rf74ge34AAOCY1U3Iq/MLtRxjfjF7bgAA4LjFoLylA6VaVpa3Zc8L
+        AACckFhoNtVie00HyrUcKW35UFy6+ZTseQEAgBMWr9j+qGibL6aXbFkufx0XbT0ne04AAGDVxJ7m
+        vBiU2ztQtuUBGa3J3Nbs+QAAgFVXi+7zoy335pduWUzb7I+296LsuQAAgDVTNyCXpRdv+V488QoA
+        gMkXbXNlB8r3dKdt3po9BwAAsC5ifv6kWoCvTi/h05s/iL27Ts6eAwAAWDfRnn9mLcKf7EAZn660
+        zWdj97azstcfAADWXS3CT4y23JReyqclbfPNGMxtzl53AABIExf2ttdifGd6OZ/4lLvquT4/e70B
+        ACBdLcjzNQfyS/rEpp7buQuy1xkAADqjluTXdaCoT2basjd7fQEAoFNiZmZDLcvvSC/rk5d3j85t
+        9voCAEDnxO5dD62F+c86UNonJX8RC81p2esKAACdVQvz2dE2X+xAeR/3fCUGz/i+7PUEAIDOi8Hc
+        02uBvrUDJX5MU26PPc152esIAABjI4blJ6It9+aX+XFLua+euxdmrx8AAIydWqiH+YV+zDIsr85e
+        NwAAGFsxKP8+vdSPS9rm17PXCwAAxlrMz59Ui/X708t919M2/zP27jo5e70AAGDsRXv+mbVgX5te
+        8rubz8RC8/DsdQIAgIkRr9z2/bVo/00Hyn7HUm6Mdu4J2esDAAATJ4aliba5M7/0dyXlrnpOdmav
+        CwAATKwYNi+pm5D9+eU/PQdqXpa9HgAAMPHqBuSKDmwAsvPa7HUAAICpEDMzG2JQfrsDm4CctM27
+        Rucgex0AAGBqxEKzqZbxa9I3A+ufD8alm0/JPv8AADB14hXbH1UL+Rc6sClYp28+ypfjoq3nZJ93
+        AACYWrHQ/GC0zS3pm4M1T/l2tL0fzj7fAAAw9aLf21VL+j35m4S1+uaj2VeP8XnZ5xkAADgo2l6b
+        vlFYu1ycfX4BAIDDxKD8Wgc2C6v97cevZp9XAABgCbF3ZmO05X3pm4ZVS/n9mJ8/Kfu8AgAAy4iF
+        5rS6Cflo/ubhRL/5KB+PS7ackX0+AQCAo4h27nG1wH8tfRNx3JuP5obY03t89nkEAABWKPY0pZb5
+        76RvJo455bvRb56Rff4AAIBjFIO5n4222Z+/qVhxDkTb+4Xs8wYAABynWur/aQc2Fiv91at/kn2+
+        AACAE1SL/X9K31wcPW/LPk8AAMAqiIVmU92E/HEHNhnLffPxp3Hp5lOyzxMAALBKYrDzkdGWz6dv
+        Nh6U8qXozz46+/wAAACrLPq9J0fbfDN/0/G9bz7KzTHc/rTs8wIAAKyRGJZn1U3I3fmbj2ZftHPP
+        zT4fAADAGou27EnfgAyaV2WfBwAAYJ3UTcib8jYf5Y3Zxw8AAKyjmJnZEG3zroRfvboq9s5szD5+
+        AABgncX8zlOjLX++jhuQj8UFW0/PPm4AACBJLDSPjUG5bh02H9fHcMe52ccLAAAki+H22WibO9bw
+        167ujAt727OPEwAA6Ii6UXhBDMp9a7D52B/D5sXZxwcAAHRM3TC8Zg02IJdnHxcAANBRMShvWb0N
+        SPkv2ccDAAB0WCw0m+rG4Y9WYQPyJzG/5SHZxwMAAHRcvHzHw6Itnz6Bbz4+Fxef94js4wAAAMZE
+        DHc8qW4mvnEcm49vxZ7Zp2Z/fgAAYMxEv3lmtM3dx3DD+b6aH83+3AAAwJiKtvcLdXNxYEUbkH7z
+        yuzPCwAAjLm6uXjD0b/9KK/P/pwAAMAEiJmZDXWD8c4j3Pfxntg7szH7cwIAABMi5neeGm3z4SXu
+        +/i/sdCclv35AACACRO7tz+mbji+esgG5G/ildu+P/tzAQAAEyr6s1vqJuS2GJTb63/elv15AACA
+        CVc3IP9glOzPAcD4+f/rItes5j0e7wAAAABJRU5ErkJggg==

--- a/operators/vcp-operator/v1.4.0/metadata/annotations.yaml
+++ b/operators/vcp-operator/v1.4.0/metadata/annotations.yaml
@@ -1,0 +1,13 @@
+---
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: vcp-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-unknown
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown
+  com.redhat.openshift.versions: v4.6
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"

--- a/operators/vcp-operator/v1.4.0/tests/scorecard/config.yaml
+++ b/operators/vcp-operator/v1.4.0/tests/scorecard/config.yaml
@@ -1,0 +1,21 @@
+kind: Configuration
+apiversion: scorecard.operatorframework.io/v1alpha3
+metadata:
+  name: config
+stages:
+  - parallel: true
+    tests:
+      - image: quay.io/operator-framework/scorecard-test:v1.31.0
+        entrypoint:
+          - scorecard-test
+          - basic-check-spec
+        labels:
+          suite: basic
+          test: basic-check-spec-test
+      - image: quay.io/operator-framework/scorecard-test:v1.31.0
+        entrypoint:
+          - scorecard-test
+          - olm-bundle-validation
+        labels:
+          suite: olm
+          test: olm-bundle-validation-test


### PR DESCRIPTION
Venafi-internal link: https://venafi.atlassian.net/browse/VC-34649

For context, this new release of the Venafi Control Plane Operator brings the following version changes:

| Component Name             | Old Version (1.3.0) | New Version (1.4.1) |
|----------------------------|-------------|-------------|
| AWSPrivateCAIssuer         | v1.3.0      | **v1.4.0**      |
| ApproverPolicyEnterprise   | v0.18.1     | **v0.19.0**     |
| CertManagerApproverPolicy  | v0.15.1     | **v0.17.0**     |
| CertManager                | v1.15.3     | **v1.16.2**     |
| OpenshiftRoutes            | v0.6.0      | **v0.7.0**      |
| TrustManager               | v0.12.0     | **v0.13.0**     |
| VenafiConnection           | v0.1.0      | **v0.2.0**      |
| VenafiKubernetesAgent      | 1.0.0       | **1.4.0**       |

