### PR TITLE
Catalog update [hazelcast-platform-operator] [v4.12,v4.13,v4.14,v4.15,v4.16,v4.17,v4.18,v4.19,v4.20,v4.21]

### DIFF
--- a/operators/hazelcast-platform-operator/5.16.0/metadata/annotations.yaml
+++ b/operators/hazelcast-platform-operator/5.16.0/metadata/annotations.yaml
@@ -12,4 +12,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.12-v4.18
+  com.redhat.openshift.versions: v4.12-v4.21

--- a/operators/hazelcast-platform-operator/ci.yaml
+++ b/operators/hazelcast-platform-operator/ci.yaml
@@ -1,2 +1,2 @@
 cert_project_id: 61710ab3468f306699ee5887
-merge: true
+merge: false


### PR DESCRIPTION
## Summary
This PR extends the `com.redhat.openshift.versions` range for two already-published
`hazelcast-platform-operator` bundles to include OpenShift `v4.19`, `v4.20`, and `v4.21`.
| Bundle  | Before          | After           |
| ------- | --------------- | --------------- |
| `5.16.0` | `v4.12-v4.18`  | `v4.12-v4.21`  |

No manifests, CRDs, RBAC, CSV, or `ci.yaml` are modified. The only change is the value of `com.redhat.openshift.versions` in each bundle's `metadata/annotations.yaml`. 

## Motivation
When `5.16.0` was released the latest GA OpenShift was `v4.18`, and the annotation was set to `v4.12-v4.18`. The same closed range was carried forward to `5.17.0`. As a result, customers running OpenShift `v4.19`, `v4.20`, or `v4.21` cannot see `5.16.0` or `5.17.0` in OperatorHub - they only see `5.15.0` (which has an open-ended `v4.8` annotation). This blocks them from receiving the features and fixes shipped in `5.16.0` and `5.17.0`. 