### PR TITLE
Add latest versions to the catalogs

### DIFF
--- a/operators/f5-ai-security-operator/0.7.0/release-config.yaml
+++ b/operators/f5-ai-security-operator/0.7.0/release-config.yaml
@@ -1,0 +1,5 @@
+catalog_templates:
+  - channels:
+      - stable
+    replaces: f5-ai-security-operator.v0.6.1
+    template_name: basic.yaml

--- a/operators/f5-ai-security-operator/0.7.1/release-config.yaml
+++ b/operators/f5-ai-security-operator/0.7.1/release-config.yaml
@@ -1,0 +1,5 @@
+catalog_templates:
+  - channels:
+      - stable
+    replaces: f5-ai-security-operator.v0.7.0
+    template_name: basic.yaml


### PR DESCRIPTION
Versions 0.7.0 and 0.7.1 were missing from the catalogs do the issues when migrating to the FBC bundle format. The result of this was that 0.6.1 was being selected in the version selection list by default. This corrects that.