### PR TITLE
Catalog update [kubecost-operator] [v4.12,v4.13,v4.14,v4.15,v4.16,v4.17,v4.18,v4.19]

### DIFF
--- a/catalogs/v4.12/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.12/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.13/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.13/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.14/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.14/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.15/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.15/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.16/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.16/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.17/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.17/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.18/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.18/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/catalogs/v4.19/kubecost-operator/catalog.yaml
+++ b/catalogs/v4.19/kubecost-operator/catalog.yaml
@@ -9,11 +9,17 @@ schema: olm.package
 entries:
 - name: kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.1
-  replaces: kubecost-operator.v2.5.4
+  skips:
+  - kubecost-operator.v2.5.4
 - name: kubecost-operator.v2.7.2
-  replaces: kubecost-operator.v2.7.1
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
 - name: kubecost-operator.v2.8.0
-  replaces: kubecost-operator.v2.7.2
+  skips:
+  - kubecost-operator.v2.5.4
+  - kubecost-operator.v2.7.1
+  - kubecost-operator.v2.7.2
 name: alpha
 package: kubecost-operator
 schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.12.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.12.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.13.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.13.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.14.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.14.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.15.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.15.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.16.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.16.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.17.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.17.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.18.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.18.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel

--- a/operators/kubecost-operator/catalog-templates/v4.19.yaml
+++ b/operators/kubecost-operator/catalog-templates/v4.19.yaml
@@ -9,11 +9,17 @@ entries:
 - entries:
   - name: kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.1
-    replaces: kubecost-operator.v2.5.4
+    skips:
+    - kubecost-operator.v2.5.4
   - name: kubecost-operator.v2.7.2
-    replaces: kubecost-operator.v2.7.1
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
   - name: kubecost-operator.v2.8.0
-    replaces: kubecost-operator.v2.7.2
+    skips:
+    - kubecost-operator.v2.5.4
+    - kubecost-operator.v2.7.1
+    - kubecost-operator.v2.7.2
   name: alpha
   package: kubecost-operator
   schema: olm.channel


### PR DESCRIPTION
Updates the catalog for `kubecost-operator`, so that users can upgrade directly to the latest version from any version they are currently on. Uses the `skips` method documented [here](https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#methods-for-specifying-updates).