### PR TITLE
operator minio-volume-manager-operator (2025.10.05135452)

### DIFF
--- a/operators/minio-volume-manager-operator/2025.10.05135452/manifests/charts.quay.io_aistorvolumemanagers.yaml
+++ b/operators/minio-volume-manager-operator/2025.10.05135452/manifests/charts.quay.io_aistorvolumemanagers.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: aistorvolumemanagers.charts.quay.io
+spec:
+  group: charts.quay.io
+  names:
+    kind: AistorVolumemanager
+    listKind: AistorVolumemanagerList
+    plural: aistorvolumemanagers
+    singular: aistorvolumemanager
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AistorVolumemanager is the Schema for the aistorvolumemanagers
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of AistorVolumemanager
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of AistorVolumemanager
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/minio-volume-manager-operator/2025.10.05135452/manifests/minio-volume-manager-operator.clusterserviceversion.yaml
+++ b/operators/minio-volume-manager-operator/2025.10.05135452/manifests/minio-volume-manager-operator.clusterserviceversion.yaml
@@ -1,0 +1,286 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "charts.quay.io/v1alpha1",
+          "kind": "AistorVolumemanager",
+          "metadata": {
+            "name": "aistorvolumemanager-sample"
+          },
+          "spec": {
+            "annotations": {},
+            "controller": {
+              "podAnnotations": {},
+              "podLabels": {},
+              "replicas": 3
+            },
+            "images": {
+              "pullPolicy": "IfNotPresent",
+              "pullSecrets": []
+            },
+            "labels": {},
+            "license": "",
+            "nodeserver": {
+              "nodeSelector": {},
+              "podAnnotations": {},
+              "podLabels": {},
+              "tolerations": []
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-10-05T19:54:26Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+  name: minio-volume-manager-operator.v5.0.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: AistorVolumemanager
+      name: aistorvolumemanagers.charts.quay.io
+      version: v1alpha1
+  description: directpv
+  displayName: directpv
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - charts.quay.io
+          resources:
+          - aistorvolumemanagers
+          - directpvcharts
+          - directpvcharts/status
+          - directpvcharts/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - '*'
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - csidrivers
+          - storageclasses
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: private-dpv-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: private-dpv-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: private-dpv-operator
+          control-plane: controller-manager
+        name: private-dpv-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d8cc6ffb98190e8dd403bfe67ddcb454e6127d32b87acc237b3e5240f70a20fb
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 5m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                - --leader-election-id=private-dpv-operator
+                image: quay.io/cniackz4/directpv-operator@sha256:af06e57661a7e05809e44c3fac571ed949cc04fd656fdb0c8324b533778eb604
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: private-dpv-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: private-dpv-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - directpv
+  links:
+  - name: Private Dpv Operator
+    url: https://private-dpv-operator.domain
+  maintainers:
+  - email: cesarcelis@minio.io
+    name: celis
+  maturity: alpha
+  provider:
+    name: directpv
+  version: 5.0.3

--- a/operators/minio-volume-manager-operator/2025.10.05135452/manifests/private-dpv-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/minio-volume-manager-operator/2025.10.05135452/manifests/private-dpv-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: private-dpv-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: private-dpv-operator
+    control-plane: controller-manager
+  name: private-dpv-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/minio-volume-manager-operator/2025.10.05135452/manifests/private-dpv-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/minio-volume-manager-operator/2025.10.05135452/manifests/private-dpv-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: private-dpv-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: private-dpv-operator
+  name: private-dpv-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/minio-volume-manager-operator/2025.10.05135452/metadata/annotations.yaml
+++ b/operators/minio-volume-manager-operator/2025.10.05135452/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: minio-volume-manager-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # OpenShift versions supported
+  com.redhat.openshift.versions: v4.11-v4.18


### PR DESCRIPTION
## Update to v5.0.3 with Helm charts 0.3.1

### Changes
- Update Helm charts to 0.3.1 (seccomp, hostNetwork support)
- Fix OOMKilled issue (memory: 1Gi/256Mi)
- Build for x86 (linux/amd64) architecture
- Use image digests
- Add Red Hat certification metadata

### Version Information
- **Operator Version:** 5.0.3
- **Chart Version:** 0.3.1
- **Red Hat Version:** 2025.10.05135452
- **Operator Name:** minio-volume-manager-operator
- **Certification Project ID:** 6866ea1357a2e3760f91f145

### Repository
https://github.com/cniackz/Private-DPV-Operator

### Testing
- ✅ Tested locally with operator-sdk run bundle
- ✅ Memory limits verified: 1Gi/256Mi
- ✅ Image digests used
- ✅ Built for linux/amd64

/cc @redhat-openshift-ecosystem/certified-operators-reviewers