### PR TITLE
Lowered minKubeVersion for splunk-operator version 2.7.0 to match docs.

### DIFF
--- a/operators/splunk-operator/2.7.0/manifests/splunk-operator.clusterserviceversion.yaml
+++ b/operators/splunk-operator/2.7.0/manifests/splunk-operator.clusterserviceversion.yaml
@@ -811,7 +811,7 @@ spec:
   - email: support@splunk.com
     name: Splunk Operator Maintainers
   maturity: stable
-  minKubeVersion: 1.30.0
+  minKubeVersion: 1.27.0
   provider:
     name: Splunk Inc.
     url: www.splunk.com


### PR DESCRIPTION
Lowered minKubeVersion for splunk-operator version 2.7.0 to 1.27, as mentioned in the docs here https://github.com/splunk/splunk-operator/releases/tag/2.7.0.