### PR TITLE
operator iax-webhook-router (0.1.7)

### DIFF
--- a/operators/iax-webhook-router/0.1.7/manifests/iax-operator-sa_v1_serviceaccount.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-operator-sa_v1_serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iax-operator-sa
+  labels:
+    app.kubernetes.io/name: iax-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/managed-by: olm

--- a/operators/iax-webhook-router/0.1.7/manifests/iax-operator_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-operator_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,136 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: iax-operator
+  labels:
+    app.kubernetes.io/name: iax-operator
+    app.kubernetes.io/managed-by: olm
+rules:
+- apiGroups:
+  - itrsgroup.com
+  resources:
+  - iaxplatforms
+  - iaxplatforms/status
+  - obcervs
+  - obcervs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - endpoints/restricted
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets/scale
+  - deployments/scale
+  - statefulsets/scale
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - patch

--- a/operators/iax-webhook-router/0.1.7/manifests/iax-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: iax-operator
+  labels:
+    app.kubernetes.io/name: iax-operator
+    app.kubernetes.io/managed-by: olm
+subjects:
+- kind: ServiceAccount
+  name: iax-operator-sa
+roleRef:
+  kind: Role
+  name: iax-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/operators/iax-webhook-router/0.1.7/manifests/iax-troubleshoot_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-troubleshoot_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: iax-troubleshoot
+  labels:
+    app.kubernetes.io/name: iax-troubleshoot
+    app.kubernetes.io/managed-by: olm
+rules:
+- apiGroups: [""]
+  resources: ["secrets", "services"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/portforward"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets", "daemonsets"]
+  verbs: ["get", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list"]

--- a/operators/iax-webhook-router/0.1.7/manifests/iax-troubleshoot_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-troubleshoot_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: iax-troubleshoot
+  labels:
+    app.kubernetes.io/name: iax-troubleshoot
+    app.kubernetes.io/managed-by: olm
+subjects:
+- kind: ServiceAccount
+  name: iax-troubleshoot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: iax-troubleshoot

--- a/operators/iax-webhook-router/0.1.7/manifests/iax-troubleshoot_v1_serviceaccount.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-troubleshoot_v1_serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iax-troubleshoot
+  labels:
+    app.kubernetes.io/name: iax-troubleshoot
+    app.kubernetes.io/component: support
+    app.kubernetes.io/managed-by: olm

--- a/operators/iax-webhook-router/0.1.7/manifests/iax-webhook-router.clusterserviceversion.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iax-webhook-router.clusterserviceversion.yaml
@@ -1,0 +1,200 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: iax-webhook-router.v0.1.7
+  annotations:
+    alm-examples: >-
+      [{"apiVersion":"itrsgroup.com/v1","kind":"IAXPlatform","metadata":{"name":"example-iaxplatform","namespace":"default"},"spec":{}}]
+    capabilities: Basic Install
+    categories: Monitoring,Integration & Delivery
+    containerImage: quay.io/itrs/iax-webhook-router@sha256:9729028f5c97c4f0c1cedf982fffb4c9c848430a55a16fa91d3236b060488084
+    createdAt: "2026-06-08T10:00:00Z"
+    description: Proxies validating admission requests for IAXPlatform custom resources to the iax-operator webhook server.
+    repository: https://github.com/ITRS-Group/iax-webhook-router
+    support: https://support.itrsgroup.com/hc/en-us
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+spec:
+  displayName: ITRS Analytics Webhook Router
+  description: |-
+    **ITRS Analytics Webhook Router** is an HTTPS reverse proxy that forwards Kubernetes
+    admission requests for `IAXPlatform` custom resources to the **iax-operator** webhook
+    server running in the target namespace.
+
+    It provides a CRD and a `ValidatingWebhookConfiguration` managed through OLM,
+    ensuring admission validation is enforced for all `IAXPlatform` resources.
+  version: 0.1.7
+  minKubeVersion: "1.29.0"
+  maturity: alpha
+  keywords:
+    - iax
+    - webhook
+    - admission
+    - kubernetes
+    - itrsgroup
+  maintainers:
+    - name: ITRS Group
+      email: support@itrsgroup.com
+  provider:
+    name: ITRS Group
+    url: https://www.itrsgroup.com
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAATA0lEQVR42u2dP0xbabrGH9CUa+XcMi7WTmNuZcx1tKnGmIYqJqTYSEFhIQV2QxQiQjWWOEjeKnADCg2mIBErkHaKEDzN0vjgWyUCYVxdaGKncLbbw/X03IKYzQDJ2NjH5/2+8/yk1WqyG8lzznmf7/33vS9ACCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEDfoauUvn56envIREuKiAXd1tWTD3XyEhHgXCgAhFABCCAWAEEIBIIRQAAghFABCCAWAEEIBIIRQAAghFABCCAWAEEIBIIRQAAghFABCCAWAEEIBIITI4wc+Ar2x7RpO7BoAoFKunv+5YfgQjvTwAVEAiMrG/alcxWHxGCcntbP/tmsol6s4sX/9jcFfZHQ8gdU1kw+RAkBUMfaCtYfC7j4+lT/jsHj8XQMnhAKgMJVyFQVrH4XdfRSsfRo7oQDofsKXikfYfmcht7VLgycUAC8YfW7LQmF3H7ktC/aXZB0hFACNKVh7WH/zC42eUAC8dNovL21geXGTRk8oAF467TNzWRSsfT4MQgGg4RNCAdCW9dc5ZOayzOITCgANnxAKAF19QsDbgNCtU29wIInBgRSN34Vnv/4mxwdBAYAr5bzM3Ap6biVo+C6RmctiYtzExGOTIRcFoLPu/p2+EWTMLB+Gm6f/69x53qXnVgKZuRU+GAqAs6f+zLN5DA6keOK4zIP705c9AjOLnlsJvhsKgHOn/qvFTT4MuF9pOSwef9MzoDdAAeCpr3ns/7v/H3oDFIB2xJk89WWxvLTRsFHX3x8rBb9PVyt/+fT09FQ7N/NNDjNTC9pf2InFoxgdS5z/cyB4E8DZrMAbhg+BoF9YyfV6ntiTqYd48fK5vgbc1dVFAWgTM8/meep/RSDoRyB488sA0RDCvSEEg/6ODxOdeGyeZ/6v+++xk18RJWoUAGHx/oP706zrN0hdEGLxKGL9UYQjPTAMn2Onf8+tRFvE7Oe3CwhHQhQACkB73Evy25BiaDh+LghSTv+LzC9OY/LpCAWAAgCUiscYHEhyQIcDoUNiuB9/GUu0JAbrr3OYeGy2/felzSTSsykKgJcFwCvJPglikDaTiPVHm47BnSzn6SICFIBrGv/EuEnr7DCj4wmMjt1FLH7btdNft+UoFAA020yywl5+IV7B12VIuJSXGRqOI7tmOpbElC4A3d7qJKPxQ0jidWLcRM+txJXNOs00/bTK9pbl6TyQZzwAGr8aHkG7yn7NEo6E8OFgkyGAjgKwvLSB51MLtDTh9EZCCAT92N6yXMtRqJYToACACT/iXRGgAOD7df4/9T3kV02ga4mQSUB8f2YfIc2SMbOemSvQra/xp9jkQ1oSAS9cJ9YyBPhT30OUvjE5hhA0cenp/cGG6FuEDAFw+UovjZ+gTbdEdfcku3WbGsP7/KTd4eRVg0gZAggLAdxqICFgZYBlQPddtTt9I7zTTxxlJ59FLB5lDkBe3L9A4yfoxGgy3fIB3TrMim/nxBhCvhdmJh2+okwBaPKFNDIrnhC08fbg8tIGmAQUkANo97w4aFbDvmH40BsJfRnzfRPGjbM/u8iJXYN9UoNt1/Cp/Bm2XUOpeMxGKgX6AzybBOzExBjVpvSGIyH09vYgFo+25eOsC0GpeITC7j4K1j5FAf8egrqTz1IAOMkXrg7eHLo3gHAk1LGJNqXiMQrWHrbfWZ4fo/73twsYGo5TAOj6d+6kfzR+F0P3BkSUoyrlKgrWPpaXNr65tFP39/G/H3OujhPznAB4seEnFo8iPZsSV4O+6Bm8WtrwnDC7vXrMcwLgpc2vKhj+VQK9/voXrL/JeeY9fTjYdG3jkKcagWy7ppQxtJpgkth51uh8v538CtKzKWWn7TbD82fzYBkQna0AZOay2p0wKp74jfZq6B4auCXWnr4LoIsQGIYP6dkUJqceQu8JTfpWbtwqC3r6LsDoeAI7+RWMjieU/nDeH2xobfz10ODoY06bnXwXKVj7SpZFtboOPPHYVOolzL98rr3he8kbqIscPQCXHv5OPovVNVP0CKf6b/1wsOlJ4//3u1Lbc/teXwQ9AMgY6ri8tCGudTUWj+Lvbxc8kR334gTeTucCOBBEoQz05NMRzC9O0+ov8GpxEzMKl9LgYkWAAtDwXLfnOCweufYb0rMppE3uKcB3Ogl1WdLZSS+AOYAGY873Bxuu5Qdo/GhoOedOPqtFaKRSRaDba3vf0rNJGj9FwHG23+XBJKBAOnmXgMbv3XCgUzcFGQKguc7BThn/5NMRGn8LnsCLl9PKLxX5mwKrxTzlAXTq9A9HQvhwwAUl8Hh1oBPJQHoAwk7/QNCPn98u0HrRnrv2T6ZGwGQgmARslU5ND97Jr4jvRFSJn2aT6HXprn1bRGB3jwLgldM/PZui8aP9yTSVOyeXhe+q9IQALC85/xKGhuNM+jkYVv2k6C1C266JDgO0F4CCted4B2Ag6Fc+a61CPkDVQSmSewK0F4D1N790wPVP0vXvAKtrppKhQG5rlwLglvvl9EWgQNCv3bVWyaGAileoK+Wq2NkHWgtAbstCJ7L+BB1trVbR28q9sygAnXf/c47fLaDr704ooOJSUbATUK8FIkcfcxQAlxgcSCo1fccwfPjnvyx2AqKDXVg8/fUOBcByIEMAt9z/Tl8rJrjUZ69aWbB0eEQB0MEDaNf6bYKWm6/4TVIArmz+cZInT0egwwRb1Xk0llCqL0CiAPygowA4WXIJBP1IKHTy2HYNuS0Lhd19HBaP8Kn8+dKgjXAkhGDQf+ZW90cRjvRAlcTa5NRDZMysMu+iUq6K8h61FAAnd9UnhvuV8YIyc9mGTp1S8Ril4vF5qaq+4DNxLy7+hI313waQhTq3A/cxKkgAunXs/nPS1ZLu/hesPQwOJDE4kLr2c6iUq5gYN3Gnb8TxZKrXkoFuTqb2hACUHHzAvZGQ2OSfbdcw82y+JcP/lhB0co7idUVAFT6VP1MAnC21OOf+/yj0QzvbtZfEK4funlfKVdzpGxHbzZa4N8DwlAJwxq6D7v+QwA+tvmiz5PCHZds1PLg/LTIkkOyZXfW+JE071k4AnHKxDMMnztV0Y8vuxLgpUgSGFEnOAsAJBUC9JIvEONOtFdszUwuOexzNEu7tgUp7DygAisVX0gQgM7fiWmLOtmv48/1pUa6sSonASqVKAXDGtfo/T5wwlXLV9eaXSrmK5aUNSBoWokpXIHMAClYAwoJGU088NiFl4q2kj/lHRbyAiqBSYLduTUBwKAEo5XQpWHtiesptuybKCwgGbzIJ6GUBcEpZJZ3+nRhyqqoXoEoiUFJTlWYCUHUsvvTKkNNrXTYSMu/uxn+okgP4lQIApabR3hRzkQS85vpNentDDAEYAujrAfyPtefZ6csNeQCsAtADcALjho995A3cc5cwH4BQALQ9WSrCbpJJdGs5qs3TjUA1rV+W5Cu5h4fHtCYFw4Af+FAJgWfbksULwMyzeWwLXq5ICC6ti8tSANpZM9Vhgi3alOSS6uUEAoy9mQMg8GqZyzD+wBekYCWim004UCa5KDm2lDJK3G1v8QYFQD/sk5qY0Vdg0ot4SQAkuFRSPIAf+28LPf1DPP2FtY1rIwA3BHThlYUkIXsjIfQK3Nrzl7EEBYAegL43vCTNcpe2mag3EhIT/9snv7ITUbskoIDykqQe/MmnI6IyzZOCNiWVBGzdYQigYXlJkmtZX4gppe9+dDwBLt1gGVD7YY8lQTvdJp+OiHA1d/Ir4NottRuiutkAo95lF8Pw4ee3C67+hvRsSlS8a9s1EYs3GQJAzzKTlKk3Xz+TFy+fw50tPHGkzSS8shS2Gf7IJCC0nPYqTQAA4MnUQ6RnUx0XnuyaKe5ZSJhLqNJuArU8AAHTXivlqsg6c9pMdkwEYvEodvJZkR+5hASgau6/QiFAD0+Z3xGB1TXT0Zh88umIWOOvlKsiPLRwJEQB0FlZt7cssc9odDyBnfxK28tygaAfO/ks5henxf67SwnP+oW2aisvAIbhE9ECWyoei546FAj6sbpmYnXNbPmCjmH4kJ5N4f3BhvjLPttCPDOGAI7Gn/8FCaWmv73JiX9WZ95AFh8ONjE6nmg4NDAMH4aG49jJZ/HPf1lIm0nxSa1KuSpiLLlh+MSEqtBxJqCUtU/bW5ao9tffi0lXv2Tsz5KYn1EqHl263hwI+NEb6VEyhpXi/qv47ACgq5W/fHp6etpJpe+5JaPt9MPBhpJqryM9txIiqjPzi9OuHAxdXV1dnggBAkG/mM6zbaHVAK9RsPbElGZVWUyq9EQgKckoSRtxvYyUTcmG4VN2KpJaAtAfFdN3vry0QQuEu8k/KZuSVR6JppQAJIbjYn4LvQB3yczJmb2fuBenAHjN1aIXwNOfHgDcuYlGL4CnvyTjV3khqXIC8GgsIeoO+l/nVmiR6GQfRl7U6T8q6Hv0hABIy7i+WtwUeVVYV2ae/TdYmfL4YhBJYQAAPH82T8vsiOu/IupKturuv7IC8GgsIapHvVQ8RoahAJxO/GVMWVt3VXf/lRUAw/DhR2GuV8bMoiRofLhuDA6kxH2DCWGeqKd2Az4ReCHnz/enWRVwJO6fFzeNKTEcV278l1YCEItHxa3JqpSrSD42abFtZHlpA68WN8X9rvRsElwN5vq997uQV6aymA/QOO7XJfmnhQBISwZ+nQ9YV2BwiHTjHxxIiQypdEj+aSEAktZkXYpbpxaYFMT1G6wGB1IipzBLW4fmaQEA5C3L/O1HnKQIXPO5SV31rUvsr40ASPYCKAJ6PS/dTn8tBECyF0AR0Os56Xb6ayMAkr2Arz9uyXsF4HLC707fiGjj1/H010YApHsBdRF4cH+aJUJcbqOWmvDT/fTXSgCkewH4qkQ4w8tDAID1NznRCT/dT39AobHgUGxMdGMrt1a0aSi5zhwFiR1+V3H0MSf2PXlmLHijrApcXf29uNdrY8VKxWPc6RtRxvib2axEDwBSbo4llRrSMTqeQHo2qfWHVp+hKLG1V2UvrVUPQEsBqJ+uqt3MS5tJpGdT0HGBx8TjOSVCs4vepPTYnyHAN5T7JwUNKWNm0XMroc09goK1h8GBpBJZflxx4UfXxJ/2HoCqocBFEUubSSUvnhSsPWTmsso+e8Pw4f3BhhIhGUMADUOBq4QgcU/+AArVDb/O/MvnSpSUKQBobGqvDnX3+giq0bG7iMVvQ1pyL7dl4VCDdufR8YQylSQKABodKbWAV4sbWuU4EsP9GLoXd0UMKuUqcu8sbG9ZWo1EV7E3gwLQ4Cl1p29EuURUM3sSYvEowr0hRwShUq6iYO3j8PAIua1dLZ8jAHw42EQ4ElLqN1MAPJQPaJRwJIRg0I9wJIRAwI9A8CYMw4cbX/5zMZdQN+hKuYpK+TNOTmo4LB6jUq6iVDz2xDNLz6aQNtXr96cANMH66xwmOLST4PJFsvnFaSV/OwUAzdfaeSOPfB33vz/YUHbENxuBrtFtp9NQR9J60k+H+f70AJrkTt9DLcpWBNo3+9ADcIB/5LOevIpLztjh+/e2ABiGz7P38b3O6pqpXLmPAsDGD+KRG34UAIoAofFTACgChMZPAaAIELSS66Hxg2VANNEy/OD+NEuE2iR6s1on/FgGdMAT+Ec+y2YhTTr8mO2nAFzPbXxttmU+304+q+WcPzg0huvJ0xG04zIUwzmGAGjXQJG/zq1c60bc18MlKuUqMnNZrL/O8au7wvDTsynE4lEAre12UPliDy8DCc4LXGew5VULJSgE3zZ8nI8W28fgQFLrUV7MAShYIWgmk5yeTV3pggaCfqyumTj6mPNsZjoWj2Inn8VOPnvJ+Ov/+1V//r338+Fg03PGzxBAaEjQzBXT+rSdzFxW20k7wFle5dH4XQzdG2jIuBsd4DI6lsCLxWnP3uhjCCAwJLhu3blg7WP9TU6r8CAWj2LoXhyPxhNNG2lmbuWbm4QMw4fsmomh4bi3T3AKAEQNFwkE/Tj6mGt5hmFuyzofvKmi0cf6b2N0/G5LmXjbruE/byUueQGxeBSrayaz/BQAGd7AxGPzfDpuuwdL2nYNBWsfuXdnE3glhgnng0n7o9c66dHgGLdA0I8XL6c9f+pTACBz3mCl/NnxwZL1nEFhdx+l4pErHYuBoB+xeBS9vSGEIz1NJexwzQ1Psf7bmJx66OnpPRQAgm+t3C6XqygdHp1P8W11mm99inBvJIQ/Bm8iGPAjHOlBOBKiEVIAKAAqhSgn9q/nYmDbNZxcEIb6qPAzo//DlaPDCQWAAkAIG4EIIeBlIEIIBYAQQgEghFAACCEUAEIIBYAQQgEghFAACCEUAEIIBYAQQgEghFAACCEUAEIIBYAQQgEghFAACCEUAEIIBYAQQgEghFAACCEUAEIIBYAQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBAF+H9qGKvENkn1WwAAAABJRU5ErkJggg==
+      mediatype: image/png
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: false
+  customresourcedefinitions:
+    owned:
+      - name: iaxplatforms.itrsgroup.com
+        version: v1
+        kind: IAXPlatform
+        displayName: IAXPlatform
+        description: ITRS Analytics platform custom resource (schema validated in iax-operator).
+        resources:
+          - kind: Service
+            name: ""
+            version: v1
+          - kind: ValidatingWebhookConfiguration
+            name: ""
+            version: v1
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: iax-webhook-router
+          rules:
+            - apiGroups:
+                - itrsgroup.com
+              resources:
+                - iaxplatforms
+              verbs:
+                - get
+                - list
+                - watch
+      clusterPermissions:
+        - serviceAccountName: iax-webhook-router
+          rules:
+            - apiGroups:
+                - itrsgroup.com
+              resources:
+                - iaxplatforms
+              verbs:
+                - get
+                - list
+                - watch
+      deployments:
+        - name: iax-webhook-router
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: iax-webhook-router
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: iax-webhook-router
+              spec:
+                serviceAccountName: iax-webhook-router
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: iax-webhook-router
+                    image: quay.io/itrs/iax-webhook-router@sha256:9729028f5c97c4f0c1cedf982fffb4c9c848430a55a16fa91d3236b060488084
+                    args: []
+                    imagePullPolicy: IfNotPresent
+                    env:
+                      - name: RELATED_IMAGE_IAX_WEBHOOK_ROUTER
+                        value: quay.io/itrs/iax-webhook-router@sha256:9729028f5c97c4f0c1cedf982fffb4c9c848430a55a16fa91d3236b060488084
+                      - name: LISTEN_ADDR
+                        value: ":8443"
+                      - name: HEALTH_LISTEN_ADDR
+                        value: ":8081"
+                      - name: TLS_CERT_FILE
+                        value: /tmp/k8s-webhook-server/serving-certs/tls.crt
+                      - name: TLS_KEY_FILE
+                        value: /tmp/k8s-webhook-server/serving-certs/tls.key
+                      - name: TARGET_SERVICE_NAME
+                        value: iax-operator-webhook
+                      - name: TARGET_SERVICE_PORT
+                        value: "443"
+                      - name: TARGET_PATH
+                        value: /validate
+                      - name: LOG_LEVEL
+                        value: info
+                    ports:
+                      - name: https
+                        containerPort: 8443
+                        protocol: TCP
+                      - name: health
+                        containerPort: 8081
+                        protocol: TCP
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: 64Mi
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      seccompProfile:
+                        type: RuntimeDefault
+  webhookdefinitions:
+    - type: ValidatingAdmissionWebhook
+      generateName: viaxplatforms.itrsgroup.com
+      deploymentName: iax-webhook-router
+      containerPort: 8443
+      targetPort: 8443
+      admissionReviewVersions:
+        - v1
+      sideEffects: None
+      failurePolicy: Fail
+      webhookPath: /validate-iaxplatform
+      rules:
+        - apiGroups:
+            - itrsgroup.com
+          apiVersions:
+            - v1
+          resources:
+            - iaxplatforms
+          operations:
+            - CREATE
+            - UPDATE
+          scope: Namespaced
+  relatedImages:
+    - name: iax-webhook-router
+      image: quay.io/itrs/iax-webhook-router@sha256:9729028f5c97c4f0c1cedf982fffb4c9c848430a55a16fa91d3236b060488084

--- a/operators/iax-webhook-router/0.1.7/manifests/iaxplatforms.itrsgroup.com.crd.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/iaxplatforms.itrsgroup.com.crd.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: iaxplatforms.itrsgroup.com
+spec:
+  group: itrsgroup.com
+  scope: Namespaced
+  names:
+    kind: IAXPlatform
+    listKind: IAXPlatformList
+    plural: iaxplatforms
+    singular: iaxplatform
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/operators/iax-webhook-router/0.1.7/manifests/replicated-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/replicated-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: replicated-role
+  labels:
+    app.kubernetes.io/name: replicated
+    app.kubernetes.io/managed-by: olm
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - update
+  resourceNames:
+  - replicated
+  - replicated-instance-report
+  - replicated-custom-app-metrics-report
+  - replicated-meta-data

--- a/operators/iax-webhook-router/0.1.7/manifests/replicated-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/replicated-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: replicated-rolebinding
+  labels:
+    app.kubernetes.io/name: replicated
+    app.kubernetes.io/managed-by: olm
+subjects:
+- kind: ServiceAccount
+  name: replicated
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: replicated-role

--- a/operators/iax-webhook-router/0.1.7/manifests/replicated_v1_serviceaccount.yaml
+++ b/operators/iax-webhook-router/0.1.7/manifests/replicated_v1_serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: replicated
+  labels:
+    app.kubernetes.io/name: replicated
+    app.kubernetes.io/component: sdk
+    app.kubernetes.io/managed-by: olm

--- a/operators/iax-webhook-router/0.1.7/metadata/annotations.yaml
+++ b/operators/iax-webhook-router/0.1.7/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: iax-webhook-router
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  com.redhat.openshift.versions: "v4.16-v4.21"


### PR DESCRIPTION
## Summary

- CSV version: `0.1.7` (`iax-webhook-router.v0.1.7`)
- Nine namespace-scoped RBAC manifests added to the bundle (ServiceAccounts, Roles, RoleBindings)
- Runtime image unchanged: `quay.io/itrs/iax-webhook-router@sha256:9729028f5c97c4f0c1cedf982fffb4c9c848430a55a16fa91d3236b060488084`
- `minKubeVersion`: `1.29.0`
- OCP versions: `v4.16–v4.21`
- Install modes: OwnNamespace, SingleNamespace

Made with [Cursor](https://cursor.com)