### PR TITLE
operator dell-csm-operator-certified (1.9.0)

### DIFF
--- a/operators/dell-csm-operator-certified/1.9.0/manifests/dell-csm-operator-certified.clusterserviceversion.yaml
+++ b/operators/dell-csm-operator-certified/1.9.0/manifests/dell-csm-operator-certified.clusterserviceversion.yaml
@@ -1496,7 +1496,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/dell/csm-operator
     support: Dell Technologies
-  name: dell-csm-operator.v1.9.0
+  name: dell-csm-operator-certified.v1.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
Fixed the name of the bundle: dell-csm-operator.v1.9.0 -> dell-csm-operator-certified.v1.9.0.