### PR TITLE
Add myoperator v0.1.2 for certification

### DIFF
--- a/operators/myoperator/apps.psj.dev_myapps.yaml
+++ b/operators/myoperator/apps.psj.dev_myapps.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  creationTimestamp: null
+  name: myapps.apps.psj.dev
+spec:
+  group: apps.psj.dev
+  names:
+    kind: MyApp
+    listKind: MyAppList
+    plural: myapps
+    singular: myapp
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MyAppSpec defines the desired state of MyApp
+            properties:
+              foo:
+                type: string
+            type: object
+          status:
+            description: MyAppStatus defines the observed state of MyApp
+            properties:
+              bar:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/myoperator/ci.yaml
+++ b/operators/myoperator/ci.yaml
@@ -1,0 +1,1 @@
+certification_id: 688b18732a25ae083b6eed04

--- a/operators/myoperator/manifests/apps.psj.dev_myapps.yaml
+++ b/operators/myoperator/manifests/apps.psj.dev_myapps.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  creationTimestamp: null
+  name: myapps.apps.psj.dev
+spec:
+  group: apps.psj.dev
+  names:
+    kind: MyApp
+    listKind: MyAppList
+    plural: myapps
+    singular: myapp
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MyAppSpec defines the desired state of MyApp
+            properties:
+              foo:
+                type: string
+            type: object
+          status:
+            description: MyAppStatus defines the observed state of MyApp
+            properties:
+              bar:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/myoperator/manifests/myoperator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/myoperator/manifests/myoperator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: myoperator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: myoperator
+    control-plane: controller-manager
+  name: myoperator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/myoperator/manifests/myoperator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/myoperator/manifests/myoperator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: myoperator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: myoperator
+  name: myoperator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/myoperator/manifests/myoperator.clusterserviceversion.yaml
+++ b/operators/myoperator/manifests/myoperator.clusterserviceversion.yaml
@@ -1,0 +1,211 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: myoperator.v0.1.2
+  namespace: placeholder
+  annotations:
+    olm.skipRange: '>=0.1.0 <0.1.1'
+    alm-examples: |
+      [
+        {
+          "apiVersion": "apps.psj.dev/v1",
+          "kind": "MyApp",
+          "metadata": {
+            "name": "example-myapp"
+          },
+          "spec": {
+            "replicas": 1,
+            "message": "hello world"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-07-31T07:01:58Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.35.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    categories: "Security"
+    containerImage: "docker.io/sjpark00/myoperator@sha256:5fd5180b06ba7dab5eb3e202a659cfecd5b6c2c5aca18be795e6e670107ac47b"
+    repository: "https://github.com/dreamQAQC/myoperator"
+    support: "sjpark00@dreamsecurity.com"
+    description: "MyApp Operators that syncs spec to status."
+    operators.operatorframework.io.bundle.package.v1: myoperator
+    operators.operatorframework.io.bundle.channels.v1: stable
+    operators.operatorframework.io.bundle.channel.default.v1: stable
+spec:
+  displayName: MyApp Operator
+  description: >
+    A lightweight Kubernetes Operator that syncs Spec input to Status output
+    for custom MyApps resources.
+  version: 0.1.2
+  maturity: alpha
+  keywords:
+    - kubernetes
+    - operator
+    - myapp
+  links:
+    - name: Myoperator
+      url: https://myoperator.domain
+  provider:
+    name: DreamSecurity Co., Ltd.
+  maintainers:
+    - name: psj
+      email: sjpark00@dreamsecurity.com
+  icon:
+    - base64data: >
+        iVBORw0KGgoAAAANSUhEUgAAADsAAAA0CAIAAAC7EdcxAAAACXBIWXMAAA7
+        EAAAOxAGVKw4bAAAN+ElEQVRo3tVafVRUR7Kv6hlg
+      mediatype: image/png
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - name: myapps.apps.psj.dev
+        version: v1
+        kind: MyApp
+        displayName: My App
+        description: A custom resource to manage MyApp instances
+  install:
+    strategy: deployment
+    spec:
+      serviceAccountName: myoperator-controller-manager
+      clusterPermissions:
+        - serviceAccountName: myoperator-controller-manager
+          rules:
+            - apiGroups: ["apps.psj.dev"]
+              resources: ["myapps"]
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups: ["apps.psj.dev"]
+              resources: ["myapps/finalizers"]
+              verbs: ["update"]
+            - apiGroups: ["apps.psj.dev"]
+              resources: ["myapps/status"]
+              verbs: ["get", "patch", "update"]
+            - apiGroups: ["authentication.k8s.io"]
+              resources: ["tokenreviews"]
+              verbs: ["create"]
+            - apiGroups: ["authorization.k8s.io"]
+              resources: ["subjectaccessreviews"]
+              verbs: ["create"]
+      permissions:
+        - serviceAccountName: myoperator-controller-manager
+          rules:
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups: ["coordination.k8s.io"]
+              resources: ["leases"]
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs: ["create", "patch"]
+      deployments:
+        - name: myoperator-controller-manager
+          label:
+            app.kubernetes.io/component: manager
+            app.kubernetes.io/created-by: myoperator
+            app.kubernetes.io/instance: controller-manager
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: deployment
+            app.kubernetes.io/part-of: myoperator
+            control-plane: controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                serviceAccountName: myoperator-controller-manager
+                terminationGracePeriodSeconds: 10
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                  - name: kube-rbac-proxy
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                    args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                  - name: manager
+                    image: docker.io/sjpark00/myoperator-controller:v0.1.2
+                    command:
+                      - /manager
+                    args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=127.0.0.1:8080
+                      - --leader-elect
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+  installModes:
+    - type: OwnNamespace
+      supported: false
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true

--- a/operators/myoperator/metadata/annotations.yaml
+++ b/operators/myoperator/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: myoperator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.35.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/myoperator/myoperator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/myoperator/myoperator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: myoperator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: myoperator
+    control-plane: controller-manager
+  name: myoperator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/myoperator/myoperator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/myoperator/myoperator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: myoperator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: myoperator
+  name: myoperator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/myoperator/myoperator.clusterserviceversion.yaml
+++ b/operators/myoperator/myoperator.clusterserviceversion.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: myoperator.v0.1.2
+  namespace: placeholder
+  annotations:
+    alm-examples: |
+      [
+        {
+          "apiVersion": "apps.psj.dev/v1",
+          "kind": "MyApp",
+          "metadata": {
+            "name": "example-myapp"
+          },
+          "spec": {
+            "replicas": 1,
+            "message": "hello world"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-07-31T07:01:58Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.35.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+spec:
+  displayName: MyApp Operator
+  description: >
+    A lightweight Kubernetes Operator that syncs Spec input to Status output
+    for custom MyApps resources.
+  version: 0.1.2
+  maturity: alpha
+  minKubeVersion: "1.22.0"
+  keywords:
+    - kubernetes
+    - operator
+    - myapp
+  links:
+    - name: Myoperator
+      url: https://myoperator.domain
+  provider:
+    name: QA
+  maintainers:
+    - name: psj
+      email: sjpark00@dreamsecurity.com
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAADsAAAA0CAIAAAC7EdcxAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAN+ElEQVRo3tVafVRUR7Kv6hlg
+      mediatype: image/png
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - name: myapps.apps.psj.dev
+        version: v1
+        kind: MyApp
+        displayName: My App
+        description: A custom resource to manage MyApp instances
+  install:
+    strategy: deployment
+    spec:
+      serviceAccountName: myoperator-controller-manager
+      clusterPermissions:
+        - serviceAccountName: myoperator-controller-manager
+          rules:
+            - apiGroups: ["apps.psj.dev"]
+              resources: ["myapps"]
+              verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+            - apiGroups: ["apps.psj.dev"]
+              resources: ["myapps/finalizers"]
+              verbs: ["update"]
+            - apiGroups: ["apps.psj.dev"]
+              resources: ["myapps/status"]
+              verbs: ["get", "patch", "update"]
+            - apiGroups: ["authentication.k8s.io"]
+              resources: ["tokenreviews"]
+              verbs: ["create"]
+            - apiGroups: ["authorization.k8s.io"]
+              resources: ["subjectaccessreviews"]
+              verbs: ["create"]
+      permissions:
+        - serviceAccountName: myoperator-controller-manager
+          rules:
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: ["coordination.k8s.io"]
+              resources: ["leases"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs: ["create", "patch"]
+      deployments:
+        - name: myoperator-controller-manager
+          label:
+            app.kubernetes.io/component: manager
+            app.kubernetes.io/created-by: myoperator
+            app.kubernetes.io/instance: controller-manager
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: deployment
+            app.kubernetes.io/part-of: myoperator
+            control-plane: controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                serviceAccountName: myoperator-controller-manager
+                terminationGracePeriodSeconds: 10
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                  - name: kube-rbac-proxy
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                    args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                  - name: manager
+                    image: registry.connect.redhat.com/dreamqa/myoperator:v0.1.2
+                    command:
+                      - /manager
+                    args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=127.0.0.1:8080
+                      - --leader-elect
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+  installModes:
+    - type: OwnNamespace
+      supported: false
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true

--- a/operators/myoperator/myoperator.clusterserviceversion.yaml.bak
+++ b/operators/myoperator/myoperator.clusterserviceversion.yaml.bak
@@ -1,0 +1,230 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |
+      [
+        {
+          "apiVersion": "apps.psj.dev/v1",
+          "kind": "MyApp",
+          "metadata": {
+            "name": "example-myapp"
+          },
+          "spec": {
+            "replicas": 1,
+            "message": "hello world"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-07-31T07:01:58Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.35.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  name: myoperator.v0.1.1
+  namespace: placeholder
+spec:
+  displayName: MyApp Operator
+  minKubeVersion: "1.22.0"
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - displayName: My App
+        kind: MyApp
+        name: myapps.apps.psj.dev
+        version: v1
+        description: A custom resource to manage MyApp instances
+  maintainers:
+    - name: psj
+      email: sjpark00@dreamsecurity.com
+  provider:
+    name: QA
+  description: >
+    A lightweight Kubernetes Operator that syncs Spec input to Status output
+    for custom MyApp resources.
+  icon:
+    - base64data: |-
+        iVBORw0KGgoAAAANSUhEUgAAADsAAAA0CAIAAAC7EdcxAAAACXBIWXMAAA7EAAAOxAGVKw4b
+        AAAN+ElEQVRo3tVafVRUR7Kv6hlg
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - apps.psj.dev
+              resources:
+                - myapps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps.psj.dev
+              resources:
+                - myapps/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - apps.psj.dev
+              resources:
+                - myapps/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: myoperator-controller-manager
+      deployments:
+        - name: myoperator-controller-manager
+          label:
+            app.kubernetes.io/component: manager
+            app.kubernetes.io/created-by: myoperator
+            app.kubernetes.io/instance: controller-manager
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: deployment
+            app.kubernetes.io/part-of: myoperator
+            control-plane: controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - name: kube-rbac-proxy
+                    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                    args:
+                      - --secure-listen-address=0.0.0.0:8443
+                      - --upstream=http://127.0.0.1:8080/
+                      - --logtostderr=true
+                      - --v=0
+                    ports:
+                      - containerPort: 8443
+                        name: https
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 5m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                  - name: manager
+                    image: registry.connect.redhat.com/dreamqa/myoperator:v0.1.1
+                    command:
+                      - /manager
+                    args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=127.0.0.1:8080
+                      - --leader-elect
+                    ports: []
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: myoperator-controller-manager
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: myoperator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - kubernetes
+    - operator
+    - myapp
+  links:
+    - name: Myoperator
+      url: >
+         https://myoperator.domain
+  maturity: alpha
+  version: 0.1.1

--- a/operators/myoperator/tests/scorecard/config.yaml
+++ b/operators/myoperator/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
This PR adds the operator bundle for myoperator v0.1.2
for Red Hat OpenShift Certification.

Repository: https://github.com/dreamQAQC/myoperator
Maintainer: sjpark00@dreamsecurity.com
