### PR TITLE
operator kubecost-operator (v2.8.0)

### DIFF
--- a/operators/kubecost-operator/v2.8.0/manifests/charts.kubecost.com_costanalyzers.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/charts.kubecost.com_costanalyzers.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: costanalyzers.charts.kubecost.com
+spec:
+  group: charts.kubecost.com
+  names:
+    kind: CostAnalyzer
+    listKind: CostAnalyzerList
+    plural: costanalyzers
+    singular: costanalyzer
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CostAnalyzer is the Schema for the costanalyzers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of CostAnalyzer
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of CostAnalyzer
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubecost-operator
+    control-plane: controller-manager
+  name: kubecost-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-costanalyzer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-costanalyzer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubecost-operator
+  name: kubecost-operator-costanalyzer-editor-role
+rules:
+- apiGroups:
+  - charts.kubecost.com
+  resources:
+  - costanalyzers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - charts.kubecost.com
+  resources:
+  - costanalyzers/status
+  verbs:
+  - get

--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-costanalyzer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-costanalyzer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubecost-operator
+  name: kubecost-operator-costanalyzer-viewer-role
+rules:
+- apiGroups:
+  - charts.kubecost.com
+  resources:
+  - costanalyzers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - charts.kubecost.com
+  resources:
+  - costanalyzers/status
+  verbs:
+  - get

--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubecost-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator.clusterserviceversion.yaml
+++ b/operators/kubecost-operator/v2.8.0/manifests/kubecost-operator.clusterserviceversion.yaml
@@ -1,0 +1,449 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "charts.kubecost.com/v1alpha1",
+          "kind": "CostAnalyzer",
+          "metadata": {
+            "name": "costanalyzer-sample"
+          },
+          "spec": {
+            "clusterController": {
+              "image": {
+                "repository": "registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256",
+                "tag": "e2b70f89118dd1c4357cd70bc1a4d2808d309764c5ac83fca102627e8ead86db"
+              }
+            },
+            "forecasting": {
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:8f59f8fd8696964c1b5322ca79fae78befe97323fa56c2b509bdcc67ee4c0edd"
+            },
+            "global": {
+              "platforms": {
+                "openshift": {
+                  "createMonitoringClusterRoleBinding": true,
+                  "createMonitoringResourceReaderRoleBinding": true,
+                  "enabled": true,
+                  "scc": {
+                    "clusterController": true,
+                    "networkCosts": true,
+                    "nodeExporter": true
+                  }
+                }
+              },
+              "prometheus": {
+                "enabled": false,
+                "fqdn": "https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091",
+                "kubeRBACProxy": true
+              }
+            },
+            "grafana": {
+              "image": {
+                "repository": "registry.redhat.io/rhel9/grafana@sha256",
+                "tag": "38bab984d94788676d2faf3e7d5b201d3379ceb33bbb461c184b6e44c228db59"
+              },
+              "sidecar": {
+                "image": {
+                  "repository": "quay.io/kiwigrid/k8s-sidecar@sha256",
+                  "tag": "5a7861c45aab5fffb73bae9cf36e5088321564e8b3f126177736072bf6c074fb"
+                }
+              }
+            },
+            "kubecostAggregator": {
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff"
+            },
+            "kubecostFrontend": {
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:e7e70713348eaa817112aff9f078e9ca57924ca83e4a792f0d93c3338d35ad19"
+            },
+            "kubecostModel": {
+              "fullImageName": "registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff"
+            },
+            "networkCosts": {
+              "image": {
+                "repository": "registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256",
+                "tag": "c444d475be4f1aa36680bd84358e1e07303dcfe5d13a95544ad9e59f80d4a5f0"
+              }
+            },
+            "prometheusRule": {
+              "enabled": true
+            },
+            "serviceMonitor": {
+              "enabled": true
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring
+    createdAt: "2025-07-03T18:04:33Z"
+    description: Deploys Kubecost 2.8.0 via the Helm chart.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/valid-subscription: Contact Kubecost for subscription information.
+    operators.operatorframework.io/builder: operator-sdk-v1.39.2
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    support: Kubecost.com
+  name: kubecost-operator.v2.8.0
+  namespace: kubecost
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: The CostAnalyzer API describes a deployment of Kubecost and its
+        dependencies.
+      displayName: CostAnalyzer
+      kind: CostAnalyzer
+      name: costanalyzers.charts.kubecost.com
+      version: v1alpha1
+  description: |2-
+
+    IMPORTANT - Before installation, you must run the following command to allow monitoring of the Kubecost namespace by the local OpenShift Promtheus. If you install in a namespace other than "Kubecost", adjust accordingly.
+
+    `oc label namespace kubecost openshift.io/cluster-monitoring=true`
+
+    Kubecost provides real-time cost visibility and insights for teams using Kubernetes, helping you continuously reduce your cloud costs.
+
+    This OpenShift Operator deploys Kubecost from the official Helm chart.
+
+    Kubecost allows you to:
+
+    * See allocated spend across all native Kubernetes concepts and provide your teams with transparent, accurate cost data reconciled with your actual cloud bill.
+    * Join in-cluster costs like CPU and memory with out-of-cluster spend from other cloud services.
+    * Get complete cost visibility across OpenShift, On-Prem, AWS, GCP, Azure, Oracle, AliCloud + more.
+    * Gain insights you can use to save 30-50%+ on your infrastructure spend, without exposing your private information — your data never gets shared externally, even with us.
+    * Have real-time alerts and recurring reports, empowering teams to take control of their Kubernetes-enabled infrastructure and stay within budgeted limits.
+
+    Visit the Kubecost website for more details including features, pricing, documentation, and more at www.kubecost.com.
+  displayName: Kubecost
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAACpESURBVHhe7Z0HfFvVvcd1l662ZHkltpPYcSbZgWxCgYRVIKQ8wmhpykgpFEr72sejdAF9QOFRCqUtZZRdygw07LBJIMPZe287jm3tLd31/o4OjiJL8r3nXo3k6dt86PnLAdvS7/7P/5zzP/8/IUmSrkyRaOe9e7kjbiGQNKsoWyVlG6avJ5L2iUxZWAXFLQQ/jKz5OrpNlERRJ2Z760kdQRJkE9PvKusZA+gq9OoJRVlYhSAh8QtDy5ZFt8YkDr0kGz1BD2Xqr7HNclBm9NKJQFlY+QUk9bj/g22JQ7wkoJewAB/Wn3be5Ph2LeVAL5U2ZWHlEfBSn0bWc+oklQrIazTbuMB+rpHQo5dKlbKw8kIb7/6L792eqFxbjAR7uXXm6caRyC5JysLSnrdCyxeH1wo6Edl5AFzXWLbpZseFyC49ysLSmEd972yK70dGnoF461fOy00ki+xSoiwszQAXdbf75Xbeg+yCYCGNt9gvbNb3R3bJUBaWNsDq7073S678BFW5YQnmJ46LhusbkF0akOj/y6ggLnF3uf9VFFUB8N1h/t2RaEN2aVAWllpiUuJ/vQu7BD+yiwH4y7/43jnCe5FdApSFpQpeJz7sXXSQ60J28QC/9YB3YURKILvYlIWFj6STXg0s2csdQXaxCYnRe9yvIKPYlIWFz/Lo9i+im5BRGsCM/LjvA2QUlbKwMGnjPc8GPkFGKbEmvrslthMZxaMsLBxiEvdEaTiGjDzlX+wTwsgoEuV9LBz+HVrxXngVMlRgIPSDmdqh+vpayuESA7sThw/wXX4tNOGkrPdVzaeK5zjKwlLMbq79Ac8byMCFJqgZhpFXWGcyBI1e+oZPwusXhVfGVK/vvms98yzTGGQUnLKwlJGQ+Hs9rx5Wd25TRdl+ZD+/kalFdiZAu3u4I7DwRDYWD1Rd66QsyCgs5RhLGZ9FNqpUVTPT//eVV+dWFXC787LpxhGETlX6+599b4vqpIlNWVgK8InhhaGvkYHFqeyQXzovYwgK2Tm5xjZ7tmm8Gm0d5t0QtyGjsJSFpYA3Q8vQCIvhTP2NjguQIY/LraefYRylRluP+t5RmRWNR1lYctnDtS+PbkeGciDWuaXiImQo4WrbWRMNzchQTlziWmK7kFFAysKSy9uhFjRSDqkjfuq4xICbqH6j/YL+lBMZynk28HFIjCKjUJSFJQtYoG1NHESGcq63n1tH4ysDuM15KS0vMsvI0uhWNCoUZWHJYlFoBRopBwL2yYZhyMDFShrnmKcgQzlvhZYHC+u0ysLqm73cke2JQ8hQzg/ss9BIHeebJzYzmCnIkk5aEt2CjIJQFlbfvBlajr0XdJP921rdAYS14Q3285GhnPfCLYKUx4tDaZSF1QdeIbwLdysI4qpxhiZkaAEsLc8xjUeGQjhJWFXArIeysPrgtdBSEfeGIDgYzY+B51qmOXBPaV5Xt7uriLKw+mBLHHMxeIp+gMqVYEb0BH2h+TRkKCQgRraqCBYVURZWLj4Mr4lKcWQo5GrbWSpP+rIxwzDSQWI6raWRAoXwZWHl4ivc7Z9T2SFVlA0ZWsMQ9MWWychQyNr4bq8QQkY+KQsrK4d4F/alrkut0/PkrpJMNQy3kzjlskSdtKogJzxlYWXlrdByvJyTRqamOm/uKglEWnNwndZn0Y1olE/KwsrKPq4DjRRyo/2CvLqrJOPZwXiHPG4hUIAra2VhZQbmC7yDWxPBVhQkadNGms41TUCGQlZEd6BR3igLKzOfRNajkUKusc0iC/WuYh9BrorvyvcufFlYmTnMu9FIIWM13WrPTT1d2YBVUxmc8ebEAWTkh7KwMgDzIEZ5Y2AI07/AN64utUxDI4Wsje1Bo/xQFlYGFkfWopESIFz/ccFrNzYx/SgC50PczrViH1XJoSysDHTyPjRSAk3QVtKIjEJhIQ1TWJxIyyMED+SzSE5ZWOm08u4o1mXRKYbhaFRYzjKNRSOFLM1nhlZZWOm8E1qJRkogdMSV1pnIKCz9aSeJtW2W192ssrDS2Z5oRSMlGAk9SzDIKCzwfWcYTkGGEtp4d/7ylcvCOg5BJ+KtB8cbBqNRMTjbjDkb5q/gUVlYx7E8uh1vrfQd3GW/JlTgZtFsUXH1KDdlYR3HR5F1aKQEE8E6sHINtMJMGobo65ChhEN5WxiWhXUcLqw8mWrKjkbFY44ZJ9nBJ4a7+LzUey4L6zh4rBO0C3BzhTWknq5EI4XkKcwqC+sYy6LbMepRMQStpraCVlhw92Z3cnnpPFAW1jE+x8qAs5HGvOdeyYDUEdMMI5ChhA4B55ihT8rCQog66QBWZt9ApgaNis1srCuHHiEUx9phyU1ZWAhRytr6OzczDaPQqNhUYuVDw+zfEtU+zCoLC9GO1YgGAqxT2AHIKDZGEvMuv5pCOtkoCwuBd3fFTpqKWPI6DQizxugHIUMJ7YL23Z3KwkJ8GduMRkrAm33yx5lYmQ5+MYJG2lEWVje8JEbEGDKUMJIplXkwyVCs/fewGIuImBe+s1EWVjecjkcjhYwzNKJRaUDrcC6EQfy+JrYbGRpRFlY3Uazn1UAweHcZ8gdNUPperS7ksIvTuGp3WVjdbEzg9J3HLieUPwhwoixOAk8r70IjjTgJhYVR1nxDbB8aKQGWhGhUSuBlSIewQswcnKi9dESdeJBzHeS7jvDedsETEKMuwQ8zWuovYyT0ZtJYQZorKEsVZaulHPV0ZS3tSCuLDf/KzZ2PccrleK5pwjzr6cgoGWJi4iddTyBDNizB/LXmRmRowQkmLJ8Y3hI/uDq+a3uiFa/hAqkj62jnMKZ+mL6uiennpCxxibul83H0ZSXc4rhoHFu466kygUfuxo7HME7T/1h1nZ3SLKvsxBCWqJM2xfcviW7ZGMeZs3IA0fdIpuHNwFIrY0UvyeZP1QsKf9+rT0BSICyMPNgF9nM1vGhU6jHWUUkd+L375b/63tVcVQAEre+GV673rVvpXnEwcjAiyN0qNJOGElQVQOgIA4lzrUPbSzslLawDXOfvPS8/6nu7DbeSghxCfBD+mRATB8L713hWr/ascsVdvNjHzlZxc5FzM5bBmaD3JP4fCAvip1eDS+/xvNrG5VFSSQJct7B6iArRbYGty93L9oX3wRi92ovSdFdJhrFY+++SlgvDUhSWX4zc7XkZu5CQUoJ8AI2OpzVyCLzXjsD2MB/qHQuX2ilhKqOxjqITmmZllZywWjn371z/PIKVxIJHiMtV7LUz3rnWu3add22avOqoCjQqPSooC0ZJwbiEea6VkdIS1l6u4x7PKxHcCtgYiJIoyNi2CPNhkNdm/yYIxZKv1OFeXigMGCVoEhKPsUmRjRISVifvf8DzuqB8nawGRctyX8IHi8ct/s28xOev2rYmYFQVBFVpGNGWirDgcbnT8xJelWI1yHFXaXgSnuWuZesT+wrZ80gpeGVCNMz4KwlhgZ5u7XyiKK2LYSpEIyXoSf3C4Nc/63rKJRy3oiwdLKQBjZSwn8csFN2bkhDWQ963CjwD9oAnLOpoakpMStzheu5B75vJF0sKvPureIn/GSm+sFp5985EXu5MyiF4dHdUKQx5LOcJfvgfd/5d80Q5ldRh9ZBu5z1opJoiCwtCq3s9ryKjGHAizuYNfXwyHSfxj/s/+IPndWSXAP2xPJaGUWORhbU8ur0ooVUPcazcUTrFY/Wwlztya+eTnULm7dYCU0kpPlMHOJ1mn0UxsxsgRvlZ51OaRFdGUj9e3zTO0NyPcvSstFt51xHeu5tr38m1Zqv2scm/0ZdQfMe83lg/2JK5XgMsx2aZxs+zzihA15MchMUYrC2QIRsTwf655gZkqKOYwvoysvmfwc+RgQVD0FdbzxrFDsjdCkvUiSExFhSjq2O7lkS3BFJuO63xro7wii8/NZobB5gGIiMT/eiKOyrmmUgW2cXgRx1/Vbp9o2G6X9GEBdHVT7uexJ4HaYICSU0xDFPaqAjea68Q2pI4uDi8tlPwfe36CmNhOMw6vNZQi4wsWEnTzY4Lm5l+yC44N3b+TWnMBA/qYzU3IUMdRYuxXEIAW1UVpOWuyu/OMI7EaH8FUxXEH2cYR91TdfWdlVc1GBvQF5RAkX1/36AY+aP3zffDq5FdcDCuaONtvmSkaMJ6G6vqNeAgzXc459VSDmTjAjFQNWUfZG6cVjV9hHUkoyQ5jpFXIBmenLdCy//mew8joV49GEGehruJxREWzIPrE3uRoZDr7Odo1bctGYLQBF1tqJ5aOe0U+yi9vLoailS4Pr73Ee+i/BW+zgbeqQ5E/WikjuIIq0vw422ZjGcHj9Rrdqs9bS6u1FdOqZw60nYKS/URdCudgndybfd6Xu0q7E4EidVjR6taWcURFnYW7CWWKWikBRlTG6rYqlMrTmsyD6ayqwfjM3MLwfs9r+N1J8ADb7fDo1Er8uIIa20cp6fZEKZO2yvtYpYVMUiqwdRwqvO0akNNxkiFxmpCERAjj/reXp+HKyEZwdtI0yoZrgjCknTSDg7nwR3HalyBI3cyFkuyI6wjxjjGGinN0tshin/S/8Hqghws4gkrhtWgqjdFEFZIjOFtNIzCSuXOgZz9Qztjn1Axsc5Y3zP95Zgi5QDaesq/eFl0G7LzBp6wtKIowsJZH7EEM4ApTmkXUFKzpXm0fYxBI9cFnvLZwCcfRtYgu5QIZb+YpIgiCCuC5Wyr85AKrOjEA1zXxIqJENojWzULg8vyqi287YYEbqmwNIogLLxrRtWqd0R7o3SjGVzXSNspI2wj8GpQ9Qa09TFW9x5ZFHMmLIaw8Pq2WbFybfNBHdv/7srvaXWv8I3g16WWJKgJxZgKsfZ2jUQxMwXSqKJs/1N59Qg9zjljGjAdQyy/rYD7W4WhCMLCO47C69WePxiC+kXFdy40T0K2CgSd+Ih30a5EO7JPCorwaZWOQDCSI9KYa5n684q56ku9wzrxId+bqYliJzql5QZygNdZvgCM1A/4pXMeozqcFyTxdtdzWu1PAtnOFXLjxMpp7k0RhJVWqVEmmhcix6b3PfRGpuZP1QvULxV5Sbi188li3YTTliIIC6/lSzQPBR3wqqJnPP83EMyfq29QPyeCan/tekHRBls2cAsxaLNLUQRh4c0aWp265w+I2B6vvVm9ttxC8F/BL5GhAjxhOXH7lqdRDI+FNRXmo18jdvCe41Tqsdqb8Ob6VL6MbFK/uYXrsbShCMIyEThbnZzEH9bunm7+IHXkw9UL8EonpPKE/0OVBTLxZOXUKDu3CMLCftMPa12JFNtjBXPu8cJ/9oGqa1VqC/zNHzyvq0loxrsZoVXadxGEBasnvOJSO7Xu98JgBe9An583/I73Vs63qWtdAauEh72LcieN5QBjBUDqCK2SbYogLAAvb30/Vs/mHGB7LDmnUiaSvbvyu9jN5ZMc4rveC2FeIMNQJF6afEaKI6whTH80UsIh3qX5PSo8pxKSV2AYVHVbxaUsVh5zD++GW3ZjnfZgbJDiZdpkpDjCGsBUo5ESeEnQvHsxXgcv+bmKdbTzVsccNQedMKM95n8fIxUdw2Np2Ia4OMKqwN0sWYd1CyMHTqw+AAElMfUwfd3lFlW9nIJi5KXAF8iQh08IY6wKT/ip0EyyeP2AdiY0jt+rKTsaKcEvhtFIHmebxl1gPhUZWLTEdrYoaYfuwrrDeMJ7LFh6TGNHIEMJXYL/ENeFDC2owhIWxon4XMvUUWyuAjV98s/A5x7ZJU8P8jjvEvZqpjfFERYwyTAUjRTyeXQTGmkBXq1OjBNxUkfeYD+/n4q2A1Ep/nJwCTL64jBWYW2TdtmURRMWdnqGtj3AbFjbARGstjPwsd3gOF9NEsT6+N6V0R3IyEmXhDMVDtDuPnDRhGUhDQ1Y3sIvRjbHDyBDNXgn4rl33nMAn9yV1jOQgcUboa/l+Ms2DqfHc38apyRuRoomLOBiM2YhhsWRtWikGjz/ERFj2HVgZxpHTWAzl5mUg08Mvx76ChnZwWuMczJ4LGCIHmebFNjDHdGqOXaqxxIkoedP7tQAUSd5RPzWAdfYZmFvuADLo9v39XUIgXcQpKGwilmDFD68X7qel7/SSWWqYcT19nOQ0RdBMXq0BmkkJMUCQgSWlmDCox8So/ClDzo/5rLfSGMIhiZpmqAZUs+QDEuxBpKFwQ8rLppgHGIjTHh5i1sThx72/hsZymlm+v/SeRkyMnFjx9+UZqJSOvLx2puRoZpiCgtYF9v7mP89ZCjBQhr/WHVdxh1trxAC0biEwAGuE57sfXwHl3NeWOVpiQmK/V+TeXCDqfv6l4lkhzH1TUxtA10FKxI7aZLZI/OlwBdfqFjhXmubPd04Ehm9uKHjr0rzsYyE/tGaHyFDNUUWVkxK/KRTcS//JHPMUy62TIZBQuLBCXXwvpbYzq3coajCvYDtwe1dsU5kyKbWUDvMmrk1dyVlG882jdIPqqUdlZQ1265jVEr82vUCdmJMDeW4u/J7dKZHaz/Xda/nFWTIxkGaH6y+DhmqKbKwgHs8r4JrQYZs4HGkJWKB44Il0c3bEofQq1i0Rw/vDilO17Qz9rGOccjIDiwOxrPNM4wj+1EVDsqcdsq7PdH6kPctZCjnEsvUizJdbFwcXguLR2TIBpR6b9X3kaEa6q677kLDIjFG3/ix7C69EFZHhWhr5NC2wNZ9kf1r4rs5UoMD+SMxxRUGKZKqM/bdehkCnTbevSK2/ZPI+q9jWykdiMtgIPQk0f1jV1G2/Xxnp4CZdd3Ku842jesdDywKr8A40hms7zfFkNkHY1DMVWESO2Xu84gK/BPoaVdw5zLX12u9a9qibcn0SBgojSR602fF0YzEBcWb7xD8vRz8Eqa/n3Y9+WlkAwSCsLqcbzsb+4QuLMbeDC1DRgq7sE5UhzP1aKQFxRcWzA5zLdOQ0Qte4o9E20FPqz2revsVXuQPRVTNgwDekT74zgTuVce4xL0SXHJb1zP/3fVMK+e6yvot9AXlLI9tT+vmAk8a3qPWyPTREkERxRcWcK55Qu8UM3AJ67xrl7uW7QrtypG+DdOiSqeFXaEvwKntgukXI3/2vf1C4NO9ob0C1pZmRIy/FlqKjKOAF8R7Q4brTy6PBYCqRrGoDCS8KX7OD3pq8awM8X3fJQTPsdW/BRlYEDrCQOFcfPBx2rSNBJdZY6hZ5loGXhnjBsSK6I5UJYndyzHFwtLw+DlJSQgLuNVxMYQaAT4As95G3waYAdEXZOBNqP2AHXqcpAOM7k7ZMNNmCPUgjvza9dUqT4sieUWl+MLgsUgL75Be5t6bfEpFWG4htD2wdYN3PcYjCw9oixuzgUqSaj3OUUZMu3IS4DXHOyYkxzEhBvIC7wXOOPlKn6yMHUt5wEsr0rxRWfGFBQvy/3G/cofruSG24dipsXExHuD8yFCOmcY5uUsoXxjmQE/qrfSxVCLwXivcy2EhLOdJgwXm0mh3PAABFl4f5KFY11tyUGRhvRdefUvn4wf5LvA68NQ6GPw8uI2+jRjeLgle/A4/c4DTsovJKPtoNDoK/DqwEF7pXiHnmfkg3F0nl+/r+DwbpxmGoZFGFE1YQTF6u+u5f4eWp9Z8H2kbie204A3dEdyODIUQR7crMXDFtcyTZkjG0st3Qri5wbdhs3+TmHNmdAmBuMTxWL13aYJqZGqQoRHFEdZHkXW3dz3bO68BVFWBFUcnccVdEV7ZNYck4Cztepzkd1htoJFGjHGMRaPjgQVKi6cF1svI7gU8V49631kbw7nFZCNN8A4gQyMKLSxOEh7yvvV68Ktsfa2HW0eoaf2w3rdefsybSi2L0woVY/89NzRBp0ZaqXAit8m3cW8oazs+iCiWHI20lKJV6aJUCiqsLsH/W/eLuTtggarqj6aj4AGq2h1UcE2qB7zOAPBhYwd22UiLtFIBt9QWbQV5ZXx4olJ8dQhHWIPz0F+4cNkN2+OtTwQ+kJP5CW9fi3tlQsSvxjnKPsqpT0+ot5LGgXR1f9pZT1c6KLOZMOgJ2kjo9QSTTFC+ufPvyb+ZRDy61wgfIfwB9fAQwUhClI+E+HBECIe/mXOHWIb2N2q8pFrpWZEQcv36Zto8xj42rR8nqBwc9iSn4kLOt1dchp3Nm40CCWtNbM8/AotT4/TcQLS0LbAVGcqBWO0056RRbOMwfUMTU1NJ2SpIS+66QvAu/KTzcfltIEH9MA/GxJhZx55jm7KNO9TBa7MRDwT54HpvHx0rQFWgLVAYsrtPAnyb/ZtPr1J269pAMH/RqHN9KoUQ1urY7qcDH8lXVZKN/g3+hLKtKdCTU++E8N9CW4ezA39deSWjJFx72v/xipjidSVEvg9VXw8DcMZtvGsv17E2vucA1wnKS/4FPJa7l/FiH8cPEJCNdozpicm2Bra44+7R9jGKFkDgv++q/C4ytCPv+Vh4qgLsjKMjdkTOx2OkjXXGuoHmQUMsQ2oMNaAqPakPSlFwP6O/OYKUA7zFn0U3IkM2nMTPNo9jCBrm0yrKNlRfd4Zx1Bmm0U1MrYFkOgQfXhVkmHxzrAGTwGTtSrgr2UrwXvD3dwS7999DfEhOolgP8BapuTWUjfwKa0v8IMRVGKoCaJIWJDHH3iBLsvWm+mZLc6O5ycE4DJQhbTtqL3ekjnbWyb69CHPle+HVSj0N/G29jh52fGoAzC/wfcezg2ebxkNoTOnIToUKs+lth2Vkm4Ge3HEXBHm8xLdFu/fcYTDAPFD+9sHFlskaXifsIY+rwiOC95nAx3iqSjLIPMhEp9evgvmumq0e4xg7uXLKIFNj7tOYf/g/UpT3nDGFvE9WpBzVpcESzDi26Tr7OQ9X/3C+7eyhjFxfQurI3pulGYFVznrfOn8CpaGCFuUf4YOjHaVXVVEiG/kSVkLi/+57X2UPD3jshlmPHSDCBNdgapjknDzCNhJcVPLF3ICTeML/ofwf41R2CBopwSuj+AxMlDONo/7b+R+/cV5xpnFMch2aG/DEaNQXET6yuuNYkvuhsNwqYrWUXWVduGzkS1jPBz7VpMgxRKb1xnqWYgdbBk92TmkyDwZ5oa/Jo0vw/933Qe4bYD2cj1VsKCFxe2QX3RvE1HzPduYfq6+/0DypImd1Lhtjg+keGTkRRSEc9cXiKH2tPSb3hxms9dlzD3kR1qb4gZbYTmSow0jof1wzb071+fXGBuwTvd3c4RcCn4sygieIyfCqOSwMZ8g9zwH8XnMtU++r+sGllunm7Psgdr0sx8wf3fTyhzuSu7Xwz+SgT2CaRiOt0V5YnCQ8H/gEGeqAX/v+qmu+Y5m2wH6uXp3HXhHb/k6oBRk5watKehCrahdNUBeYT4XfcbpxZMbJcZBJVhgeinRPDpIkeQPoGoWccy0Q91i2ERlao72wXgsu9atujwaf7o8dF97iuCiZgAbTx6XZL1zI5N1wy5cykuDOMY5HIyXAbNjBY97igiXktbbZd1d+r6FX6QQDZewzbRrmwQSPbr1yfIzju48v5aRNN+XhJKcHjYUVEmPLlO8xptHE1N5XNX8COxjZR5llGocXWafyz8AXa/uqYnq66RRYkSFDNjDLvhD8DBlYVFG2OyuvusIyM20uhkgLjbLAH38Q7vZ3H8V2xvr2oBMN2m9f9aCxsJ4OfIzXS7yHb5tO+6VzXsalynz72Q6sWrSpPOn7cC+X63oqfGu8phK5/7MymW0e/4eq+alV6QaY+qiJH4qmOScpwcc8iT4q+pE6Iu3R1RYthQVr+11YebE9XGk54zvWab2vgiUxESzMj9m+KhP4IR/yvtWas3vKeKx3nJcEN1ZJ2TTspPmBqmtgGZE0jZQpx0JYEPkEl179IRlp5Y7fIbrAiyZloqWwXgt8Jf8QtzcQZ8wy91ENAWbJH9hnIwOXhMTf53ntcPYz43mW0/ES357yf4RGqoGQaySLfFXqSXMa8USGcFaCVaEo5C6RlVd3BWgprFVx/C0GWPrlKMqTynTDiBnGU5CBCyfx93he7hAynxcZSMaBVS18D9eOXemvNz93zAW/AoMqNmu/hVAks+v1BttzeCx4bCZpneSehmbCknSSnFyrjNTTld82n4YMGXzfepb61sWcJNzlfilb8Ywxesx1+BZNe2f8xnlFJWWrziIsWANmS4TvXh5mz+gawFTh9cmSj2bC+ndwhdLj2ySwCFKatkER5J3Oq5ChAoiKfuN+sT3TnDjPMgONFPK0/yO89yEbdzjn6Ukm46ZDOJprgyMmZK28pWFVmWxoJqylMcx77ldbz0IjJZhI9r6q+chQAcxcd7pf6r0HYSD1PeGzIiJSXNuG+3bSNNUwwtBroSoIXCyRqwRBZyRrzZkZBllRhxo0ExZe2A4LvelGnBYVQDVlv63iUmSoABzM4773P+lVo2s67rv/vP9TNNIImPqtTHqmQyTexwq0PZxZWLDmzXGIpBWaCQsvaD3HhO6V4zFMX3+L4yJkqACmrleDS//sfTt1FptlGm/EKpUB/k9bpwVT/yTTcesVWPflngcBmAozxu8z5C2SVKKNsHxiGCNPktKR55snIgOXsWzjhZnKJWKwOXHgQc+bPat0miCb9ZiHHksim9FII2aaj7tvGImBu+o7kut9YmgjTfk7H0xFG2EdwuqDAHGS+q5AsHK+xDLldNUbEEl2cYdv73qupzngRSZMyS4Kr5SZqCOT5pQMVXBXoaislCSp19N+rmkCxoEVBtp8D7w24FqlmIG25ttmYW8QpAHe97auZ5L965r1/eVnNqcCqtqkXV8WoB9zbCURinpBW8jIAUH0brI6xZj39WASbYSFmdWO2+u7N4ROd2vFxT1b1SpJSPyD3oUvB7+E3+sM4yj0qkKeC3wC/x1kqMb/TQ06WAxGYrLSKGgyPQ9nunGk+sNWmRTCK2YDry1HDn5qn4PXFDgjn0U23u95A9ZQThJnMxbi943x/chQzYFvMlSDEbfMG3sklS6ss4yZC0PkA22EhdculddaWLB6+nXF5cljEE04wHf+1v1ijoYoufln8HM1h6epLAt130tLcNHce1ep0JQ+NecWYnbNS8rkQBth4fV3VNpCQg6grTsq5qVdxlIDJwleMbQzuAPjyn9YjH0W2YAMdXwd2gCOyh9WcOOI0JGpR+kQtqNRQdBGWHiPQkxKYGdd5gC0dVvFpeqzAnugCZommLWeNYePXtxTxKLQSrwuVKlsiO7ZGTsYjLggwEIvyQDcVc8Fp6FM3RC9glus6tFGWDRBYdzIg0ghrZS0htzouOAMY9ayLUoZaB4g6aQ9oT3rveuCSqpwCzrxpeAXcu5x5OB/jzwfS4Sj3XtXCgBh9RSEmmuZht2mAA/NvhkN/1POtsQhNTdac/N921lnaxSugsfqZ+zeLA3ywY3+DTAzym8YBiH8KiUN6NN4L7BsdXCLP9yh6GxbTxucbGVyKhylH4i904uNZsLqT+OEWRDBPKvRlZ6MXGX71vdsZ2rSnH2QqTGZySlKYkesY7V31YHwgdzlG3t4MfBZV5bcr9y4hMB9h59xB9pEUdnjZzTY+rHozuAV1pkFdleAZt/vAiUJVamsju1qw9pflcmZxjHX2mar34yFeGWQ+ViJEQilD0YOrHCvaIu29hnXw9rwCd+HSleIcYn/r8N/2+XZmnZdQg4GvSV5C2Mi25yP0gx9opmwJrCD8a56Qvxxv+cNbU9t05hsGHaHc576FO9+hv5p9RQESdgb2tviXgnhV+7J8QDf+WLg87S+N7m5u+vFj9oW905plwNF0jRJwzoGHDZ6qbBo6SFrKJz6sAAsD+92v4xxjC2ferryt84r1ddEbLYMSV3DJ4HoBxaMqzwtm3wbPQlPtsuiK2M7Xgh8KicNBP7On9wLn939TCSOM4EaWesA4wD4OS+zzMjrjYkcaFnGqJKyrsS9WR+V4ru49inG4Sov4eTAQOqnG0a6xGArj3NknoSlWF7iIYRH9vHExFhXvPNQ5BAncbAiY0imZ8GfBL51h+AboW/IURQkLMZ/1fH047ueiGFVgAYq7Q2jHGMqKdsPHef1fgwKg8YV/W7resYno/RKNpqYfj9zzNG8/UYaSyJb/hX8AttBQvAOkbvMeskV+opaQz+YQEFk9Ddigifwevt5vZtBgKNaH9vz80OPbDqyUuayoDckSQ2tGT/WMe7+qmvgG6FXC47Gwvoksv7VoKqtKStp/JXz8nyn+ruFwB88b/hxn4EAF9jo26Bo/Q8YKAMozMbYzbQZRNZAV33HMq2Gdgg6CX6e3Ym2513vHQjvd/lUXceosPWfVXf+HPOUOZYp6KVioH0N0jtcz2P0jU1jgf28SYah+ZsWAV4SHvW/sy2O2UdzX3hvayRXXXHlSJFYIBBW1eoCZt4hteNnOKf+qXpBsSbBJNoLqyW28x9a3FQ5hR24wHau5u3O0tjDtT/sXYRxVAy/4FrPmoigTWc5QeTd/laxr2q2feK09T+v/qK/1dyU12dSDnmpmny/5w34wJChjmtt50w2DMOr4CgTUNUfPK9j7KXFxThe68pU4P0PRT3h9PoLOFAUM7n+Wy8N/J36S5fqyYuw4KP6RdfTGG4gI2bS8FPHnEamJq++/avothcDnylNEYvwkTXe1chQTiwe8oU0KCUCwJszsPqUBwf94lxzQbMYspEXYQEbYvv+6n8XGVpgItifVVzSpGlD7N78zv1Su8IKl76Eb5NfcRHvaCygKAemT+zmmp8Nvuk/nXORXWzyJSwAHABez6Ac0AR1meX0WaY8ZkJ2CL573K/ElLhbd9y1VW4fDSkQcUejfvUxaCosY7qu+Zr7an9Y5MAqhTwKS9RJD3oW7tYo2EoF5DWE6X+FdWbvEniaAAvGTyMb/h1eIT/z4lDk4P5wrkTkBBcJhLsTqrSVFMDQhu82XvlI/a3FXQamkUdhAQmJf8DzxkFey26RPcC7aCINw5mGq2xn5OOOQESKvxda9VGkj542PRyOte0Jpl/V54VEINzF8XFZ92qUQ1P6Sxoufqrx10VfBqaRX2EBUSlxr/u1DkGDVU8OzIRhIFP9LePoCYZmbd9ivxj5h39x7lZ4Pfg530Zfd7wVjQciMT/4J5VrxtwwNHvlgP94ZMDP1XR4zBN5FxYQEeOwnj+SZ20lYQjaTpoG0NWnGYaMY5u0urrYJfjfDC1fnT1fjxf5rnhXV6LLH/d2ePflyT+lYtBbFjTNv7vf9YXPtZJDIYQFgN96xLtIkyqd8gHXZSGNNtJUQ9khJhuubwCvhr6GhVcILYlufjfcvXfl5/xhPuzjvHExwXX/ORbsiyLvCbRjJFHJp8racMuga39SObc0VQUUSFhAVIo/5/+0z6LFeYXUkWaSNREsBGcGgnFSVpCdjTRaCANL6tnjMw7CYlyQhKAUcwuBgBgNiJGoGI9JCTCPxDv3hffmPoeOJUK+YEf3Fr2mwPQ3onr8f/X/wcXWqaUWV6VSOGEBok5cFFr5fhh/R7F0gMVdiAt2xjsPR7OWoRJEPhRxR+Nqb+kkIUm63t50auWkWysvzWslbU0oqLCSbIrv/4f/o57CGyc6vMQHuIAr7uqIZZ7oYWEYinqPNrrBfKspkq6zN42oGD3C2HST40K8inAFpgjCAiBYecq/eBeX9Vk/EYHAK8gHfAmfJ+EJfVNqoQdRFGKJMCwV5cdeBEE4jNWN9qF1lgEmyjTTOOoK60ytliP5pjjCAkSd9Flkg8rkrZKFF7kgHwx3dyYPhoVwlI/27IvC/Hi0MUmM4+KCyIGZfD2JnmLthgo7W1llqq0wVCVT7O2keb7t7MLUtdKKogkriV+MvBj4fEN8L7JPUuBNjosxWD8mxDgvCSCmHp2RBAUROEuyDMmYaTPVK2X5HNP4SyxTTxRH1UORhQXAt98Y37cotOKQilT0k5LR+kGXWqcPyM+xVb4pvrB6+DC85qPIuqCIc9vpJKORqfm2edJ4tqmkjv8UUULCSvJ+ePWnkQ0qe/6euAyiay6ygKTy24+kAJScsJJ8Htn0ZXRTXm9IlxSkjmxm+p1nnpi/lqcFpkSFlWR9fO8XkU07ucPaFootKQyEfjQ7aK5lai0lq0vviUJJCytJTEq8G1q1MbGvg/eprAdUOtAE1UBXTTEMn23qo+HZCcoJIKwejvDeDyNrtydavULwBFUYQ1BVlH2yYdh5pokwRq+ejJxIwuoh2u3DWjYm9nuFkFZXNvKKmTRUUbbTDENnG8dpUlOp9DkhhZXKzsThJdHNu7jDITGmsmuwtpgIFvQ0kW3+lnF0NY1ZLuXE5YQXVipHBO+66J41iT0eIZiQePijeYJ5NkgdoScYlmDAM00zjjiVHYLXWPqk4aQSVm92JNq2JA7u4drbeLcoiYJOhOBMkERswYGASIIkdSSlIxiCHsTUNNP9TjUOwasbfRJzkgsrG+DMDnCdMHu6xWBMjPukCEgttbwxS+iTLqeCMNsps50019B2J2k9uSNuzdDp/g/XyhYvvQNw/gAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - nodes
+          - pods
+          - events
+          - services
+          - resourcequotas
+          - replicationcontrollers
+          - limitranges
+          - persistentvolumeclaims
+          - persistentvolumes
+          - namespaces
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - charts.kubecost.com
+          resources:
+          - costanalyzers
+          - costanalyzers/status
+          - costanalyzers/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - statefulsets
+          - replicasets
+          verbs:
+          - '*'
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - persistentvolumeclaims
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+          - list
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers
+          - alertmanagers/finalizers
+          - alertmanagers/status
+          - alertmanagerconfigs
+          - prometheuses
+          - prometheuses/finalizers
+          - prometheuses/status
+          - prometheusagents
+          - prometheusagents/finalizers
+          - prometheusagents/status
+          - scrapeconfigs
+          - servicemonitors
+          - podmonitors
+          - probes
+          - prometheusrules
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubecost-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: kubecost-operator
+          control-plane: controller-manager
+        name: kubecost-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --leader-election-id=kubecost-operator
+                - --health-probe-bind-address=:8081
+                image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:6c637a8273451aa4cac8b7c4d2544a401b3434683c2aafbdc13278b14b2360d8
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 500Mi
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kubecost-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: kubecost-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - kubernetes
+  - cost
+  - kubernetes costs
+  - kubernetes optimization
+  - k8s
+  - cost monitoring
+  - cloud costs
+  - k8s cost
+  links:
+  - name: Kubecost
+    url: https://www.kubecost.com
+  maintainers:
+  - email: support@kubecost.com
+    name: Kubecost Support
+  maturity: alpha
+  minKubeVersion: 1.21.0
+  provider:
+    name: Kubecost
+    url: https://www.kubecost.com
+  version: 2.8.0
+  relatedImages:
+  - name: kubecost-operator
+    image: registry.connect.redhat.com/kubecost/kubecost-operator-manager@sha256:6c637a8273451aa4cac8b7c4d2544a401b3434683c2aafbdc13278b14b2360d8
+  - name: kubecost-cost-model
+    image: registry.connect.redhat.com/kubecost/kubecost-cost-model@sha256:30382f1126a6c480208aa8efc73f2a824ed82381740ff950d5f576e65ec78eff
+  - name: kubecost-frontend
+    image: registry.connect.redhat.com/kubecost/kubecost-frontend@sha256:e7e70713348eaa817112aff9f078e9ca57924ca83e4a792f0d93c3338d35ad19
+  - name: kubecost-modeling
+    image: registry.connect.redhat.com/kubecost/kubecost-modeling@sha256:8f59f8fd8696964c1b5322ca79fae78befe97323fa56c2b509bdcc67ee4c0edd
+  - name: kubecost-cluster-controller
+    image: registry.connect.redhat.com/kubecost/kubecost-cluster-controller@sha256:e2b70f89118dd1c4357cd70bc1a4d2808d309764c5ac83fca102627e8ead86db
+  - name: kubecost-network-costs
+    image: registry.connect.redhat.com/kubecost/kubecost-network-costs@sha256:c444d475be4f1aa36680bd84358e1e07303dcfe5d13a95544ad9e59f80d4a5f0
+  - name: kubecost-grafana
+    image: registry.redhat.io/rhel9/grafana@sha256:38bab984d94788676d2faf3e7d5b201d3379ceb33bbb461c184b6e44c228db59
+  - name: k8s-sidecar
+    image: quay.io/kiwigrid/k8s-sidecar@sha256:5a7861c45aab5fffb73bae9cf36e5088321564e8b3f126177736072bf6c074fb

--- a/operators/kubecost-operator/v2.8.0/metadata/annotations.yaml
+++ b/operators/kubecost-operator/v2.8.0/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+---
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kubecost-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  com.redhat.openshift.versions: 4.12-4.19


### PR DESCRIPTION
Republishing the v2.8.0 kubecost-operator. This time the ClusterServiceVersion uses image tags that point directly to the `linux/amd64` architecture images.