### PR TITLE
Delete operator/oracle-db-operator directory

### DIFF
--- a/operators/oracle-db-operator/ci.yaml
+++ b/operators/oracle-db-operator/ci.yaml
@@ -1,1 +1,0 @@
-cert_project_id: 60da3f683a733787222135f0


### PR DESCRIPTION
Removes legacy oracle-db-operator directory