### PR TITLE
Fix Makefiles for fbc operator

### DIFF
--- a/operators/appian-operator/Makefile
+++ b/operators/appian-operator/Makefile
@@ -67,7 +67,7 @@ catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
 		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir

--- a/operators/cloud-native-postgresql/Makefile
+++ b/operators/cloud-native-postgresql/Makefile
@@ -67,7 +67,7 @@ catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
 		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir

--- a/operators/cloudnative-pg/Makefile
+++ b/operators/cloudnative-pg/Makefile
@@ -67,7 +67,7 @@ catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
 		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir

--- a/operators/dell-csm-operator-certified/Makefile
+++ b/operators/dell-csm-operator-certified/Makefile
@@ -67,7 +67,7 @@ catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
 		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir

--- a/operators/operator-certification-operator/Makefile
+++ b/operators/operator-certification-operator/Makefile
@@ -67,7 +67,7 @@ catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
 		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir


### PR DESCRIPTION
There was a copy/paste bug that uses hardcoded operator name in Makefile. This commit fixes it.