### PR TITLE
[ISV-5446] Configure allowed catalog bundle registries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,3 +22,6 @@ tests:
   - name: check_upgrade_graph_loop
     ignore_operators:
       - ^vfunction-server-operator
+
+allowed_bundle_registries:
+  - registry.connect.redhat.com


### PR DESCRIPTION
Configure image registries allowed for bundle images in catalog. Relates to the new static check in pipeline [check_bundle_images_in_fbc](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/docs/users/static_checks.md#check_bundle_images_in_fbc)

Closes ISV-5446