### PR TITLE
operator minio-directpv (2025.12.17013747)

### DIFF
--- a/operators/minio-directpv/2025.12.17013747/manifests/charts.quay.io_directpvs.yaml
+++ b/operators/minio-directpv/2025.12.17013747/manifests/charts.quay.io_directpvs.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: directpvs.charts.quay.io
+spec:
+  group: charts.quay.io
+  names:
+    kind: Directpv
+    listKind: DirectpvList
+    plural: directpvs
+    singular: directpv
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Directpv is the Schema for the directpvs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Directpv
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of Directpv
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/minio-directpv/2025.12.17013747/manifests/directpv-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/minio-directpv/2025.12.17013747/manifests/directpv-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: directpv-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: directpv-operator
+    control-plane: controller-manager
+  name: directpv-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/minio-directpv/2025.12.17013747/manifests/directpv-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/minio-directpv/2025.12.17013747/manifests/directpv-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: directpv-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: directpv-operator
+  name: directpv-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/minio-directpv/2025.12.17013747/manifests/minio-directpv.clusterserviceversion.yaml
+++ b/operators/minio-directpv/2025.12.17013747/manifests/minio-directpv.clusterserviceversion.yaml
@@ -1,0 +1,314 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "charts.quay.io/v1alpha1",
+          "kind": "Directpv",
+          "metadata": {
+            "name": "directpv-sample"
+          },
+          "spec": {
+            "annotations": {},
+            "controller": {
+              "podAnnotations": {},
+              "podLabels": {},
+              "replicas": 3
+            },
+            "images": {
+              "pullPolicy": "IfNotPresent",
+              "pullSecrets": []
+            },
+            "labels": {},
+            "license": "",
+            "nodeserver": {
+              "nodeSelector": {},
+              "podAnnotations": {},
+              "podLabels": {},
+              "tolerations": []
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-12-17T01:41:52Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    features.operators.openshift.io/cnf: 'false'
+    features.operators.openshift.io/cni: 'false'
+    features.operators.openshift.io/csi: 'true'
+    features.operators.openshift.io/disconnected: 'true'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'false'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
+  name: minio-directpv.v2025.12.17013747
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Directpv
+      name: directpvs.charts.quay.io
+      version: v1alpha1
+  description: |
+    DirectPV is a Kubernetes Container Storage Interface (CSI) driver designed for direct-attached storage. It enables container orchestrators to automatically manage the full lifecycle of local storage devices including discovery, formatting, mounting, scheduling, and monitoring across distributed environments. DirectPV is composed of two core components:
+
+    • DirectPV CSI Driver – deployed within the Kubernetes cluster to provision and manage local persistent volumes.
+    • DirectPV Plugin – a command-line utility installed on local machines to configure and interact with the CSI Driver.
+
+    Unlike traditional SAN or NAS systems, DirectPV is not a storage backend but a distributed persistent-volume manager that exposes local disks directly to Kubernetes. This approach eliminates unnecessary data-path hops introduced by networked storage or SAN/NAS-based CSI drivers, delivering lower latency, higher throughput, and simplified storage management for modern distributed workloads.
+
+    Distributed data platforms such as object storage, databases, and message queues benefit most from direct-attached storage, as they natively handle replication and data durability. Running these systems atop SAN/NAS-based CSI drivers introduces redundant replication layers and performance bottlenecks.
+
+    For compatibility, prerequisites, release notes, and other user information, see [MinIO DirectPV documentation](https://min.io/docs/directpv/overview/).
+  displayName: DirectPV
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAKcAAACnCAYAAAB0FkzsAAAACXBIWXMAABcRAAAXEQHKJvM/AAAIj0lEQVR4nO2dT6hVVRSHjykI/gMDU0swfKAi2KgGOkv6M1RpqI9qZBYo9EAHSaIopGCQA8tJDXzNgnRcGm+SgwLDIFR4omBmCQrqE4Tkxu/6Tlyv7569zzn73Lvu3t83VO+5HN/31t5r7bX3ntVqtVoZgD0mnuOHAlZBTjALcoJZkBPMgpxgFuQEsyAnmAU5wSzICWZBTjALcoJZkBPMgpxgFuQEsyAnmAU5wSzICWbRHqIJfjxgjiz77T8hbd197bqGkwAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - charts.quay.io
+          resources:
+          - directpvs
+          - directpvs/status
+          - directpvs/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - '*'
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - csidrivers
+          - storageclasses
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: directpv-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: directpv-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: directpv-operator
+          control-plane: controller-manager
+        name: directpv-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d8cc6ffb98190e8dd403bfe67ddcb454e6127d32b87acc237b3e5240f70a20fb
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 5m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                - --leader-election-id=directpv-operator
+                image: quay.io/cniackz4/directpv-operator@sha256:f53036ffbd688bc588d0ddf111d3e7d5a53c57148d754e5f40d1706d6280d8a4
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: directpv-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: directpv-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - directpv
+  - storage
+  - csi
+  - minio
+  links:
+  - name: DirectPV Operator
+    url: https://min.io/docs/directpv/overview/
+  maintainers:
+  - email: cesarcelis@minio.io
+    name: celis
+  maturity: stable
+  provider:
+    name: MinIO
+  relatedImages:
+  - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d8cc6ffb98190e8dd403bfe67ddcb454e6127d32b87acc237b3e5240f70a20fb
+    name: kube-rbac-proxy
+  - image: quay.io/cniackz4/directpv-operator@sha256:f53036ffbd688bc588d0ddf111d3e7d5a53c57148d754e5f40d1706d6280d8a4
+    name: manager
+  replaces: minio-directpv.v2025.12.16190343
+  version: 2025.12.17013747

--- a/operators/minio-directpv/2025.12.17013747/metadata/annotations.yaml
+++ b/operators/minio-directpv/2025.12.17013747/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: minio-directpv
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # OpenShift versions supported
+  com.redhat.openshift.versions: v4.11-v4.18


### PR DESCRIPTION
## Summary
- New certified version 2025.12.17013747 of minio-directpv operator
- Added icon to base CSV config for OperatorHub display
- Documented operator description for future releases
- Replaces version 2025.12.16190343

## Changes
- Digest-pinned images for disconnected installations
- Added relatedImages section
- OpenShift v4.11-v4.18 compatibility annotations