### PR TITLE
fixing crunchy 5.8.1 pgbackrest, pgbouncer,and postgres-exporter digests

### DIFF
--- a/operators/crunchy-postgres-operator/5.8.1/manifests/crunchy-postgres-operator.clusterserviceversion.yaml
+++ b/operators/crunchy-postgres-operator/5.8.1/manifests/crunchy-postgres-operator.clusterserviceversion.yaml
@@ -582,11 +582,11 @@ spec:
                       - name: RELATED_IMAGE_STANDALONE_PGADMIN
                         value: registry.connect.redhat.com/crunchydata/crunchy-pgadmin4@sha256:4f1c5d64d2cfc1217edba1d975ca93044d4709e1c109fa7b9a7f92676fc0823e
                       - name: RELATED_IMAGE_PGBACKREST
-                        value: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:826e579759b43ee2f1533f6d8d64f694a756d384db66e54f99aa43a7d015ae0f
+                        value: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:2c35208eef1a69efef6c817c58cebd5218a4671259b4809d042c5efeebd71de4
                       - name: RELATED_IMAGE_PGBOUNCER
-                        value: registry.connect.redhat.com/crunchydata/crunchy-pgbouncer@sha256:6469e24ea7d0174f2cbe033e97fafc3ebb4f3c73e88a9ddcc160b9d0cc0023b1
+                        value: registry.connect.redhat.com/crunchydata/crunchy-pgbouncer@sha256:fa2ab1d1cb2e9c1c88b85e3f5a6574e5c4bd91aedb7d62a56bf89dd737673c4e
                       - name: RELATED_IMAGE_PGEXPORTER
-                        value: registry.connect.redhat.com/crunchydata/crunchy-postgres-exporter@sha256:a0c232306de7a66abbd6d669961dfc9e4257d8149fe1ada006215b3616ad7258
+                        value: registry.connect.redhat.com/crunchydata/crunchy-postgres-exporter@sha256:136b9bcf46b1e3567485b52841f62714aa8387db483f70e0f670fdc411d56de2
                       - name: RELATED_IMAGE_PGUPGRADE
                         value: registry.connect.redhat.com/crunchydata/crunchy-upgrade@sha256:1cf0380bdf536ed13ee98f5052ca506c0f4386127921ad04ae5a7f08cdb3eab8
                       - name: RELATED_IMAGE_POSTGRES_16
@@ -659,11 +659,11 @@ spec:
     - name: STANDALONE_PGADMIN
       image: registry.connect.redhat.com/crunchydata/crunchy-pgadmin4@sha256:4f1c5d64d2cfc1217edba1d975ca93044d4709e1c109fa7b9a7f92676fc0823e
     - name: PGBACKREST
-      image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:826e579759b43ee2f1533f6d8d64f694a756d384db66e54f99aa43a7d015ae0f
+      image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:2c35208eef1a69efef6c817c58cebd5218a4671259b4809d042c5efeebd71de4
     - name: PGBOUNCER
-      image: registry.connect.redhat.com/crunchydata/crunchy-pgbouncer@sha256:6469e24ea7d0174f2cbe033e97fafc3ebb4f3c73e88a9ddcc160b9d0cc0023b1
+      image: registry.connect.redhat.com/crunchydata/crunchy-pgbouncer@sha256:fa2ab1d1cb2e9c1c88b85e3f5a6574e5c4bd91aedb7d62a56bf89dd737673c4e
     - name: PGEXPORTER
-      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-exporter@sha256:a0c232306de7a66abbd6d669961dfc9e4257d8149fe1ada006215b3616ad7258
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres-exporter@sha256:136b9bcf46b1e3567485b52841f62714aa8387db483f70e0f670fdc411d56de2
     - name: PGUPGRADE
       image: registry.connect.redhat.com/crunchydata/crunchy-upgrade@sha256:1cf0380bdf536ed13ee98f5052ca506c0f4386127921ad04ae5a7f08cdb3eab8
     - name: POSTGRES_16


### PR DESCRIPTION
- Updating these images to use the `5.8.2` digests, since the `5.8.1` digest are no longer available in the registry.