### PR TITLE
operator kubecost-operator (v2.8.0)

### DIFF
--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator.clusterserviceversion.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator.clusterserviceversion.yaml
@@ -430,21 +430,20 @@ spec:
     name: Kubecost
     url: https://www.kubecost.com
   version: 2.8.0
-  spec:
-    relatedImages:
-    - name: kubecost-operator
-      image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:6c637a8273451aa4cac8b7c4d2544a401b3434683c2aafbdc13278b14b2360d8
-    - name: kubecost-cost-model
-      image: registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff
-    - name: kubecost-frontend
-      image: registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:e7e70713348eaa817112aff9f078e9ca57924ca83e4a792f0d93c3338d35ad19
-    - name: kubecost-modeling
-      image: registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:8f59f8fd8696964c1b5322ca79fae78befe97323fa56c2b509bdcc67ee4c0edd
-    - name: kubecost-cluster-controller
-      image: registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256:e2b70f89118dd1c4357cd70bc1a4d2808d309764c5ac83fca102627e8ead86db
-    - name: kubecost-network-costs
-      image: registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256:c444d475be4f1aa36680bd84358e1e07303dcfe5d13a95544ad9e59f80d4a5f0
-    - name: kubecost-grafana
-      image: registry.redhat.io/rhel9/grafana@sha256:38bab984d94788676d2faf3e7d5b201d3379ceb33bbb461c184b6e44c228db59
-    - name: k8s-sidecar
-      image: quay.io/kiwigrid/k8s-sidecar@sha256:5a7861c45aab5fffb73bae9cf36e5088321564e8b3f126177736072bf6c074fb
+  relatedImages:
+  - name: kubecost-operator
+    image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:6c637a8273451aa4cac8b7c4d2544a401b3434683c2aafbdc13278b14b2360d8
+  - name: kubecost-cost-model
+    image: registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff
+  - name: kubecost-frontend
+    image: registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:e7e70713348eaa817112aff9f078e9ca57924ca83e4a792f0d93c3338d35ad19
+  - name: kubecost-modeling
+    image: registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:8f59f8fd8696964c1b5322ca79fae78befe97323fa56c2b509bdcc67ee4c0edd
+  - name: kubecost-cluster-controller
+    image: registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256:e2b70f89118dd1c4357cd70bc1a4d2808d309764c5ac83fca102627e8ead86db
+  - name: kubecost-network-costs
+    image: registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256:c444d475be4f1aa36680bd84358e1e07303dcfe5d13a95544ad9e59f80d4a5f0
+  - name: kubecost-grafana
+    image: registry.redhat.io/rhel9/grafana@sha256:38bab984d94788676d2faf3e7d5b201d3379ceb33bbb461c184b6e44c228db59
+  - name: k8s-sidecar
+    image: quay.io/kiwigrid/k8s-sidecar@sha256:5a7861c45aab5fffb73bae9cf36e5088321564e8b3f126177736072bf6c074fb

--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator.clusterserviceversion.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator.clusterserviceversion.yaml
@@ -15,11 +15,11 @@ metadata:
             "clusterController": {
               "image": {
                 "repository": "registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256",
-                "tag": "5b791b8832ae85f9b7d777ffbb04c0a0961d13a0508b46b9c404ad2289bcaf97"
+                "tag": "e2b70f89118dd1c4357cd70bc1a4d2808d309764c5ac83fca102627e8ead86db"
               }
             },
             "forecasting": {
-              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:a2259b098b1371c4f19a0b2b20d8fdee9f05cacccc65b487325f17b6b2dc23f8"
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:8f59f8fd8696964c1b5322ca79fae78befe97323fa56c2b509bdcc67ee4c0edd"
             },
             "global": {
               "platforms": {
@@ -43,28 +43,28 @@ metadata:
             "grafana": {
               "image": {
                 "repository": "registry.redhat.io/rhel9/grafana@sha256",
-                "tag": "1bc3043056f1df2cf840ccb3ba12a52fbf836b81cfdc76f1f643fd6c8c4fee70"
+                "tag": "38bab984d94788676d2faf3e7d5b201d3379ceb33bbb461c184b6e44c228db59"
               },
               "sidecar": {
                 "image": {
                   "repository": "quay.io/kiwigrid/k8s-sidecar@sha256",
-                  "tag": "b50fb46b5b3291fb82e85429781a27a5c36fe97f330908afe00652ee6c425459"
+                  "tag": "5a7861c45aab5fffb73bae9cf36e5088321564e8b3f126177736072bf6c074fb"
                 }
               }
             },
             "kubecostAggregator": {
-              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:01340cd7c89ef98057f1df85ffcdcdf712432a66e7a2a60fb1f02b095cb9abd9"
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff"
             },
             "kubecostFrontend": {
-              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:ec55bb6d2f7a5da7bb982d0be5395ed320ea2623401eb245db2d79853631da9b"
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:e7e70713348eaa817112aff9f078e9ca57924ca83e4a792f0d93c3338d35ad19"
             },
             "kubecostModel": {
-              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:01340cd7c89ef98057f1df85ffcdcdf712432a66e7a2a60fb1f02b095cb9abd9"
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff"
             },
             "networkCosts": {
               "image": {
                 "repository": "registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256",
-                "tag": "76768b864e12d8f1c04dcb1c9dfbba0a6a91e961ee82c5f8d6b8a8cc59f8a4bb"
+                "tag": "c444d475be4f1aa36680bd84358e1e07303dcfe5d13a95544ad9e59f80d4a5f0"
               }
             },
             "prometheusRule": {
@@ -78,7 +78,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Monitoring
-    createdAt: "2025-06-24T00:39:49Z"
+    createdAt: "2025-07-03T18:04:33Z"
     description: Deploys Kubecost 2.8.0 via the Helm chart.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
@@ -335,7 +335,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=kubecost-operator
                 - --health-probe-bind-address=:8081
-                image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:352f62964b784a48a4314849d97c7f502a61e6c0669e19c23a351ac59a912914
+                image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:6c637a8273451aa4cac8b7c4d2544a401b3434683c2aafbdc13278b14b2360d8
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -424,26 +424,27 @@ spec:
   maintainers:
   - email: support@kubecost.com
     name: Kubecost Support
-  maturity: alpha
+  maturity: stable
   minKubeVersion: 1.21.0
   provider:
     name: Kubecost
     url: https://www.kubecost.com
   version: 2.8.0
-  relatedImages:
-  - name: kubecost-operator
-    image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:352f62964b784a48a4314849d97c7f502a61e6c0669e19c23a351ac59a912914
-  - name: kubecost-cost-model
-    image: registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:01340cd7c89ef98057f1df85ffcdcdf712432a66e7a2a60fb1f02b095cb9abd9
-  - name: kubecost-frontend
-    image: registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:ec55bb6d2f7a5da7bb982d0be5395ed320ea2623401eb245db2d79853631da9b
-  - name: kubecost-modeling
-    image: registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:a2259b098b1371c4f19a0b2b20d8fdee9f05cacccc65b487325f17b6b2dc23f8
-  - name: kubecost-cluster-controller
-    image: registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256:5b791b8832ae85f9b7d777ffbb04c0a0961d13a0508b46b9c404ad2289bcaf97
-  - name: kubecost-network-costs
-    image: registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256:76768b864e12d8f1c04dcb1c9dfbba0a6a91e961ee82c5f8d6b8a8cc59f8a4bb
-  - name: kubecost-grafana
-    image: registry.redhat.io/rhel9/grafana@sha256:1bc3043056f1df2cf840ccb3ba12a52fbf836b81cfdc76f1f643fd6c8c4fee70
-  - name: k8s-sidecar
-    image: quay.io/kiwigrid/k8s-sidecar@sha256:b50fb46b5b3291fb82e85429781a27a5c36fe97f330908afe00652ee6c425459
+  spec:
+    relatedImages:
+    - name: kubecost-operator
+      image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:6c637a8273451aa4cac8b7c4d2544a401b3434683c2aafbdc13278b14b2360d8
+    - name: kubecost-cost-model
+      image: registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff
+    - name: kubecost-frontend
+      image: registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:e7e70713348eaa817112aff9f078e9ca57924ca83e4a792f0d93c3338d35ad19
+    - name: kubecost-modeling
+      image: registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:8f59f8fd8696964c1b5322ca79fae78befe97323fa56c2b509bdcc67ee4c0edd
+    - name: kubecost-cluster-controller
+      image: registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256:e2b70f89118dd1c4357cd70bc1a4d2808d309764c5ac83fca102627e8ead86db
+    - name: kubecost-network-costs
+      image: registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256:c444d475be4f1aa36680bd84358e1e07303dcfe5d13a95544ad9e59f80d4a5f0
+    - name: kubecost-grafana
+      image: registry.redhat.io/rhel9/grafana@sha256:38bab984d94788676d2faf3e7d5b201d3379ceb33bbb461c184b6e44c228db59
+    - name: k8s-sidecar
+      image: quay.io/kiwigrid/k8s-sidecar@sha256:5a7861c45aab5fffb73bae9cf36e5088321564e8b3f126177736072bf6c074fb


### PR DESCRIPTION
Update the image tags in the Operator Bundle to point directly at the `linux/amd64` architecture images, instead of at the multiarch manifest.