### PR TITLE
Catalog update [amd-gpu-operator] [v4.22]

### DIFF
--- a/catalogs/v4.22/amd-gpu-operator/catalog.yaml
+++ b/catalogs/v4.22/amd-gpu-operator/catalog.yaml
@@ -1,0 +1,4757 @@
+---
+defaultChannel: alpha
+icon:
+  base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MDAiIGhlaWdodD0iMTkwLjgwMyIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIj48cGF0aCBkPSJNMTg3Ljg4OCAxNzguMTIySDE0My41MmwtMTMuNTczLTMyLjczOEg1Ni4wMDNsLTEyLjM2NiAzMi43MzhIMEw2Ni42NjcgMTIuNzc2aDQ3Ljc2MXpNOTEuMTU1IDUyLjI4Nkw2Ni45MTIgMTE2LjUzaDUwLjkxM3ptMjU3LjkwMS0zOS41MWgzNS44OHYxNjUuMzQ2aC00MS4yMTlWNzQuODQybC00NC42MDggNTEuODc3aC02LjMwMWwtNDQuNjA1LTUxLjg3N1YxNzguMTJoLTQxLjIxOVYxMi43NzZoMzUuODhsNTMuMDkyIDYxLjMzNnptMTQwLjMxOSAwYzYwLjM2NCAwIDkxLjM5MSAzNy41NzMgOTEuMzkxIDgyLjkwOSAwIDQ3LjUxNy0zMC4wNTggODIuNDM3LTk2IDgyLjQzN2gtNjguMzY5VjEyLjc3NnptLTMxLjc2MiAxMzUuMDQxaDI2LjkwNmM0MS40NTcgMCA1My44MjMtMjguMTI5IDUzLjgyMy01Mi4zNzcgMC0yOC4zNjgtMTUuMjc2LTUyLjM2My01NC4zMDgtNTIuMzYzaC0yNi40MjJ2MTA0Ljc0em0yMDUuMTU2LTk1LjgzNkw2MTAuNzk3IDBIODAwdjE4OS4yMWwtNTEuOTcyLTUxLjk3NVY1MS45ODF6bS0uMDYxIDEwLjQxNkw2MDkuMiAxMTUuOTAzdjc0Ljg5OWg3NC44ODlsNTMuNTA1LTUzLjUwNmgtNzQuODg2eiIvPjwvc3ZnPg==
+  mediatype: image/svg+xml
+name: amd-gpu-operator
+schema: olm.package
+---
+entries:
+- name: amd-gpu-operator.v1.1.1
+- name: amd-gpu-operator.v1.2.1
+  replaces: amd-gpu-operator.v1.1.1
+- name: amd-gpu-operator.v1.3.1
+  replaces: amd-gpu-operator.v1.2.1
+- name: amd-gpu-operator.v1.3.2
+  replaces: amd-gpu-operator.v1.3.1
+- name: amd-gpu-operator.v1.4.1
+  replaces: amd-gpu-operator.v1.3.2
+- name: amd-gpu-operator.v1.5.0
+  replaces: amd-gpu-operator.v1.4.1
+name: alpha
+package: amd-gpu-operator
+schema: olm.channel
+---
+image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:54cdff8b0d36aa7c47cff1b115a1ee041cf79a6599dd4acba3d1031e0f780dd6
+name: amd-gpu-operator.v1.1.1
+package: amd-gpu-operator
+properties:
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: DeviceConfig
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: amd-gpu-operator
+    version: 1.1.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "amd.com/v1alpha1",
+            "kind": "DeviceConfig",
+            "metadata": {
+              "name": "test-deviceconfig",
+              "namespace": "kube-amd-gpu"
+            },
+            "spec": {
+              "devicePlugin": {
+                "devicePluginImage": "rocm/k8s-device-plugin:latest",
+                "nodeLabellerImage": "rocm/k8s-device-plugin:labeller-latest"
+              },
+              "driver": {
+                "image": "my.registry.io/myUserName/myRepo",
+                "imageRegistrySecret": {
+                  "name": "docker-auth"
+                },
+                "version": "6.2.2"
+              },
+              "selector": {
+                "feature.node.kubernetes.io/amd-gpu": "true"
+              }
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: AI/Machine Learning, Monitoring
+      containerImage: docker.io/rocm/gpu-operator@sha256:597e1b8e080b67da3391d0bc7f5982a97eba732b76f5ff2017f8d9bcc243d479
+      createdAt: "2024-12-05T11:43:38Z"
+      description: |-
+        Operator responsible for deploying AMD GPU kernel drivers, device plugin and device metrics exporter
+        For more information, visit [documentation](https://dcgpu.docs.amd.com/projects/gpu-operator/en/latest/)
+      devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:e55a8618492fc64fc0c15f0891df1dabd963cc964b309d5051381f60a4d49f1d
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:8bbe4a51395e7ec1d5fd763c0cd715a7262a84707444d50e6757cad9b835a76e
+      nodelabellerImage: docker.io/rocm/k8s-device-plugin@sha256:776365fd3f24a6e88e5a9e85d5fc367fc4ff99c0634c20dc1d3c3b8ebe541b7a
+      operatorframework.io/suggested-namespace: kube-amd-gpu
+      operators.openshift.io/valid-subscription: '[]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ROCm/gpu-operator
+      support: Advanced Micro Devices, Inc.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DeviceConfig describes how to enable AMD GPU device
+        displayName: DeviceConfig
+        kind: DeviceConfig
+        name: deviceconfigs.amd.com
+        resources:
+        - kind: Daemonset
+          name: apps
+          version: v1
+        - kind: services
+          name: core
+          version: v1
+        - kind: Module
+          name: modules.kmm.sigs.x-k8s.io
+          version: v1beta1
+        specDescriptors:
+        - description: device plugin
+          displayName: DevicePlugin
+          path: devicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+        - description: device plugin image
+          displayName: DevicePluginImage
+          path: devicePlugin.devicePluginImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+        - description: enable or disable the node labeller
+          displayName: EnableNodeLabeller
+          path: devicePlugin.enableNodeLabeller
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+        - description: node labeller image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: devicePlugin.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: node labeller image
+          displayName: NodeLabellerImage
+          path: devicePlugin.nodeLabellerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+        - description: driver
+          displayName: Driver
+          path: driver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driver
+        - description: radeon repo URL for fetching amdgpu installer if building driver
+            image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+            by default
+          displayName: AMDGPUInstallerRepoURL
+          path: driver.amdgpuInstallerRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+        - description: blacklist amdgpu drivers on the host
+          displayName: BlacklistDrivers
+          path: driver.blacklist
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+        - description: enable driver install. default value is true. disable is for
+            skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+            module
+          displayName: Enable
+          path: driver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: defines image that includes drivers and firmware blobs, don't
+            include tag since it will be fully managed by operator for vanilla k8s
+            the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for
+            OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+            image tag will be in the format of <linux distro>-<release version>-<kernel
+            version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+            and ubuntu-22.04-5.15.0-94-generic-6.1.3
+          displayName: Image
+          path: driver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: secrets used for pull/push images from/to private registry
+            specified in driversImage
+          displayName: ImageRegistrySecret
+          path: driver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: driver image registry TLS setting for the container image
+          displayName: ImageRegistryTLS
+          path: driver.imageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: image signing config to sign the driver image when building
+            driver image on the fly image signing is required for installing driver
+            on secure boot enabled system
+          displayName: ImageSign
+          path: driver.imageSign
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+        - description: ImageSignCertSecret the public key used to sign kernel modules
+            within image necessary for secire boot enabled system
+          displayName: ImageSignCertSecret
+          path: driver.imageSign.certSecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+        - description: ImageSignKeySecret the private key used to sign kernel modules
+            within image necessary for secire boot enabled system
+          displayName: ImageSignKeySecret
+          path: driver.imageSign.keySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+        - description: 'version of the drivers source code, can be used as part of
+            image of dockerfile source image default value for different OS is: ubuntu:
+            6.1.3, coreOS: 6.2.2'
+          displayName: Version
+          path: driver.version
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:version
+        - description: metrics exporter
+          displayName: MetricsExporter
+          path: metricsExporter
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+        - description: optional configuration for metrics
+          displayName: Config
+          path: metricsExporter.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: Name of the configMap that defines the list of metrics default
+            list:[]
+          displayName: Name
+          path: metricsExporter.config.name
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:name
+        - description: enable metrics exporter, disabled by default
+          displayName: Enable
+          path: metricsExporter.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: metrics exporter image
+          displayName: Image
+          path: metricsExporter.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: metrics exporter image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: metricsExporter.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: NodePort is the external port for pulling metrics from outside
+            the cluster, in the range 30000-32767 (assigned automatically by default)
+          displayName: NodePort
+          path: metricsExporter.nodePort
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+        - description: Port is the internal port used for in-cluster and node access
+            to pull metrics from the metrics-exporter (default 5000).
+          displayName: Port
+          path: metricsExporter.port
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:port
+        - description: optional kube-rbac-proxy config to provide rbac services
+          displayName: RbacConfig
+          path: metricsExporter.rbacConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+        - description: disable https protecting the proxy endpoint
+          displayName: DisableHttps
+          path: metricsExporter.rbacConfig.disableHttps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+        - description: enable kube-rbac-proxy, disabled by default
+          displayName: Enable
+          path: metricsExporter.rbacConfig.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: kube-rbac-proxy image
+          displayName: Image
+          path: metricsExporter.rbacConfig.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: certificate secret to mount in kube-rbac container for TLS,
+            self signed certificates will be generated by default
+          displayName: Secret
+          path: metricsExporter.rbacConfig.secret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:secret
+        - description: Selector describes on which nodes to enable metrics exporter
+          displayName: Selector
+          path: metricsExporter.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+            by default
+          displayName: ServiceType
+          path: metricsExporter.serviceType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+        - description: Selector describes on which nodes the GPU Operator should enable
+            the GPU device.
+          displayName: Selector
+          path: selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        statusDescriptors:
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: devicePlugin.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: devicePlugin.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: devicePlugin.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: driver.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: driver.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: driver.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: metricsExporter.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: metricsExporter.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: metricsExporter.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: NodeModuleStatus contains per node status of driver module
+            installation
+          displayName: NodeModuleStatus
+          path: nodeModuleStatus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+        version: v1alpha1
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin and device metrics exporter
+      For more information, visit [documentation](https://dcgpu.docs.amd.com/projects/gpu-operator/en/latest/)
+    displayName: amd-gpu-operator-olm
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AMD
+    - GPU
+    - AI
+    - Deep Learning
+    - Hardware
+    - Driver
+    - Monitoring
+    links:
+    - name: AMD GPU Operator
+      url: https://github.com/ROCm/gpu-operator
+    maintainers:
+    - email: Yan.Sun3@amd.com
+      name: Yan Sun
+    - email: farshad.ghodsian@amd.com
+      name: Farshad Ghodsian
+    - email: shrey.ajmera@amd.com
+      name: Shrey Ajmera
+    maturity: stable
+    provider:
+      name: Advanced Micro Devices, Inc.
+relatedImages:
+- image: docker.io/rocm/device-metrics-exporter@sha256:8bbe4a51395e7ec1d5fd763c0cd715a7262a84707444d50e6757cad9b835a76e
+  name: device-metrics-exporter-8bbe4a51395e7ec1d5fd763c0cd715a7262a84707444d50e6757cad9b835a76e-annotation
+- image: docker.io/rocm/gpu-operator@sha256:597e1b8e080b67da3391d0bc7f5982a97eba732b76f5ff2017f8d9bcc243d479
+  name: manager
+- image: docker.io/rocm/gpu-operator@sha256:597e1b8e080b67da3391d0bc7f5982a97eba732b76f5ff2017f8d9bcc243d479
+  name: gpu-operator-597e1b8e080b67da3391d0bc7f5982a97eba732b76f5ff2017f8d9bcc243d479-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:776365fd3f24a6e88e5a9e85d5fc367fc4ff99c0634c20dc1d3c3b8ebe541b7a
+  name: k8s-device-plugin-776365fd3f24a6e88e5a9e85d5fc367fc4ff99c0634c20dc1d3c3b8ebe541b7a-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:e55a8618492fc64fc0c15f0891df1dabd963cc964b309d5051381f60a4d49f1d
+  name: k8s-device-plugin-e55a8618492fc64fc0c15f0891df1dabd963cc964b309d5051381f60a4d49f1d-annotation
+- image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:54cdff8b0d36aa7c47cff1b115a1ee041cf79a6599dd4acba3d1031e0f780dd6
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:4ff9f10f18113dc9c0e5473cab361c8fffe99800c660a3fcd50c50b896e2ca2f
+name: amd-gpu-operator.v1.2.1
+package: amd-gpu-operator
+properties:
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: DeviceConfig
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: amd-gpu-operator
+    version: 1.2.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "amd.com/v1alpha1",
+            "kind": "DeviceConfig",
+            "metadata": {
+              "name": "test-deviceconfig",
+              "namespace": "openshift-amd-gpu"
+            },
+            "spec": {
+              "devicePlugin": {
+                "devicePluginImage": "rocm/k8s-device-plugin:rhubi-latest",
+                "nodeLabellerImage": "rocm/k8s-node-labeller:rhubi-latest"
+              },
+              "driver": {
+                "enable": "true",
+                "version": "6.3.1"
+              },
+              "selector": {
+                "feature.node.kubernetes.io/amd-gpu": "true"
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning,Monitoring
+      containerImage: docker.io/rocm/gpu-operator@sha256:75acf0ce776264494317c3545f3069519dfd939eb4b06f1f0965312502bc5182
+      createdAt: "2025-04-11T09:26:09Z"
+      description: |-
+        Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+        For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+      devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:b970e87f3244de795f595a4f06efc90164c15ec72f8843240a56b6e5ea4c7390
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:d90e570acb1371b31cd3aa1d8cbda818846cf7a0b56f8ccec472826c6a2b9dfe
+      nodelabellerImage: docker.io/rocm/k8s-node-labeller@sha256:a9a492fad3c922110d142a4ce20520d8c44586867c9175ea4cb1b849f5e42940
+      operatorframework.io/suggested-namespace: openshift-amd-gpu
+      operators.openshift.io/valid-subscription: '[]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ROCm/gpu-operator
+      support: Advanced Micro Devices, Inc.
+      testRunnerImage: docker.io/rocm/test-runner@sha256:6cbee00819b4f7285841d5b2a10a5bb46ed10640a697630dfb7dd92f41e8c539
+      utilsContainerImage: docker.io/rocm/gpu-operator-utils@sha256:5792202b622c57c77458f9f195ef2086c259870d33798909ce1ff840af7d0d5d
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DeviceConfig describes how to enable AMD GPU device
+        displayName: DeviceConfig
+        kind: DeviceConfig
+        name: deviceconfigs.amd.com
+        resources:
+        - kind: Daemonset
+          name: apps
+          version: v1
+        - kind: services
+          name: core
+          version: v1
+        - kind: Module
+          name: modules.kmm.sigs.x-k8s.io
+          version: v1beta1
+        specDescriptors:
+        - description: common config
+          displayName: CommonConfig
+          path: commonConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:commonConfig
+        - description: InitContainerImage is being used for the operands pods, i.e.
+            metrics exporter, test runner, device plugin and node labeller
+          displayName: InitContainerImage
+          path: commonConfig.initContainerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:initContainerImage
+        - description: UtilsContainer contains parameters to configure operator's
+            utils container
+          displayName: UtilsContainer
+          path: commonConfig.utilsContainer
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:utilsContainer
+        - description: Image is the image of utils container
+          displayName: Image
+          path: commonConfig.utilsContainer.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for utils container
+          displayName: ImagePullPolicy
+          path: commonConfig.utilsContainer.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: secret used for pull utils container image
+          displayName: ImageRegistrySecret
+          path: commonConfig.utilsContainer.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: device plugin
+          displayName: DevicePlugin
+          path: devicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+        - description: device plugin image
+          displayName: DevicePluginImage
+          path: devicePlugin.devicePluginImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+        - description: image pull policy for device plugin
+          displayName: DevicePluginImagePullPolicy
+          path: devicePlugin.devicePluginImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:DevicePluginImagePullPolicy
+        - description: tolerations for the device plugin DaemonSet
+          displayName: DevicePluginTolerations
+          path: devicePlugin.devicePluginTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginTolerations
+        - description: enable or disable the node labeller
+          displayName: EnableNodeLabeller
+          path: devicePlugin.enableNodeLabeller
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+        - description: node labeller image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: devicePlugin.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: node labeller image
+          displayName: NodeLabellerImage
+          path: devicePlugin.nodeLabellerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+        - description: image pull policy for node labeller
+          displayName: NodeLabellerImagePullPolicy
+          path: devicePlugin.nodeLabellerImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:NodeLabellerImagePullPolicy
+        - description: tolerations for the node labeller DaemonSet
+          displayName: NodeLabellerTolerations
+          path: devicePlugin.nodeLabellerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerTolerations
+        - description: upgrade policy for device plugin and node labeller daemons
+          displayName: UpgradePolicy
+          path: devicePlugin.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: devicePlugin.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: devicePlugin.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: driver
+          displayName: Driver
+          path: driver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driver
+        - description: radeon repo URL for fetching amdgpu installer if building driver
+            image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+            by default
+          displayName: AMDGPUInstallerRepoURL
+          path: driver.amdgpuInstallerRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+        - description: blacklist amdgpu drivers on the host. Node reboot is required
+            to apply the baclklist on the worker nodes. Not working for OpenShift
+            cluster. OpenShift users please use the Machine Config Operator (MCO)
+            resource to configure amdgpu blacklist. Example MCO resource is available
+            at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+          displayName: BlacklistDrivers
+          path: driver.blacklist
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+        - description: enable driver install. default value is true. disable is for
+            skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+            module
+          displayName: Enable
+          path: driver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: 'defines image that includes drivers and firmware blobs, don''t
+            include tag since it will be fully managed by operator for vanilla k8s
+            the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for
+            OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+            image tag will be in the format of <linux distro>-<release version>-<kernel
+            version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+            and ubuntu-22.04-5.15.0-94-generic-6.1.3 NOTE: Updating the driver image
+            repository is not supported. Please delete the existing DeviceConfig and
+            create a new one with the updated image repository'
+          displayName: Image
+          path: driver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: secrets used for pull/push images from/to private registry
+            specified in driversImage
+          displayName: ImageRegistrySecret
+          path: driver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: driver image registry TLS setting for the container image
+          displayName: ImageRegistryTLS
+          path: driver.imageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: image signing config to sign the driver image when building
+            driver image on the fly image signing is required for installing driver
+            on secure boot enabled system
+          displayName: ImageSign
+          path: driver.imageSign
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+        - description: ImageSignCertSecret the public key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignCertSecret
+          path: driver.imageSign.certSecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+        - description: ImageSignKeySecret the private key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignKeySecret
+          path: driver.imageSign.keySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+        - description: policy to upgrade the drivers
+          displayName: UpgradePolicy
+          path: driver.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: enable upgrade policy, disabled by default If disabled, user
+            has to manually upgrade all the nodes.
+          displayName: Enable
+          path: driver.upgradePolicy.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: MaxParallelUpgrades indicates how many nodes can be upgraded
+            in parallel 0 means no limit, all nodes will be upgraded in parallel
+          displayName: MaxParallelUpgrades
+          path: driver.upgradePolicy.maxParallelUpgrades
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelUpgrades
+        - description: 'MaxUnavailableNodes indicates maximum number of nodes that
+            can be in a failed upgrade state beyond which upgrades will stop to keep
+            cluster at a minimal healthy state Value can be an integer (ex: 2) which
+            would mean atmost 2 nodes can be in failed state after which new upgrades
+            will not start. Or it can be a percentage string(ex: "50%") from which
+            absolute number will be calculated and round up'
+          displayName: MaxUnavailableNodes
+          path: driver.upgradePolicy.maxUnavailableNodes
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailableNodes
+        - description: Node draining policy
+          displayName: NodeDrainPolicy
+          path: driver.upgradePolicy.nodeDrainPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+        - description: Pod Deletion policy. If both NodeDrainPolicy and PodDeletionPolicy
+            config is available, NodeDrainPolicy(if enabled) will take precedence.
+          displayName: PodDeletionPolicy
+          path: driver.upgradePolicy.podDeletionPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podDeletionPolicy
+        - description: reboot between driver upgrades, enabled by default, if enabled
+            spec.commonConfig.utilsContainer will be used to perform reboot on worker
+            nodes
+          displayName: RebootRequired
+          path: driver.upgradePolicy.rebootRequired
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rebootRequired
+        - description: 'version of the drivers source code, can be used as part of
+            image of dockerfile source image default value for different OS is: ubuntu:
+            6.1.3, coreOS: 6.2.2'
+          displayName: Version
+          path: driver.version
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:version
+        - description: metrics exporter
+          displayName: MetricsExporter
+          path: metricsExporter
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+        - description: optional configuration for metrics
+          displayName: Config
+          path: metricsExporter.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: Name of the configMap that defines the list of metrics default
+            list:[]
+          displayName: Name
+          path: metricsExporter.config.name
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:name
+        - description: enable metrics exporter, disabled by default
+          displayName: Enable
+          path: metricsExporter.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: metrics exporter image
+          displayName: Image
+          path: metricsExporter.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for metrics exporter
+          displayName: ImagePullPolicy
+          path: metricsExporter.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: metrics exporter image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: metricsExporter.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: NodePort is the external port for pulling metrics from outside
+            the cluster, in the range 30000-32767 (assigned automatically by default)
+          displayName: NodePort
+          path: metricsExporter.nodePort
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+        - description: Port is the internal port used for in-cluster and node access
+            to pull metrics from the metrics-exporter (default 5000).
+          displayName: Port
+          path: metricsExporter.port
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:port
+        - description: optional kube-rbac-proxy config to provide rbac services
+          displayName: RbacConfig
+          path: metricsExporter.rbacConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+        - description: disable https protecting the proxy endpoint
+          displayName: DisableHttps
+          path: metricsExporter.rbacConfig.disableHttps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+        - description: enable kube-rbac-proxy, disabled by default
+          displayName: Enable
+          path: metricsExporter.rbacConfig.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: kube-rbac-proxy image
+          displayName: Image
+          path: metricsExporter.rbacConfig.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: certificate secret to mount in kube-rbac container for TLS,
+            self signed certificates will be generated by default
+          displayName: Secret
+          path: metricsExporter.rbacConfig.secret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:secret
+        - description: Selector describes on which nodes to enable metrics exporter
+          displayName: Selector
+          path: metricsExporter.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+            by default
+          displayName: ServiceType
+          path: metricsExporter.serviceType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+        - description: tolerations for metrics exporter
+          displayName: Tolerations
+          path: metricsExporter.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for metrics exporter daemons
+          displayName: UpgradePolicy
+          path: metricsExporter.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: metricsExporter.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: metricsExporter.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: Selector describes on which nodes the GPU Operator should enable
+            the GPU device.
+          displayName: Selector
+          path: selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: test runner
+          displayName: TestRunner
+          path: testRunner
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:testRunner
+        - description: config map to customize the config for test runner, if not
+            specified default test config will be aplied
+          displayName: Secret
+          path: testRunner.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: enable test runner, disabled by default
+          displayName: Enable
+          path: testRunner.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: test runner image
+          displayName: Image
+          path: testRunner.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for test runner
+          displayName: ImagePullPolicy
+          path: testRunner.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: test runner image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: testRunner.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: captures logs location and export config for test runner logs
+          displayName: LogsLocation
+          path: testRunner.logsLocation
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsLocation
+        - description: host path to store test runner internal status db in order
+            to persist test running status
+          displayName: HostPath
+          path: testRunner.logsLocation.hostPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostPath
+        - description: LogsExportSecrets is a list of secrets that contain connectivity
+            info to multiple cloud providers
+          displayName: LogsExportSecrets
+          path: testRunner.logsLocation.logsExportSecrets
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsExportSecrets
+        - description: volume mount destination within test runner container
+          displayName: MountPath
+          path: testRunner.logsLocation.mountPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:mountPath
+        - description: Selector describes on which nodes to enable test runner
+          displayName: Selector
+          path: testRunner.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: tolerations for test runner
+          displayName: Tolerations
+          path: testRunner.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for test runner daemonset
+          displayName: UpgradePolicy
+          path: testRunner.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: testRunner.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: testRunner.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        statusDescriptors:
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: devicePlugin.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: devicePlugin.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: devicePlugin.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: driver.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: driver.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: driver.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: metricsExporter.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: metricsExporter.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: metricsExporter.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: NodeModuleStatus contains per node status of driver module
+            installation
+          displayName: NodeModuleStatus
+          path: nodeModuleStatus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+        version: v1alpha1
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+      For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+    displayName: amd-gpu-operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AMD
+    - GPU
+    - AI
+    - Deep Learning
+    - Hardware
+    - Driver
+    - Monitoring
+    links:
+    - name: AMD GPU Operator
+      url: https://github.com/ROCm/gpu-operator
+    maintainers:
+    - email: Yan.Sun3@amd.com
+      name: Yan Sun
+    - email: farshad.ghodsian@amd.com
+      name: Farshad Ghodsian
+    - email: shrey.ajmera@amd.com
+      name: Shrey Ajmera
+    maturity: stable
+    provider:
+      name: Advanced Micro Devices, Inc.
+relatedImages:
+- image: docker.io/rocm/device-metrics-exporter@sha256:d90e570acb1371b31cd3aa1d8cbda818846cf7a0b56f8ccec472826c6a2b9dfe
+  name: device-metrics-exporter-d90e570acb1371b31cd3aa1d8cbda818846cf7a0b56f8ccec472826c6a2b9dfe-annotation
+- image: docker.io/rocm/gpu-operator-utils@sha256:5792202b622c57c77458f9f195ef2086c259870d33798909ce1ff840af7d0d5d
+  name: gpu-operator-utils-5792202b622c57c77458f9f195ef2086c259870d33798909ce1ff840af7d0d5d-annotation
+- image: docker.io/rocm/gpu-operator@sha256:75acf0ce776264494317c3545f3069519dfd939eb4b06f1f0965312502bc5182
+  name: manager
+- image: docker.io/rocm/gpu-operator@sha256:75acf0ce776264494317c3545f3069519dfd939eb4b06f1f0965312502bc5182
+  name: gpu-operator-75acf0ce776264494317c3545f3069519dfd939eb4b06f1f0965312502bc5182-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:b970e87f3244de795f595a4f06efc90164c15ec72f8843240a56b6e5ea4c7390
+  name: k8s-device-plugin-b970e87f3244de795f595a4f06efc90164c15ec72f8843240a56b6e5ea4c7390-annotation
+- image: docker.io/rocm/k8s-node-labeller@sha256:a9a492fad3c922110d142a4ce20520d8c44586867c9175ea4cb1b849f5e42940
+  name: k8s-node-labeller-a9a492fad3c922110d142a4ce20520d8c44586867c9175ea4cb1b849f5e42940-annotation
+- image: docker.io/rocm/test-runner@sha256:6cbee00819b4f7285841d5b2a10a5bb46ed10640a697630dfb7dd92f41e8c539
+  name: device-test-runner-6cbee00819b4f7285841d5b2a10a5bb46ed10640a697630dfb7dd92f41e8c539-annotation
+- image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:4ff9f10f18113dc9c0e5473cab361c8fffe99800c660a3fcd50c50b896e2ca2f
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:77d65eeb41f7c688b1411c33ea9a61b880ac3f7d0d3a33319dbd2ee188430b32
+name: amd-gpu-operator.v1.3.1
+package: amd-gpu-operator
+properties:
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: DeviceConfig
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: amd-gpu-operator
+    version: 1.3.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "amd.com/v1alpha1",
+            "kind": "DeviceConfig",
+            "metadata": {
+              "name": "test-deviceconfig",
+              "namespace": "openshift-amd-gpu"
+            },
+            "spec": {
+              "devicePlugin": {
+                "devicePluginImage": "rocm/k8s-device-plugin:rhubi-latest",
+                "nodeLabellerImage": "rocm/k8s-node-labeller:rhubi-latest"
+              },
+              "driver": {
+                "enable": "true",
+                "version": "6.4.2"
+              },
+              "selector": {
+                "feature.node.kubernetes.io/amd-gpu": "true"
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning,Monitoring
+      containerImage: docker.io/rocm/gpu-operator@sha256:2a2adbaa18e2b7fda3940ffdbf688f2bfc509f84cdde8d34f50c7f71caaa18a3
+      createdAt: "2025-08-01T01:55:48Z"
+      description: |-
+        Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+        For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+      deviceConfigManagerImage: docker.io/rocm/device-config-manager@sha256:d2896271eacfc664ac7651425f46a85af4f4ef98d713988c2a4fee4a846548ee
+      devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:840c4ea1bf58df60ef3e80e3bf27bbf620a393854e42f58b2224b288767e3dd4
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:6c946c6ca10d5c0f40e67b5759759f12d51c45e3b934cb1af912821d5fd76e6e
+      nodelabellerImage: docker.io/rocm/k8s-node-labeller@sha256:75f916c5a407e40e9ffdd26cdfc65b7da855710568937e740a969094e2991065
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-amd-gpu
+      operators.openshift.io/valid-subscription: '[]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ROCm/gpu-operator
+      support: Advanced Micro Devices, Inc.
+      testRunnerImage: docker.io/rocm/test-runner@sha256:98e698263b4df26959341b14b3ddded9df51e504e7c6819d5c7c56c434855e9d
+      utilsContainerImage: docker.io/rocm/gpu-operator-utils@sha256:9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DeviceConfig describes how to enable AMD GPU device
+        displayName: DeviceConfig
+        kind: DeviceConfig
+        name: deviceconfigs.amd.com
+        resources:
+        - kind: Daemonset
+          name: apps
+          version: v1
+        - kind: services
+          name: core
+          version: v1
+        - kind: Module
+          name: modules.kmm.sigs.x-k8s.io
+          version: v1beta1
+        specDescriptors:
+        - description: common config
+          displayName: CommonConfig
+          path: commonConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:commonConfig
+        - description: InitContainerImage is being used for the operands pods, i.e.
+            metrics exporter, test runner, device plugin and node labeller
+          displayName: InitContainerImage
+          path: commonConfig.initContainerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:initContainerImage
+        - description: UtilsContainer contains parameters to configure operator's
+            utils container
+          displayName: UtilsContainer
+          path: commonConfig.utilsContainer
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:utilsContainer
+        - description: Image is the image of utils container
+          displayName: Image
+          path: commonConfig.utilsContainer.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for utils container
+          displayName: ImagePullPolicy
+          path: commonConfig.utilsContainer.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: secret used for pull utils container image
+          displayName: ImageRegistrySecret
+          path: commonConfig.utilsContainer.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: config manager
+          displayName: ConfigManager
+          path: configManager
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManager
+        - description: config map to customize the config for config manager, if not
+            specified default config will be applied
+          displayName: Config
+          path: configManager.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: tolerations for the device config manager DaemonSet
+          displayName: ConfigManagerTolerations
+          path: configManager.configManagerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManagerTolerations
+        - description: enable config manager, disabled by default
+          displayName: Enable
+          path: configManager.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: config manager image
+          displayName: Image
+          path: configManager.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for config manager
+          displayName: ImagePullPolicy
+          path: configManager.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: config manager image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: configManager.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: Selector describes on which nodes to enable config manager
+          displayName: Selector
+          path: configManager.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: upgrade policy for config manager daemonset
+          displayName: UpgradePolicy
+          path: configManager.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: configManager.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: configManager.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: device plugin
+          displayName: DevicePlugin
+          path: devicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+        - description: 'device plugin arguments is used to pass supported flags and
+            their values while starting device plugin daemonset supported flag values:
+            {"resource_naming_strategy": {"single", "mixed"}}'
+          displayName: DevicePluginArguments
+          path: devicePlugin.devicePluginArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginArguments
+        - description: device plugin image
+          displayName: DevicePluginImage
+          path: devicePlugin.devicePluginImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+        - description: image pull policy for device plugin
+          displayName: DevicePluginImagePullPolicy
+          path: devicePlugin.devicePluginImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:DevicePluginImagePullPolicy
+        - description: tolerations for the device plugin DaemonSet
+          displayName: DevicePluginTolerations
+          path: devicePlugin.devicePluginTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginTolerations
+        - description: enable or disable the node labeller
+          displayName: EnableNodeLabeller
+          path: devicePlugin.enableNodeLabeller
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+        - description: node labeller image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: devicePlugin.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: 'node labeller arguments is used to pass supported labels while
+            starting node labeller daemonset some flags are enabled by default as
+            they are applicable and bare minimum for all setups and are supported
+            in all versions of node labeller default flags: {"vram", "cu-count", "simd-count",
+            "device-id", "family", "product-name", "driver-version"} supported flags:
+            {"compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"}'
+          displayName: NodeLabellerArguments
+          path: devicePlugin.nodeLabellerArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerArguments
+        - description: node labeller image
+          displayName: NodeLabellerImage
+          path: devicePlugin.nodeLabellerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+        - description: image pull policy for node labeller
+          displayName: NodeLabellerImagePullPolicy
+          path: devicePlugin.nodeLabellerImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:NodeLabellerImagePullPolicy
+        - description: tolerations for the node labeller DaemonSet
+          displayName: NodeLabellerTolerations
+          path: devicePlugin.nodeLabellerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerTolerations
+        - description: upgrade policy for device plugin and node labeller daemons
+          displayName: UpgradePolicy
+          path: devicePlugin.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: devicePlugin.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: devicePlugin.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: driver
+          displayName: Driver
+          path: driver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driver
+        - description: radeon repo URL for fetching amdgpu installer if building driver
+            image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+            by default
+          displayName: AMDGPUInstallerRepoURL
+          path: driver.amdgpuInstallerRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+        - description: blacklist amdgpu drivers on the host. Node reboot is required
+            to apply the baclklist on the worker nodes. Not working for OpenShift
+            cluster. OpenShift users please use the Machine Config Operator (MCO)
+            resource to configure amdgpu blacklist. Example MCO resource is available
+            at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+          displayName: BlacklistDrivers
+          path: driver.blacklist
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+        - description: enable driver install. default value is true. disable is for
+            skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+            module
+          displayName: Enable
+          path: driver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: 'defines image that includes drivers and firmware blobs, don''t
+            include tag since it will be fully managed by operator for vanilla k8s
+            the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for
+            OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+            image tag will be in the format of <linux distro>-<release version>-<kernel
+            version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+            and ubuntu-22.04-5.15.0-94-generic-6.1.3 NOTE: Updating the driver image
+            repository is not supported. Please delete the existing DeviceConfig and
+            create a new one with the updated image repository'
+          displayName: Image
+          path: driver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image build configs
+          displayName: ImageBuild
+          path: driver.imageBuild
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageBuild
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageBuild.baseImageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageBuild.baseImageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: secrets used for pull/push images from/to private registry
+            specified in driversImage
+          displayName: ImageRegistrySecret
+          path: driver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: driver image registry TLS setting for the container image
+          displayName: ImageRegistryTLS
+          path: driver.imageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: image signing config to sign the driver image when building
+            driver image on the fly image signing is required for installing driver
+            on secure boot enabled system
+          displayName: ImageSign
+          path: driver.imageSign
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+        - description: ImageSignCertSecret the public key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignCertSecret
+          path: driver.imageSign.certSecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+        - description: ImageSignKeySecret the private key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignKeySecret
+          path: driver.imageSign.keySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+        - description: tolerations for kmm module object
+          displayName: Tolerations
+          path: driver.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: policy to upgrade the drivers
+          displayName: UpgradePolicy
+          path: driver.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: enable upgrade policy, disabled by default If disabled, user
+            has to manually upgrade all the nodes.
+          displayName: Enable
+          path: driver.upgradePolicy.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: MaxParallelUpgrades indicates how many nodes can be upgraded
+            in parallel 0 means no limit, all nodes will be upgraded in parallel
+          displayName: MaxParallelUpgrades
+          path: driver.upgradePolicy.maxParallelUpgrades
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelUpgrades
+        - description: 'MaxUnavailableNodes indicates maximum number of nodes that
+            can be in a failed upgrade state beyond which upgrades will stop to keep
+            cluster at a minimal healthy state Value can be an integer (ex: 2) which
+            would mean atmost 2 nodes can be in failed state after which new upgrades
+            will not start. Or it can be a percentage string(ex: "50%") from which
+            absolute number will be calculated and round up'
+          displayName: MaxUnavailableNodes
+          path: driver.upgradePolicy.maxUnavailableNodes
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailableNodes
+        - description: Node draining policy
+          displayName: NodeDrainPolicy
+          path: driver.upgradePolicy.nodeDrainPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+        - description: Pod Deletion policy. If both NodeDrainPolicy and PodDeletionPolicy
+            config is available, NodeDrainPolicy(if enabled) will take precedence.
+          displayName: PodDeletionPolicy
+          path: driver.upgradePolicy.podDeletionPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podDeletionPolicy
+        - description: reboot between driver upgrades, enabled by default, if enabled
+            spec.commonConfig.utilsContainer will be used to perform reboot on worker
+            nodes
+          displayName: RebootRequired
+          path: driver.upgradePolicy.rebootRequired
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rebootRequired
+        - description: 'version of the drivers source code, can be used as part of
+            image of dockerfile source image default value for different OS is: ubuntu:
+            6.1.3, coreOS: 6.2.2'
+          displayName: Version
+          path: driver.version
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:version
+        - description: metrics exporter
+          displayName: MetricsExporter
+          path: metricsExporter
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+        - description: optional configuration for metrics
+          displayName: Config
+          path: metricsExporter.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: Name of the configMap that defines the list of metrics default
+            list:[]
+          displayName: Name
+          path: metricsExporter.config.name
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:name
+        - description: enable metrics exporter, disabled by default
+          displayName: Enable
+          path: metricsExporter.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: metrics exporter image
+          displayName: Image
+          path: metricsExporter.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for metrics exporter
+          displayName: ImagePullPolicy
+          path: metricsExporter.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: metrics exporter image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: metricsExporter.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: NodePort is the external port for pulling metrics from outside
+            the cluster, in the range 30000-32767 (assigned automatically by default)
+          displayName: NodePort
+          path: metricsExporter.nodePort
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+        - description: Port is the internal port used for in-cluster and node access
+            to pull metrics from the metrics-exporter (default 5000).
+          displayName: Port
+          path: metricsExporter.port
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:port
+        - description: Prometheus configuration for metrics exporter
+          displayName: Prometheus
+          path: metricsExporter.prometheus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:prometheus
+        - description: ServiceMonitor configuration for Prometheus integration
+          displayName: ServiceMonitor
+          path: metricsExporter.prometheus.serviceMonitor
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceMonitor
+        - description: AttachMetadata defines if Prometheus should attach node metadata
+            to the target
+          displayName: AttachMetadata
+          path: metricsExporter.prometheus.serviceMonitor.attachMetadata
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:attachMetadata
+        - description: Optional Prometheus authorization configuration for accessing
+            the endpoint
+          displayName: Authorization
+          path: metricsExporter.prometheus.serviceMonitor.authorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:authorization
+        - description: 'Path to bearer token file to be used by Prometheus (e.g.,
+            service account token path) Deprecated: Use Authorization instead. This
+            field is kept for backward compatibility.'
+          displayName: BearerTokenFile
+          path: metricsExporter.prometheus.serviceMonitor.bearerTokenFile
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:bearerTokenFile
+        - description: Enable or disable ServiceMonitor creation (default false)
+          displayName: Enable
+          path: metricsExporter.prometheus.serviceMonitor.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: HonorLabels chooses the metric's labels on collisions with
+            target labels (default true)
+          displayName: HonorLabels
+          path: metricsExporter.prometheus.serviceMonitor.honorLabels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorLabels
+        - description: HonorTimestamps controls whether the scrape endpoints honor
+            timestamps (default false)
+          displayName: HonorTimestamps
+          path: metricsExporter.prometheus.serviceMonitor.honorTimestamps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorTimestamps
+        - description: 'How frequently to scrape metrics. Accepts values with time
+            unit suffix: "30s", "1m", "2h", "500ms"'
+          displayName: Interval
+          path: metricsExporter.prometheus.serviceMonitor.interval
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:interval
+        - description: 'Additional labels to add to the ServiceMonitor (default release:
+            prometheus)'
+          displayName: Labels
+          path: metricsExporter.prometheus.serviceMonitor.labels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:labels
+        - description: Relabeling rules applied to individual scraped metrics
+          displayName: MetricRelabelings
+          path: metricsExporter.prometheus.serviceMonitor.metricRelabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricRelabelings
+        - description: RelabelConfigs to apply to samples before ingestion
+          displayName: Relabelings
+          path: metricsExporter.prometheus.serviceMonitor.relabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:relabelings
+        - description: TLS settings used by Prometheus to connect to the metrics endpoint
+          displayName: TLSConfig
+          path: metricsExporter.prometheus.serviceMonitor.tlsConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tlsConfig
+        - description: optional kube-rbac-proxy config to provide rbac services
+          displayName: RbacConfig
+          path: metricsExporter.rbacConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+        - description: 'Reference to a configmap containing the client CA (key: ca.crt)
+            for mTLS client validation'
+          displayName: ClientCAConfigMap
+          path: metricsExporter.rbacConfig.clientCAConfigMap
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientCAConfigMap
+        - description: disable https protecting the proxy endpoint
+          displayName: DisableHttps
+          path: metricsExporter.rbacConfig.disableHttps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+        - description: enable kube-rbac-proxy, disabled by default
+          displayName: Enable
+          path: metricsExporter.rbacConfig.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: kube-rbac-proxy image
+          displayName: Image
+          path: metricsExporter.rbacConfig.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: certificate secret to mount in kube-rbac container for TLS,
+            self signed certificates will be generated by default
+          displayName: Secret
+          path: metricsExporter.rbacConfig.secret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:secret
+        - description: Optional static RBAC rules based on client certificate Common
+            Name (CN)
+          displayName: StaticAuthorization
+          path: metricsExporter.rbacConfig.staticAuthorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:staticAuthorization
+        - description: Expected CN (Common Name) from client cert (e.g., Prometheus
+            SA identity)
+          displayName: ClientName
+          path: metricsExporter.rbacConfig.staticAuthorization.clientName
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientName
+        - description: Enables static authorization using client certificate CN
+          displayName: Enable
+          path: metricsExporter.rbacConfig.staticAuthorization.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: Selector describes on which nodes to enable metrics exporter
+          displayName: Selector
+          path: metricsExporter.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+            by default
+          displayName: ServiceType
+          path: metricsExporter.serviceType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+        - description: tolerations for metrics exporter
+          displayName: Tolerations
+          path: metricsExporter.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for metrics exporter daemons
+          displayName: UpgradePolicy
+          path: metricsExporter.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: metricsExporter.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: metricsExporter.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: Selector describes on which nodes the GPU Operator should enable
+            the GPU device.
+          displayName: Selector
+          path: selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: test runner
+          displayName: TestRunner
+          path: testRunner
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:testRunner
+        - description: config map to customize the config for test runner, if not
+            specified default test config will be aplied
+          displayName: Secret
+          path: testRunner.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: enable test runner, disabled by default
+          displayName: Enable
+          path: testRunner.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: test runner image
+          displayName: Image
+          path: testRunner.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for test runner
+          displayName: ImagePullPolicy
+          path: testRunner.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: test runner image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: testRunner.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: captures logs location and export config for test runner logs
+          displayName: LogsLocation
+          path: testRunner.logsLocation
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsLocation
+        - description: host path to store test runner internal status db in order
+            to persist test running status
+          displayName: HostPath
+          path: testRunner.logsLocation.hostPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostPath
+        - description: LogsExportSecrets is a list of secrets that contain connectivity
+            info to multiple cloud providers
+          displayName: LogsExportSecrets
+          path: testRunner.logsLocation.logsExportSecrets
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsExportSecrets
+        - description: volume mount destination within test runner container
+          displayName: MountPath
+          path: testRunner.logsLocation.mountPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:mountPath
+        - description: Selector describes on which nodes to enable test runner
+          displayName: Selector
+          path: testRunner.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: tolerations for test runner
+          displayName: Tolerations
+          path: testRunner.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for test runner daemonset
+          displayName: UpgradePolicy
+          path: testRunner.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: testRunner.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: testRunner.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        statusDescriptors:
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: configManager.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: configManager.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: configManager.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: devicePlugin.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: devicePlugin.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: devicePlugin.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: driver.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: driver.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: driver.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: metricsExporter.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: metricsExporter.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: metricsExporter.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: NodeModuleStatus contains per node status of driver module
+            installation
+          displayName: NodeModuleStatus
+          path: nodeModuleStatus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+        version: v1alpha1
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+      For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+    displayName: amd-gpu-operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AMD
+    - GPU
+    - AI
+    - Deep Learning
+    - Hardware
+    - Driver
+    - Monitoring
+    links:
+    - name: AMD GPU Operator
+      url: https://github.com/ROCm/gpu-operator
+    maintainers:
+    - email: Yan.Sun3@amd.com
+      name: Yan Sun
+    - email: farshad.ghodsian@amd.com
+      name: Farshad Ghodsian
+    - email: shrey.ajmera@amd.com
+      name: Shrey Ajmera
+    maturity: stable
+    provider:
+      name: Advanced Micro Devices, Inc.
+relatedImages:
+- image: docker.io/rocm/device-config-manager@sha256:d2896271eacfc664ac7651425f46a85af4f4ef98d713988c2a4fee4a846548ee
+  name: device-config-manager-d2896271eacfc664ac7651425f46a85af4f4ef98d713988c2a4fee4a846548ee-annotation
+- image: docker.io/rocm/device-metrics-exporter@sha256:6c946c6ca10d5c0f40e67b5759759f12d51c45e3b934cb1af912821d5fd76e6e
+  name: device-metrics-exporter-6c946c6ca10d5c0f40e67b5759759f12d51c45e3b934cb1af912821d5fd76e6e-annotation
+- image: docker.io/rocm/gpu-operator-utils@sha256:9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287
+  name: gpu-operator-utils-9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287-annotation
+- image: docker.io/rocm/gpu-operator@sha256:2a2adbaa18e2b7fda3940ffdbf688f2bfc509f84cdde8d34f50c7f71caaa18a3
+  name: manager
+- image: docker.io/rocm/gpu-operator@sha256:2a2adbaa18e2b7fda3940ffdbf688f2bfc509f84cdde8d34f50c7f71caaa18a3
+  name: gpu-operator-2a2adbaa18e2b7fda3940ffdbf688f2bfc509f84cdde8d34f50c7f71caaa18a3-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:840c4ea1bf58df60ef3e80e3bf27bbf620a393854e42f58b2224b288767e3dd4
+  name: k8s-device-plugin-840c4ea1bf58df60ef3e80e3bf27bbf620a393854e42f58b2224b288767e3dd4
+    -annotation
+- image: docker.io/rocm/k8s-node-labeller@sha256:75f916c5a407e40e9ffdd26cdfc65b7da855710568937e740a969094e2991065
+  name: k8s-node-labeller-75f916c5a407e40e9ffdd26cdfc65b7da855710568937e740a969094e2991065-annotation
+- image: docker.io/rocm/test-runner@sha256:98e698263b4df26959341b14b3ddded9df51e504e7c6819d5c7c56c434855e9d
+  name: device-test-runner-98e698263b4df26959341b14b3ddded9df51e504e7c6819d5c7c56c434855e9d-annotation
+- image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:77d65eeb41f7c688b1411c33ea9a61b880ac3f7d0d3a33319dbd2ee188430b32
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:8a92a0d18a5ae6a837ca6590c2beb65d889cd744a098c22d3f01d2fffdc4dc57
+name: amd-gpu-operator.v1.3.2
+package: amd-gpu-operator
+properties:
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: DeviceConfig
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: amd-gpu-operator
+    version: 1.3.2
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "amd.com/v1alpha1",
+            "kind": "DeviceConfig",
+            "metadata": {
+              "name": "test-deviceconfig",
+              "namespace": "openshift-amd-gpu"
+            },
+            "spec": {
+              "devicePlugin": {
+                "devicePluginImage": "rocm/k8s-device-plugin:rhubi-latest",
+                "nodeLabellerImage": "rocm/k8s-node-labeller:rhubi-latest"
+              },
+              "driver": {
+                "enable": "true",
+                "version": "6.4.2"
+              },
+              "selector": {
+                "feature.node.kubernetes.io/amd-gpu": "true"
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning,Monitoring
+      containerImage: docker.io/rocm/gpu-operator@sha256:1583d4ec172d50d4416f4030eb85910ec54633b7e8e061d4bd79b14dbf98d28c
+      createdAt: "2025-08-01T01:55:48Z"
+      description: |-
+        Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+        For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+      deviceConfigManagerImage: docker.io/rocm/device-config-manager@sha256:d2896271eacfc664ac7651425f46a85af4f4ef98d713988c2a4fee4a846548ee
+      devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:840c4ea1bf58df60ef3e80e3bf27bbf620a393854e42f58b2224b288767e3dd4
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:6c946c6ca10d5c0f40e67b5759759f12d51c45e3b934cb1af912821d5fd76e6e
+      nodelabellerImage: docker.io/rocm/k8s-node-labeller@sha256:75f916c5a407e40e9ffdd26cdfc65b7da855710568937e740a969094e2991065
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-amd-gpu
+      operators.openshift.io/valid-subscription: '[]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ROCm/gpu-operator
+      support: Advanced Micro Devices, Inc.
+      testRunnerImage: docker.io/rocm/test-runner@sha256:98e698263b4df26959341b14b3ddded9df51e504e7c6819d5c7c56c434855e9d
+      utilsContainerImage: docker.io/rocm/gpu-operator-utils@sha256:9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DeviceConfig describes how to enable AMD GPU device
+        displayName: DeviceConfig
+        kind: DeviceConfig
+        name: deviceconfigs.amd.com
+        resources:
+        - kind: Daemonset
+          name: apps
+          version: v1
+        - kind: services
+          name: core
+          version: v1
+        - kind: Module
+          name: modules.kmm.sigs.x-k8s.io
+          version: v1beta1
+        specDescriptors:
+        - description: common config
+          displayName: CommonConfig
+          path: commonConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:commonConfig
+        - description: InitContainerImage is being used for the operands pods, i.e.
+            metrics exporter, test runner, device plugin and node labeller
+          displayName: InitContainerImage
+          path: commonConfig.initContainerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:initContainerImage
+        - description: UtilsContainer contains parameters to configure operator's
+            utils container
+          displayName: UtilsContainer
+          path: commonConfig.utilsContainer
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:utilsContainer
+        - description: Image is the image of utils container
+          displayName: Image
+          path: commonConfig.utilsContainer.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for utils container
+          displayName: ImagePullPolicy
+          path: commonConfig.utilsContainer.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: secret used for pull utils container image
+          displayName: ImageRegistrySecret
+          path: commonConfig.utilsContainer.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: config manager
+          displayName: ConfigManager
+          path: configManager
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManager
+        - description: config map to customize the config for config manager, if not
+            specified default config will be applied
+          displayName: Config
+          path: configManager.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: tolerations for the device config manager DaemonSet
+          displayName: ConfigManagerTolerations
+          path: configManager.configManagerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManagerTolerations
+        - description: enable config manager, disabled by default
+          displayName: Enable
+          path: configManager.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: config manager image
+          displayName: Image
+          path: configManager.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for config manager
+          displayName: ImagePullPolicy
+          path: configManager.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: config manager image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: configManager.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: Selector describes on which nodes to enable config manager
+          displayName: Selector
+          path: configManager.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: upgrade policy for config manager daemonset
+          displayName: UpgradePolicy
+          path: configManager.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: configManager.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: configManager.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: device plugin
+          displayName: DevicePlugin
+          path: devicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+        - description: 'device plugin arguments is used to pass supported flags and
+            their values while starting device plugin daemonset supported flag values:
+            {"resource_naming_strategy": {"single", "mixed"}}'
+          displayName: DevicePluginArguments
+          path: devicePlugin.devicePluginArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginArguments
+        - description: device plugin image
+          displayName: DevicePluginImage
+          path: devicePlugin.devicePluginImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+        - description: image pull policy for device plugin
+          displayName: DevicePluginImagePullPolicy
+          path: devicePlugin.devicePluginImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:DevicePluginImagePullPolicy
+        - description: tolerations for the device plugin DaemonSet
+          displayName: DevicePluginTolerations
+          path: devicePlugin.devicePluginTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginTolerations
+        - description: enable or disable the node labeller
+          displayName: EnableNodeLabeller
+          path: devicePlugin.enableNodeLabeller
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+        - description: node labeller image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: devicePlugin.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: 'node labeller arguments is used to pass supported labels while
+            starting node labeller daemonset some flags are enabled by default as
+            they are applicable and bare minimum for all setups and are supported
+            in all versions of node labeller default flags: {"vram", "cu-count", "simd-count",
+            "device-id", "family", "product-name", "driver-version"} supported flags:
+            {"compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"}'
+          displayName: NodeLabellerArguments
+          path: devicePlugin.nodeLabellerArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerArguments
+        - description: node labeller image
+          displayName: NodeLabellerImage
+          path: devicePlugin.nodeLabellerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+        - description: image pull policy for node labeller
+          displayName: NodeLabellerImagePullPolicy
+          path: devicePlugin.nodeLabellerImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:NodeLabellerImagePullPolicy
+        - description: tolerations for the node labeller DaemonSet
+          displayName: NodeLabellerTolerations
+          path: devicePlugin.nodeLabellerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerTolerations
+        - description: upgrade policy for device plugin and node labeller daemons
+          displayName: UpgradePolicy
+          path: devicePlugin.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: devicePlugin.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: devicePlugin.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: driver
+          displayName: Driver
+          path: driver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driver
+        - description: radeon repo URL for fetching amdgpu installer if building driver
+            image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+            by default
+          displayName: AMDGPUInstallerRepoURL
+          path: driver.amdgpuInstallerRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+        - description: blacklist amdgpu drivers on the host. Node reboot is required
+            to apply the baclklist on the worker nodes. Not working for OpenShift
+            cluster. OpenShift users please use the Machine Config Operator (MCO)
+            resource to configure amdgpu blacklist. Example MCO resource is available
+            at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+          displayName: BlacklistDrivers
+          path: driver.blacklist
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+        - description: enable driver install. default value is true. disable is for
+            skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+            module
+          displayName: Enable
+          path: driver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: 'defines image that includes drivers and firmware blobs, don''t
+            include tag since it will be fully managed by operator for vanilla k8s
+            the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for
+            OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+            image tag will be in the format of <linux distro>-<release version>-<kernel
+            version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+            and ubuntu-22.04-5.15.0-94-generic-6.1.3 NOTE: Updating the driver image
+            repository is not supported. Please delete the existing DeviceConfig and
+            create a new one with the updated image repository'
+          displayName: Image
+          path: driver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image build configs
+          displayName: ImageBuild
+          path: driver.imageBuild
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageBuild
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageBuild.baseImageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageBuild.baseImageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: secrets used for pull/push images from/to private registry
+            specified in driversImage
+          displayName: ImageRegistrySecret
+          path: driver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: driver image registry TLS setting for the container image
+          displayName: ImageRegistryTLS
+          path: driver.imageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: image signing config to sign the driver image when building
+            driver image on the fly image signing is required for installing driver
+            on secure boot enabled system
+          displayName: ImageSign
+          path: driver.imageSign
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+        - description: ImageSignCertSecret the public key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignCertSecret
+          path: driver.imageSign.certSecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+        - description: ImageSignKeySecret the private key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignKeySecret
+          path: driver.imageSign.keySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+        - description: tolerations for kmm module object
+          displayName: Tolerations
+          path: driver.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: policy to upgrade the drivers
+          displayName: UpgradePolicy
+          path: driver.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: enable upgrade policy, disabled by default If disabled, user
+            has to manually upgrade all the nodes.
+          displayName: Enable
+          path: driver.upgradePolicy.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: MaxParallelUpgrades indicates how many nodes can be upgraded
+            in parallel 0 means no limit, all nodes will be upgraded in parallel
+          displayName: MaxParallelUpgrades
+          path: driver.upgradePolicy.maxParallelUpgrades
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelUpgrades
+        - description: 'MaxUnavailableNodes indicates maximum number of nodes that
+            can be in a failed upgrade state beyond which upgrades will stop to keep
+            cluster at a minimal healthy state Value can be an integer (ex: 2) which
+            would mean atmost 2 nodes can be in failed state after which new upgrades
+            will not start. Or it can be a percentage string(ex: "50%") from which
+            absolute number will be calculated and round up'
+          displayName: MaxUnavailableNodes
+          path: driver.upgradePolicy.maxUnavailableNodes
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailableNodes
+        - description: Node draining policy
+          displayName: NodeDrainPolicy
+          path: driver.upgradePolicy.nodeDrainPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+        - description: Pod Deletion policy. If both NodeDrainPolicy and PodDeletionPolicy
+            config is available, NodeDrainPolicy(if enabled) will take precedence.
+          displayName: PodDeletionPolicy
+          path: driver.upgradePolicy.podDeletionPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podDeletionPolicy
+        - description: reboot between driver upgrades, enabled by default, if enabled
+            spec.commonConfig.utilsContainer will be used to perform reboot on worker
+            nodes
+          displayName: RebootRequired
+          path: driver.upgradePolicy.rebootRequired
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rebootRequired
+        - description: 'version of the drivers source code, can be used as part of
+            image of dockerfile source image default value for different OS is: ubuntu:
+            6.1.3, coreOS: 6.2.2'
+          displayName: Version
+          path: driver.version
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:version
+        - description: metrics exporter
+          displayName: MetricsExporter
+          path: metricsExporter
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+        - description: optional configuration for metrics
+          displayName: Config
+          path: metricsExporter.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: Name of the configMap that defines the list of metrics default
+            list:[]
+          displayName: Name
+          path: metricsExporter.config.name
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:name
+        - description: enable metrics exporter, disabled by default
+          displayName: Enable
+          path: metricsExporter.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: metrics exporter image
+          displayName: Image
+          path: metricsExporter.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for metrics exporter
+          displayName: ImagePullPolicy
+          path: metricsExporter.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: metrics exporter image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: metricsExporter.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: NodePort is the external port for pulling metrics from outside
+            the cluster, in the range 30000-32767 (assigned automatically by default)
+          displayName: NodePort
+          path: metricsExporter.nodePort
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+        - description: Port is the internal port used for in-cluster and node access
+            to pull metrics from the metrics-exporter (default 5000).
+          displayName: Port
+          path: metricsExporter.port
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:port
+        - description: Prometheus configuration for metrics exporter
+          displayName: Prometheus
+          path: metricsExporter.prometheus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:prometheus
+        - description: ServiceMonitor configuration for Prometheus integration
+          displayName: ServiceMonitor
+          path: metricsExporter.prometheus.serviceMonitor
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceMonitor
+        - description: AttachMetadata defines if Prometheus should attach node metadata
+            to the target
+          displayName: AttachMetadata
+          path: metricsExporter.prometheus.serviceMonitor.attachMetadata
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:attachMetadata
+        - description: Optional Prometheus authorization configuration for accessing
+            the endpoint
+          displayName: Authorization
+          path: metricsExporter.prometheus.serviceMonitor.authorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:authorization
+        - description: 'Path to bearer token file to be used by Prometheus (e.g.,
+            service account token path) Deprecated: Use Authorization instead. This
+            field is kept for backward compatibility.'
+          displayName: BearerTokenFile
+          path: metricsExporter.prometheus.serviceMonitor.bearerTokenFile
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:bearerTokenFile
+        - description: Enable or disable ServiceMonitor creation (default false)
+          displayName: Enable
+          path: metricsExporter.prometheus.serviceMonitor.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: HonorLabels chooses the metric's labels on collisions with
+            target labels (default true)
+          displayName: HonorLabels
+          path: metricsExporter.prometheus.serviceMonitor.honorLabels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorLabels
+        - description: HonorTimestamps controls whether the scrape endpoints honor
+            timestamps (default false)
+          displayName: HonorTimestamps
+          path: metricsExporter.prometheus.serviceMonitor.honorTimestamps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorTimestamps
+        - description: 'How frequently to scrape metrics. Accepts values with time
+            unit suffix: "30s", "1m", "2h", "500ms"'
+          displayName: Interval
+          path: metricsExporter.prometheus.serviceMonitor.interval
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:interval
+        - description: 'Additional labels to add to the ServiceMonitor (default release:
+            prometheus)'
+          displayName: Labels
+          path: metricsExporter.prometheus.serviceMonitor.labels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:labels
+        - description: Relabeling rules applied to individual scraped metrics
+          displayName: MetricRelabelings
+          path: metricsExporter.prometheus.serviceMonitor.metricRelabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricRelabelings
+        - description: RelabelConfigs to apply to samples before ingestion
+          displayName: Relabelings
+          path: metricsExporter.prometheus.serviceMonitor.relabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:relabelings
+        - description: TLS settings used by Prometheus to connect to the metrics endpoint
+          displayName: TLSConfig
+          path: metricsExporter.prometheus.serviceMonitor.tlsConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tlsConfig
+        - description: optional kube-rbac-proxy config to provide rbac services
+          displayName: RbacConfig
+          path: metricsExporter.rbacConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+        - description: 'Reference to a configmap containing the client CA (key: ca.crt)
+            for mTLS client validation'
+          displayName: ClientCAConfigMap
+          path: metricsExporter.rbacConfig.clientCAConfigMap
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientCAConfigMap
+        - description: disable https protecting the proxy endpoint
+          displayName: DisableHttps
+          path: metricsExporter.rbacConfig.disableHttps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+        - description: enable kube-rbac-proxy, disabled by default
+          displayName: Enable
+          path: metricsExporter.rbacConfig.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: kube-rbac-proxy image
+          displayName: Image
+          path: metricsExporter.rbacConfig.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: certificate secret to mount in kube-rbac container for TLS,
+            self signed certificates will be generated by default
+          displayName: Secret
+          path: metricsExporter.rbacConfig.secret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:secret
+        - description: Optional static RBAC rules based on client certificate Common
+            Name (CN)
+          displayName: StaticAuthorization
+          path: metricsExporter.rbacConfig.staticAuthorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:staticAuthorization
+        - description: Expected CN (Common Name) from client cert (e.g., Prometheus
+            SA identity)
+          displayName: ClientName
+          path: metricsExporter.rbacConfig.staticAuthorization.clientName
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientName
+        - description: Enables static authorization using client certificate CN
+          displayName: Enable
+          path: metricsExporter.rbacConfig.staticAuthorization.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: Selector describes on which nodes to enable metrics exporter
+          displayName: Selector
+          path: metricsExporter.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+            by default
+          displayName: ServiceType
+          path: metricsExporter.serviceType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+        - description: tolerations for metrics exporter
+          displayName: Tolerations
+          path: metricsExporter.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for metrics exporter daemons
+          displayName: UpgradePolicy
+          path: metricsExporter.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: metricsExporter.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: metricsExporter.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: Selector describes on which nodes the GPU Operator should enable
+            the GPU device.
+          displayName: Selector
+          path: selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: test runner
+          displayName: TestRunner
+          path: testRunner
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:testRunner
+        - description: config map to customize the config for test runner, if not
+            specified default test config will be aplied
+          displayName: Secret
+          path: testRunner.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: enable test runner, disabled by default
+          displayName: Enable
+          path: testRunner.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: test runner image
+          displayName: Image
+          path: testRunner.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for test runner
+          displayName: ImagePullPolicy
+          path: testRunner.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: test runner image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: testRunner.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: captures logs location and export config for test runner logs
+          displayName: LogsLocation
+          path: testRunner.logsLocation
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsLocation
+        - description: host path to store test runner internal status db in order
+            to persist test running status
+          displayName: HostPath
+          path: testRunner.logsLocation.hostPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostPath
+        - description: LogsExportSecrets is a list of secrets that contain connectivity
+            info to multiple cloud providers
+          displayName: LogsExportSecrets
+          path: testRunner.logsLocation.logsExportSecrets
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsExportSecrets
+        - description: volume mount destination within test runner container
+          displayName: MountPath
+          path: testRunner.logsLocation.mountPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:mountPath
+        - description: Selector describes on which nodes to enable test runner
+          displayName: Selector
+          path: testRunner.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: tolerations for test runner
+          displayName: Tolerations
+          path: testRunner.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for test runner daemonset
+          displayName: UpgradePolicy
+          path: testRunner.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: testRunner.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: testRunner.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        statusDescriptors:
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: configManager.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: configManager.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: configManager.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: devicePlugin.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: devicePlugin.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: devicePlugin.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: driver.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: driver.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: driver.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: metricsExporter.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: metricsExporter.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: metricsExporter.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: NodeModuleStatus contains per node status of driver module
+            installation
+          displayName: NodeModuleStatus
+          path: nodeModuleStatus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+        version: v1alpha1
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+      For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+    displayName: amd-gpu-operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AMD
+    - GPU
+    - AI
+    - Deep Learning
+    - Hardware
+    - Driver
+    - Monitoring
+    links:
+    - name: AMD GPU Operator
+      url: https://github.com/ROCm/gpu-operator
+    maintainers:
+    - email: Yan.Sun3@amd.com
+      name: Yan Sun
+    - email: farshad.ghodsian@amd.com
+      name: Farshad Ghodsian
+    - email: shrey.ajmera@amd.com
+      name: Shrey Ajmera
+    maturity: stable
+    provider:
+      name: Advanced Micro Devices, Inc.
+relatedImages:
+- image: docker.io/rocm/device-config-manager@sha256:d2896271eacfc664ac7651425f46a85af4f4ef98d713988c2a4fee4a846548ee
+  name: device-config-manager-d2896271eacfc664ac7651425f46a85af4f4ef98d713988c2a4fee4a846548ee-annotation
+- image: docker.io/rocm/device-metrics-exporter@sha256:6c946c6ca10d5c0f40e67b5759759f12d51c45e3b934cb1af912821d5fd76e6e
+  name: device-metrics-exporter-6c946c6ca10d5c0f40e67b5759759f12d51c45e3b934cb1af912821d5fd76e6e-annotation
+- image: docker.io/rocm/gpu-operator-utils@sha256:9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287
+  name: gpu-operator-utils-9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287-annotation
+- image: docker.io/rocm/gpu-operator@sha256:1583d4ec172d50d4416f4030eb85910ec54633b7e8e061d4bd79b14dbf98d28c
+  name: manager
+- image: docker.io/rocm/gpu-operator@sha256:1583d4ec172d50d4416f4030eb85910ec54633b7e8e061d4bd79b14dbf98d28c
+  name: gpu-operator-1583d4ec172d50d4416f4030eb85910ec54633b7e8e061d4bd79b14dbf98d28c-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:840c4ea1bf58df60ef3e80e3bf27bbf620a393854e42f58b2224b288767e3dd4
+  name: k8s-device-plugin-840c4ea1bf58df60ef3e80e3bf27bbf620a393854e42f58b2224b288767e3dd4
+    -annotation
+- image: docker.io/rocm/k8s-node-labeller@sha256:75f916c5a407e40e9ffdd26cdfc65b7da855710568937e740a969094e2991065
+  name: k8s-node-labeller-75f916c5a407e40e9ffdd26cdfc65b7da855710568937e740a969094e2991065-annotation
+- image: docker.io/rocm/test-runner@sha256:98e698263b4df26959341b14b3ddded9df51e504e7c6819d5c7c56c434855e9d
+  name: device-test-runner-98e698263b4df26959341b14b3ddded9df51e504e7c6819d5c7c56c434855e9d-annotation
+- image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:8a92a0d18a5ae6a837ca6590c2beb65d889cd744a098c22d3f01d2fffdc4dc57
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:4918beef3a778e8e6bb835240f356002a8b41e40ba011112ca360faa88fe57f4
+name: amd-gpu-operator.v1.4.1
+package: amd-gpu-operator
+properties:
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: DeviceConfig
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: amd-gpu-operator
+    version: 1.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "amd.com/v1alpha1",
+            "kind": "DeviceConfig",
+            "metadata": {
+              "name": "test-deviceconfig",
+              "namespace": "openshift-amd-gpu"
+            },
+            "spec": {
+              "devicePlugin": {
+                "devicePluginImage": "rocm/k8s-device-plugin:rhubi-latest",
+                "nodeLabellerImage": "rocm/k8s-node-labeller:rhubi-latest"
+              },
+              "driver": {
+                "enable": "true",
+                "version": "7.0"
+              },
+              "selector": {
+                "feature.node.kubernetes.io/amd-gpu": "true"
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning,Monitoring
+      containerImage: docker.io/rocm/gpu-operator@sha256:619f6d1ddef671df2704e87a8cca82ee4c1b07d645f05c8d5cb2eb9c6604a270
+      createdAt: "2025-10-31T08:47:42Z"
+      description: |-
+        Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+        For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+      deviceConfigManagerImage: docker.io/rocm/device-config-manager@sha256:76363ac0cc42617f1723e14eaeb11434d4d1fa2d4d39d67bc49b3525c599c0ba
+      devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:6976ee40f7fcba3759bbbf5a36e3f12daaf306836606df18592b1b67f7f651d7
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:3872ca3534c6679159ffbef504a02e937eb3e11b215c18e649456c0d0ca9bc8d
+      nodelabellerImage: docker.io/rocm/k8s-node-labeller@sha256:8206d27891606ebc2f234fed6fe45d181cb31c3ff694a0ff9c3f02d62c280eee
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-amd-gpu
+      operators.openshift.io/valid-subscription: '[]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ROCm/gpu-operator
+      support: Advanced Micro Devices, Inc.
+      testRunnerImage: docker.io/rocm/test-runner@sha256:529a13953979e7fbd4ff9333735bd2268a81eaa4fdf8f187698cce7d8e720beb
+      utilsContainerImage: docker.io/rocm/gpu-operator-utils@sha256:9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DeviceConfig describes how to enable AMD GPU device
+        displayName: DeviceConfig
+        kind: DeviceConfig
+        name: deviceconfigs.amd.com
+        resources:
+        - kind: Daemonset
+          name: apps
+          version: v1
+        - kind: Pod
+          name: core
+          version: v1
+        - kind: services
+          name: core
+          version: v1
+        - kind: Module
+          name: modules.kmm.sigs.x-k8s.io
+          version: v1beta1
+        specDescriptors:
+        - description: common config
+          displayName: CommonConfig
+          path: commonConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:commonConfig
+        - description: InitContainerImage is being used for the operands pods, i.e.
+            metrics exporter, test runner, device plugin, device config manager and
+            node labeller
+          displayName: InitContainerImage
+          path: commonConfig.initContainerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:initContainerImage
+        - description: UtilsContainer contains parameters to configure operator's
+            utils container
+          displayName: UtilsContainer
+          path: commonConfig.utilsContainer
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:utilsContainer
+        - description: Image is the image of utils container
+          displayName: Image
+          path: commonConfig.utilsContainer.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for utils container
+          displayName: ImagePullPolicy
+          path: commonConfig.utilsContainer.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: secret used for pull utils container image
+          displayName: ImageRegistrySecret
+          path: commonConfig.utilsContainer.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: config manager
+          displayName: ConfigManager
+          path: configManager
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManager
+        - description: config map to customize the config for config manager, if not
+            specified default config will be applied
+          displayName: Config
+          path: configManager.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: tolerations for the device config manager DaemonSet
+          displayName: ConfigManagerTolerations
+          path: configManager.configManagerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManagerTolerations
+        - description: enable config manager, disabled by default
+          displayName: Enable
+          path: configManager.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: config manager image
+          displayName: Image
+          path: configManager.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for config manager
+          displayName: ImagePullPolicy
+          path: configManager.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: config manager image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: configManager.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: Selector describes on which nodes to enable config manager
+          displayName: Selector
+          path: configManager.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: upgrade policy for config manager daemonset
+          displayName: UpgradePolicy
+          path: configManager.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: configManager.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: configManager.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: device plugin
+          displayName: DevicePlugin
+          path: devicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+        - description: 'device plugin arguments is used to pass supported flags and
+            their values while starting device plugin daemonset supported flag values:
+            {"resource_naming_strategy": {"single", "mixed"}}'
+          displayName: DevicePluginArguments
+          path: devicePlugin.devicePluginArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginArguments
+        - description: device plugin image
+          displayName: DevicePluginImage
+          path: devicePlugin.devicePluginImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+        - description: image pull policy for device plugin
+          displayName: DevicePluginImagePullPolicy
+          path: devicePlugin.devicePluginImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:DevicePluginImagePullPolicy
+        - description: tolerations for the device plugin DaemonSet
+          displayName: DevicePluginTolerations
+          path: devicePlugin.devicePluginTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginTolerations
+        - description: enable or disable the node labeller
+          displayName: EnableNodeLabeller
+          path: devicePlugin.enableNodeLabeller
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+        - description: node labeller image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: devicePlugin.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: 'node labeller arguments is used to pass supported labels while
+            starting node labeller daemonset some flags are enabled by default as
+            they are applicable and bare minimum for all setups and are supported
+            in all versions of node labeller default flags: {"vram", "cu-count", "simd-count",
+            "device-id", "family", "product-name", "driver-version"} supported flags:
+            {"compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"}'
+          displayName: NodeLabellerArguments
+          path: devicePlugin.nodeLabellerArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerArguments
+        - description: node labeller image
+          displayName: NodeLabellerImage
+          path: devicePlugin.nodeLabellerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+        - description: image pull policy for node labeller
+          displayName: NodeLabellerImagePullPolicy
+          path: devicePlugin.nodeLabellerImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:NodeLabellerImagePullPolicy
+        - description: tolerations for the node labeller DaemonSet
+          displayName: NodeLabellerTolerations
+          path: devicePlugin.nodeLabellerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerTolerations
+        - description: upgrade policy for device plugin and node labeller daemons
+          displayName: UpgradePolicy
+          path: devicePlugin.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: devicePlugin.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: devicePlugin.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: driver
+          displayName: Driver
+          path: driver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driver
+        - description: radeon repo URL for fetching amdgpu installer if building driver
+            image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+            by default
+          displayName: AMDGPUInstallerRepoURL
+          path: driver.amdgpuInstallerRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+        - description: blacklist amdgpu drivers on the host. Node reboot is required
+            to apply the baclklist on the worker nodes. Not working for OpenShift
+            cluster. OpenShift users please use the Machine Config Operator (MCO)
+            resource to configure amdgpu blacklist. Example MCO resource is available
+            at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+          displayName: BlacklistDrivers
+          path: driver.blacklist
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+        - description: 'specify the type of driver (container/vf-passthrough/pf-passthrough)
+            to install on the worker node. default value is container. container:
+            normal amdgpu-dkms driver for Bare Metal GPU nodes or guest VM. vf-passthrough:
+            MxGPU GIM driver on the host machine to generate VF, then mount VF to
+            vfio-pci pf-passthrough: directly mount PF device to vfio-pci'
+          displayName: DriverType
+          path: driver.driverType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driverType
+        - description: enable driver install. default value is true. disable is for
+            skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+            module
+          displayName: Enable
+          path: driver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: 'defines image that includes drivers and firmware blobs, don''t
+            include tag since it will be fully managed by operator for vanilla k8s
+            the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for
+            OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+            image tag will be in the format of <linux distro>-<release version>-<kernel
+            version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+            and ubuntu-22.04-5.15.0-94-generic-6.1.3 NOTE: Updating the driver image
+            repository is not supported. Please delete the existing DeviceConfig and
+            create a new one with the updated image repository'
+          displayName: Image
+          path: driver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image build configs
+          displayName: ImageBuild
+          path: driver.imageBuild
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageBuild
+        - description: 'image registry to fetch base image for building driver image,
+            default value is docker.io, the builder will search for corresponding
+            OS base image from given registry e.g. if your worker node is using Ubuntu
+            22.04, by default the base image would be docker.io/ubuntu:22.04 Use spec.driver.imageRegistrySecret
+            for authentication with private registries. NOTE: this field won''t apply
+            for OpenShift since OpenShift is using its own DriverToolKit image to
+            build driver image'
+          displayName: BaseImageRegistry
+          path: driver.imageBuild.baseImageRegistry
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:baseImageRegistry
+        - description: TLS settings for fetching base image this field will be applied
+            to SourceImageRepo as well
+          displayName: BaseImageRegistryTLS
+          path: driver.imageBuild.baseImageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:baseImageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageBuild.baseImageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageBuild.baseImageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: 'SourceImageRepo specifies the image repository for the driver
+            source code (OpenShift only). Used when spec.driver.useSourceImage is
+            true. The operator automatically determines the image tag based on cluster
+            RHEL version and spec.driver.version (format: coreos-<rhel>-<driver version>).
+            Default: docker.io/rocm/amdgpu-driver Use spec.driver.imageRegistrySecret
+            for authentication with private registries.'
+          displayName: SourceImageRepo
+          path: driver.imageBuild.sourceImageRepo
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:sourceImageRepo
+        - description: secrets used for pull/push images from/to private registry
+            specified in driversImage
+          displayName: ImageRegistrySecret
+          path: driver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: driver image registry TLS setting for the container image
+          displayName: ImageRegistryTLS
+          path: driver.imageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: image signing config to sign the driver image when building
+            driver image on the fly image signing is required for installing driver
+            on secure boot enabled system
+          displayName: ImageSign
+          path: driver.imageSign
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+        - description: ImageSignCertSecret the public key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignCertSecret
+          path: driver.imageSign.certSecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+        - description: ImageSignKeySecret the private key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignKeySecret
+          path: driver.imageSign.keySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+        - description: advanced arguments, parameters and more configs to manage tne
+            driver
+          displayName: KernelModuleConfig
+          path: driver.kernelModuleConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:kernelModuleConfig
+        - description: LoadArg are the arguments when modprobe is executed to load
+            the kernel module. The command will be `modprobe ${Args} module_name`.
+          displayName: LoadArg
+          path: driver.kernelModuleConfig.loadArgs
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:loadArg
+        - description: Parameters is being used for modprobe commands. The command
+            will be `modprobe ${Args} module_name ${Parameters}`.
+          displayName: Parameters
+          path: driver.kernelModuleConfig.parameters
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:parameters
+        - description: UnloadArg are the arguments when modprobe is executed to unload
+            the kernel module. The command will be `modprobe -r ${Args} module_name`.
+          displayName: UnloadArg
+          path: driver.kernelModuleConfig.unloadArgs
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:unloadArg
+        - description: tolerations for kmm module object
+          displayName: Tolerations
+          path: driver.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: policy to upgrade the drivers
+          displayName: UpgradePolicy
+          path: driver.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: enable upgrade policy, disabled by default If disabled, user
+            has to manually upgrade all the nodes.
+          displayName: Enable
+          path: driver.upgradePolicy.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: MaxParallelUpgrades indicates how many nodes can be upgraded
+            in parallel 0 means no limit, all nodes will be upgraded in parallel
+          displayName: MaxParallelUpgrades
+          path: driver.upgradePolicy.maxParallelUpgrades
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelUpgrades
+        - description: 'MaxUnavailableNodes indicates maximum number of nodes that
+            can be in a failed upgrade state beyond which upgrades will stop to keep
+            cluster at a minimal healthy state Value can be an integer (ex: 2) which
+            would mean atmost 2 nodes can be in failed state after which new upgrades
+            will not start. Or it can be a percentage string(ex: "50%") from which
+            absolute number will be calculated and round up'
+          displayName: MaxUnavailableNodes
+          path: driver.upgradePolicy.maxUnavailableNodes
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailableNodes
+        - description: Node draining policy
+          displayName: NodeDrainPolicy
+          path: driver.upgradePolicy.nodeDrainPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+        - description: Pod Deletion policy. If both NodeDrainPolicy and PodDeletionPolicy
+            config is available, NodeDrainPolicy(if enabled) will take precedence.
+          displayName: PodDeletionPolicy
+          path: driver.upgradePolicy.podDeletionPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podDeletionPolicy
+        - description: reboot between driver upgrades, enabled by default, if enabled
+            spec.commonConfig.utilsContainer will be used to perform reboot on worker
+            nodes
+          displayName: RebootRequired
+          path: driver.upgradePolicy.rebootRequired
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rebootRequired
+        - description: 'NOTE: currently only for OpenShift cluster set to true to
+            use source image to build driver image on the fly otherwise use installer
+            debian/rpm packages from radeon repo to build driver image'
+          displayName: UseSourceImage
+          path: driver.useSourceImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:useSourceImage
+        - description: 'version of the drivers source code, can be used as part of
+            image of dockerfile source image default value for different OS is: ubuntu:
+            6.1.3, coreOS: 6.2.2'
+          displayName: Version
+          path: driver.version
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:version
+        - description: vfio config specify the specific configs for binding PCI devices
+            to vfio-pci kernel module, applies for driver type vf-passthrough and
+            pf-passthrough
+          displayName: VFIOConfig
+          path: driver.vfioConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:vfioConfig
+        - description: metrics exporter
+          displayName: MetricsExporter
+          path: metricsExporter
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+        - description: optional configuration for metrics
+          displayName: Config
+          path: metricsExporter.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: Name of the configMap that defines the list of metrics default
+            list:[]
+          displayName: Name
+          path: metricsExporter.config.name
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:name
+        - description: enable metrics exporter, disabled by default
+          displayName: Enable
+          path: metricsExporter.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: metrics exporter image
+          displayName: Image
+          path: metricsExporter.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for metrics exporter
+          displayName: ImagePullPolicy
+          path: metricsExporter.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: metrics exporter image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: metricsExporter.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: NodePort is the external port for pulling metrics from outside
+            the cluster, in the range 30000-32767 (assigned automatically by default)
+          displayName: NodePort
+          path: metricsExporter.nodePort
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+        - description: Set PodAnnotations for metrics exporter
+          displayName: PodAnnotations
+          path: metricsExporter.podAnnotations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podAnnotations
+        - description: Set the host path for pod-resource kubelet.socket, vanila kubernetes
+            path is /var/lib/kubelet/pod-resources microk8s path is /var/snap/microk8s/common/var/lib/kubelet/pod-resources/
+            path is an absolute unix path that allows a trailing slash
+          displayName: PodResourceAPISocketPath
+          path: metricsExporter.podResourceAPISocketPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podResourceAPISocketPath
+        - description: Port is the internal port used for in-cluster and node access
+            to pull metrics from the metrics-exporter (default 5000).
+          displayName: Port
+          path: metricsExporter.port
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:port
+        - description: Prometheus configuration for metrics exporter
+          displayName: Prometheus
+          path: metricsExporter.prometheus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:prometheus
+        - description: ServiceMonitor configuration for Prometheus integration
+          displayName: ServiceMonitor
+          path: metricsExporter.prometheus.serviceMonitor
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceMonitor
+        - description: AttachMetadata defines if Prometheus should attach node metadata
+            to the target
+          displayName: AttachMetadata
+          path: metricsExporter.prometheus.serviceMonitor.attachMetadata
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:attachMetadata
+        - description: Optional Prometheus authorization configuration for accessing
+            the endpoint
+          displayName: Authorization
+          path: metricsExporter.prometheus.serviceMonitor.authorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:authorization
+        - description: 'Path to bearer token file to be used by Prometheus (e.g.,
+            service account token path) Deprecated: Use Authorization instead. This
+            field is kept for backward compatibility.'
+          displayName: BearerTokenFile
+          path: metricsExporter.prometheus.serviceMonitor.bearerTokenFile
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:bearerTokenFile
+        - description: Enable or disable ServiceMonitor creation (default false)
+          displayName: Enable
+          path: metricsExporter.prometheus.serviceMonitor.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: HonorLabels chooses the metric's labels on collisions with
+            target labels (default true)
+          displayName: HonorLabels
+          path: metricsExporter.prometheus.serviceMonitor.honorLabels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorLabels
+        - description: HonorTimestamps controls whether the scrape endpoints honor
+            timestamps (default false)
+          displayName: HonorTimestamps
+          path: metricsExporter.prometheus.serviceMonitor.honorTimestamps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorTimestamps
+        - description: 'How frequently to scrape metrics. Accepts values with time
+            unit suffix: "30s", "1m", "2h", "500ms"'
+          displayName: Interval
+          path: metricsExporter.prometheus.serviceMonitor.interval
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:interval
+        - description: 'Additional labels to add to the ServiceMonitor (default release:
+            prometheus)'
+          displayName: Labels
+          path: metricsExporter.prometheus.serviceMonitor.labels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:labels
+        - description: Relabeling rules applied to individual scraped metrics
+          displayName: MetricRelabelings
+          path: metricsExporter.prometheus.serviceMonitor.metricRelabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricRelabelings
+        - description: RelabelConfigs to apply to samples before ingestion
+          displayName: Relabelings
+          path: metricsExporter.prometheus.serviceMonitor.relabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:relabelings
+        - description: TLS settings used by Prometheus to connect to the metrics endpoint
+          displayName: TLSConfig
+          path: metricsExporter.prometheus.serviceMonitor.tlsConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tlsConfig
+        - description: optional kube-rbac-proxy config to provide rbac services
+          displayName: RbacConfig
+          path: metricsExporter.rbacConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+        - description: 'Reference to a configmap containing the client CA (key: ca.crt)
+            for mTLS client validation'
+          displayName: ClientCAConfigMap
+          path: metricsExporter.rbacConfig.clientCAConfigMap
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientCAConfigMap
+        - description: disable https protecting the proxy endpoint
+          displayName: DisableHttps
+          path: metricsExporter.rbacConfig.disableHttps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+        - description: enable kube-rbac-proxy, disabled by default
+          displayName: Enable
+          path: metricsExporter.rbacConfig.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: kube-rbac-proxy image
+          displayName: Image
+          path: metricsExporter.rbacConfig.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: certificate secret to mount in kube-rbac container for TLS,
+            self signed certificates will be generated by default
+          displayName: Secret
+          path: metricsExporter.rbacConfig.secret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:secret
+        - description: Optional static RBAC rules based on client certificate Common
+            Name (CN)
+          displayName: StaticAuthorization
+          path: metricsExporter.rbacConfig.staticAuthorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:staticAuthorization
+        - description: Expected CN (Common Name) from client cert (e.g., Prometheus
+            SA identity)
+          displayName: ClientName
+          path: metricsExporter.rbacConfig.staticAuthorization.clientName
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientName
+        - description: Enables static authorization using client certificate CN
+          displayName: Enable
+          path: metricsExporter.rbacConfig.staticAuthorization.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: Set resource config for metrics exporter
+          displayName: Resource
+          path: metricsExporter.resource
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:resource
+        - description: Selector describes on which nodes to enable metrics exporter
+          displayName: Selector
+          path: metricsExporter.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: Set ServiceAnnotations for metrics exporter
+          displayName: ServiceAnnotations
+          path: metricsExporter.serviceAnnotations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceAnnotations
+        - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+            by default
+          displayName: ServiceType
+          path: metricsExporter.serviceType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+        - description: tolerations for metrics exporter
+          displayName: Tolerations
+          path: metricsExporter.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for metrics exporter daemons
+          displayName: UpgradePolicy
+          path: metricsExporter.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: metricsExporter.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: metricsExporter.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: Selector describes on which nodes the GPU Operator should enable
+            the GPU device.
+          displayName: Selector
+          path: selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: test runner
+          displayName: TestRunner
+          path: testRunner
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:testRunner
+        - description: config map to customize the config for test runner, if not
+            specified default test config will be aplied
+          displayName: Secret
+          path: testRunner.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: enable test runner, disabled by default
+          displayName: Enable
+          path: testRunner.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: test runner image
+          displayName: Image
+          path: testRunner.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for test runner
+          displayName: ImagePullPolicy
+          path: testRunner.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: test runner image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: testRunner.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: captures logs location and export config for test runner logs
+          displayName: LogsLocation
+          path: testRunner.logsLocation
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsLocation
+        - description: host path to store test runner internal status db in order
+            to persist test running status
+          displayName: HostPath
+          path: testRunner.logsLocation.hostPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostPath
+        - description: LogsExportSecrets is a list of secrets that contain connectivity
+            info to multiple cloud providers
+          displayName: LogsExportSecrets
+          path: testRunner.logsLocation.logsExportSecrets
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsExportSecrets
+        - description: volume mount destination within test runner container
+          displayName: MountPath
+          path: testRunner.logsLocation.mountPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:mountPath
+        - description: Selector describes on which nodes to enable test runner
+          displayName: Selector
+          path: testRunner.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: tolerations for test runner
+          displayName: Tolerations
+          path: testRunner.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for test runner daemonset
+          displayName: UpgradePolicy
+          path: testRunner.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: testRunner.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: testRunner.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        statusDescriptors:
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: configManager.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: configManager.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: configManager.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: devicePlugin.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: devicePlugin.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: devicePlugin.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: driver.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: driver.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: driver.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: metricsExporter.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: metricsExporter.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: metricsExporter.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: NodeModuleStatus contains per node status of driver module
+            installation
+          displayName: NodeModuleStatus
+          path: nodeModuleStatus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+        version: v1alpha1
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+      For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+    displayName: amd-gpu-operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AMD
+    - GPU
+    - AI
+    - Deep Learning
+    - Hardware
+    - Driver
+    - Monitoring
+    links:
+    - name: AMD GPU Operator
+      url: https://github.com/ROCm/gpu-operator
+    maintainers:
+    - email: Yan.Sun3@amd.com
+      name: Yan Sun
+    - email: farshad.ghodsian@amd.com
+      name: Farshad Ghodsian
+    - email: shrey.ajmera@amd.com
+      name: Shrey Ajmera
+    maturity: stable
+    provider:
+      name: Advanced Micro Devices, Inc.
+relatedImages:
+- image: docker.io/rocm/device-config-manager@sha256:76363ac0cc42617f1723e14eaeb11434d4d1fa2d4d39d67bc49b3525c599c0ba
+  name: device-config-manager-76363ac0cc42617f1723e14eaeb11434d4d1fa2d4d39d67bc49b3525c599c0ba-annotation
+- image: docker.io/rocm/device-metrics-exporter@sha256:3872ca3534c6679159ffbef504a02e937eb3e11b215c18e649456c0d0ca9bc8d
+  name: device-metrics-exporter-3872ca3534c6679159ffbef504a02e937eb3e11b215c18e649456c0d0ca9bc8d-annotation
+- image: docker.io/rocm/gpu-operator-utils@sha256:9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287
+  name: gpu-operator-utils-9cbe60dce5b3a2ffd93f7148a363ed5f072a320377d5e5bcbbfb1e05d4959287-annotation
+- image: docker.io/rocm/gpu-operator@sha256:619f6d1ddef671df2704e87a8cca82ee4c1b07d645f05c8d5cb2eb9c6604a270
+  name: manager
+- image: docker.io/rocm/gpu-operator@sha256:619f6d1ddef671df2704e87a8cca82ee4c1b07d645f05c8d5cb2eb9c6604a270
+  name: gpu-operator-619f6d1ddef671df2704e87a8cca82ee4c1b07d645f05c8d5cb2eb9c6604a270-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:6976ee40f7fcba3759bbbf5a36e3f12daaf306836606df18592b1b67f7f651d7
+  name: k8s-device-plugin-6976ee40f7fcba3759bbbf5a36e3f12daaf306836606df18592b1b67f7f651d7
+    -annotation
+- image: docker.io/rocm/k8s-node-labeller@sha256:8206d27891606ebc2f234fed6fe45d181cb31c3ff694a0ff9c3f02d62c280eee
+  name: k8s-node-labeller-8206d27891606ebc2f234fed6fe45d181cb31c3ff694a0ff9c3f02d62c280eee-annotation
+- image: docker.io/rocm/test-runner@sha256:529a13953979e7fbd4ff9333735bd2268a81eaa4fdf8f187698cce7d8e720beb
+  name: device-test-runner-529a13953979e7fbd4ff9333735bd2268a81eaa4fdf8f187698cce7d8e720beb-annotation
+- image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:4918beef3a778e8e6bb835240f356002a8b41e40ba011112ca360faa88fe57f4
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:1d7767d4e92ec7c13e98ea690658c5a089d6bd2c1e1ede85e085344ed3d088f4
+name: amd-gpu-operator.v1.5.0
+package: amd-gpu-operator
+properties:
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: DeviceConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: amd.com
+    kind: RemediationWorkflowStatus
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: amd-gpu-operator
+    version: 1.5.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "amd.com/v1alpha1",
+            "kind": "DeviceConfig",
+            "metadata": {
+              "name": "test-deviceconfig",
+              "namespace": "kube-amd-gpu"
+            },
+            "spec": {
+              "devicePlugin": {
+                "devicePluginImage": "rocm/k8s-device-plugin:latest",
+                "enableDevicePlugin": true,
+                "nodeLabellerImage": "rocm/k8s-device-plugin:labeller-latest"
+              },
+              "draDriver": {
+                "enable": false
+              },
+              "driver": {
+                "image": "my.registry.io/myUserName/myRepo",
+                "imageRegistrySecret": {
+                  "name": "docker-auth"
+                },
+                "version": "30.20.1"
+              },
+              "selector": {
+                "feature.node.kubernetes.io/amd-gpu": "true"
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning,Monitoring
+      containerImage: docker.io/rocm/gpu-operator@sha256:396310d68fe8515ceffe79750c4e0a4141e082f820cd45eff740e8d62d434477
+      createdAt: "2026-05-06T13:02:45Z"
+      description: |-
+        Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+        For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+      deviceConfigManagerImage: docker.io/rocm/device-config-manager@sha256:19b2ed0b408689dd27f42507881b4564f0a65cacbbb4c485fdc7fd8c576e23ad
+      devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:1e3f592fcf698a35907a4b1058c3e1c135364aaf5066c534d7a7ae7c2af1af61
+      draImage: docker.io/rocm/k8s-gpu-dra-driver@sha256:ec81d31d85aa26eaecfe6a29f643460d62cdae3f14856040001a861e477f1999
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:73f3978ad439c24a45560ad1ee56a759ddfd213ce1f7e0e0503cf91e67205c5e
+      nodelabellerImage: docker.io/rocm/k8s-node-labeller@sha256:059fdad195cfdd7a0caa36cff31acfb725577c8b1ebc81666938f33857e7952e
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-amd-gpu
+      operators.openshift.io/valid-subscription: '[]'
+      operators.operatorframework.io/builder: operator-sdk-v1.32.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/ROCm/gpu-operator
+      support: Advanced Micro Devices, Inc.
+      testRunnerImage: docker.io/rocm/test-runner@sha256:485418194d71b0aeea1af69a9b5e17ccdc7f6514fabeafdbbabb50987d75eccb
+      utilsContainerImage: docker.io/rocm/gpu-operator-utils@sha256:55e5340839f16661cb818fd67e26bdfa581718ac29929368d50920a7ad3a1e68
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: DeviceConfig describes how to enable AMD GPU device
+        displayName: DeviceConfig
+        kind: DeviceConfig
+        name: deviceconfigs.amd.com
+        resources:
+        - kind: Daemonset
+          name: apps
+          version: v1
+        - kind: Pod
+          name: core
+          version: v1
+        - kind: services
+          name: core
+          version: v1
+        - kind: Module
+          name: modules.kmm.sigs.x-k8s.io
+          version: v1beta1
+        specDescriptors:
+        - description: common config
+          displayName: CommonConfig
+          path: commonConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:commonConfig
+        - description: ImageRegistrySecrets are global secrets used for pull/push
+            images from/to private registries. These secrets will be applied to all
+            component pods (device plugin, metrics exporter, test runner, config manager,
+            DRA driver, node labeller) in addition to component-specific secrets.
+          displayName: ImageRegistrySecrets
+          path: commonConfig.imageRegistrySecrets
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecrets
+        - description: InitContainerImage is being used for the operands pods, i.e.
+            metrics exporter, test runner, device plugin, device config manager and
+            node labeller
+          displayName: InitContainerImage
+          path: commonConfig.initContainerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:initContainerImage
+        - description: UtilsContainer contains parameters to configure operator's
+            utils container
+          displayName: UtilsContainer
+          path: commonConfig.utilsContainer
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:utilsContainer
+        - description: Image is the image of utils container
+          displayName: Image
+          path: commonConfig.utilsContainer.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for utils container
+          displayName: ImagePullPolicy
+          path: commonConfig.utilsContainer.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: secret used for pull utils container image
+          displayName: ImageRegistrySecret
+          path: commonConfig.utilsContainer.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: config manager
+          displayName: ConfigManager
+          path: configManager
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManager
+        - description: ConfigMap holding DCM config.json. When set, the operator mounts
+            this ConfigMap and does not create it. When omitted or name is empty,
+            the operator mounts ConfigMap "default-dcm-config" and creates it in the
+            DeviceConfig namespace if it does not already exist (same default payload
+            as chart defaultDCMConfigMap).
+          displayName: Config
+          path: configManager.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: tolerations for the device config manager DaemonSet
+          displayName: ConfigManagerTolerations
+          path: configManager.configManagerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configManagerTolerations
+        - description: enable config manager, disabled by default
+          displayName: Enable
+          path: configManager.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: config manager image
+          displayName: Image
+          path: configManager.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for config manager
+          displayName: ImagePullPolicy
+          path: configManager.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: config manager image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: configManager.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: Selector describes on which nodes to enable config manager
+          displayName: Selector
+          path: configManager.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: upgrade policy for config manager daemonset
+          displayName: UpgradePolicy
+          path: configManager.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: configManager.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: configManager.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: device plugin
+          displayName: DevicePlugin
+          path: devicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+        - description: 'device plugin arguments is used to pass supported flags and
+            their values while starting device plugin daemonset supported flag values:
+            {"resource_naming_strategy": {"single", "mixed"}}'
+          displayName: DevicePluginArguments
+          path: devicePlugin.devicePluginArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginArguments
+        - description: device plugin image
+          displayName: DevicePluginImage
+          path: devicePlugin.devicePluginImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+        - description: image pull policy for device plugin
+          displayName: DevicePluginImagePullPolicy
+          path: devicePlugin.devicePluginImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:DevicePluginImagePullPolicy
+        - description: tolerations for the device plugin DaemonSet
+          displayName: DevicePluginTolerations
+          path: devicePlugin.devicePluginTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginTolerations
+        - description: enable Device Plugin, enabled by default
+          displayName: EnableDevicePlugin
+          path: devicePlugin.enableDevicePlugin
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableDevicePlugin
+        - description: enable or disable the node labeller
+          displayName: EnableNodeLabeller
+          path: devicePlugin.enableNodeLabeller
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+        - description: HostNetwork specifies whether to use host network namespace
+            for the device plugin DaemonSet pods.
+          displayName: HostNetwork
+          path: devicePlugin.hostNetwork
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostNetwork
+        - description: node labeller image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: devicePlugin.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: KubeletSocketPath specifies the kubelet device plugins directory
+            path. Useful for Kubernetes distributions like microk8s, k3s where the
+            path differs from the standard.
+          displayName: KubeletSocketPath
+          path: devicePlugin.kubeletSocketPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:kubeletSocketPath
+        - description: 'node labeller arguments is used to pass supported labels while
+            starting node labeller daemonset some flags are enabled by default as
+            they are applicable and bare minimum for all setups and are supported
+            in all versions of node labeller default flags: {"vram", "cu-count", "simd-count",
+            "device-id", "family", "product-name", "driver-version"} supported flags:
+            {"compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"}'
+          displayName: NodeLabellerArguments
+          path: devicePlugin.nodeLabellerArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerArguments
+        - description: node labeller image
+          displayName: NodeLabellerImage
+          path: devicePlugin.nodeLabellerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+        - description: image pull policy for node labeller
+          displayName: NodeLabellerImagePullPolicy
+          path: devicePlugin.nodeLabellerImagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:NodeLabellerImagePullPolicy
+        - description: tolerations for the node labeller DaemonSet
+          displayName: NodeLabellerTolerations
+          path: devicePlugin.nodeLabellerTolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerTolerations
+        - description: upgrade policy for device plugin and node labeller daemons
+          displayName: UpgradePolicy
+          path: devicePlugin.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: devicePlugin.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: devicePlugin.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: dra driver
+          displayName: DRADriver
+          path: draDriver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:draDriver
+        - description: arguments is used to pass supported flags and their values
+            while starting DRA driver daemonset
+          displayName: DRADriverArguments
+          path: draDriver.cmdLineArguments
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:cmdLineArguments
+        - description: enable DRA driver, disabled by default
+          displayName: Enable
+          path: draDriver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: DRA driver image
+          displayName: Image
+          path: draDriver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for DRA driver
+          displayName: ImagePullPolicy
+          path: draDriver.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: DRA driver image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: draDriver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: Selector describes on which nodes to enable DRA driver
+          displayName: Selector
+          path: draDriver.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: tolerations for the DRA driver DaemonSet
+          displayName: Tolerations
+          path: draDriver.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for DRA driver daemon
+          displayName: UpgradePolicy
+          path: draDriver.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: draDriver.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: draDriver.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: driver
+          displayName: Driver
+          path: driver
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driver
+        - description: radeon repo URL for fetching amdgpu installer if building driver
+            image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+            by default
+          displayName: AMDGPUInstallerRepoURL
+          path: driver.amdgpuInstallerRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+        - description: blacklist amdgpu drivers on the host. Node reboot is required
+            to apply the baclklist on the worker nodes. Not working for OpenShift
+            cluster. OpenShift users please use the Machine Config Operator (MCO)
+            resource to configure amdgpu blacklist. Example MCO resource is available
+            at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+          displayName: BlacklistDrivers
+          path: driver.blacklist
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+        - description: 'specify the type of driver (container/vf-passthrough/pf-passthrough)
+            to install on the worker node. default value is container. container:
+            normal amdgpu-dkms driver for Bare Metal GPU nodes or guest VM. vf-passthrough:
+            MxGPU GIM driver on the host machine to generate VF, then mount VF to
+            vfio-pci pf-passthrough: directly mount PF device to vfio-pci'
+          displayName: DriverType
+          path: driver.driverType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:driverType
+        - description: enable driver install. default value is true. disable is for
+            skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+            module
+          displayName: Enable
+          path: driver.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: 'defines image that includes drivers and firmware blobs, don''t
+            include tag since it will be fully managed by operator for vanilla k8s
+            the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for
+            OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+            image tag will be in the format of <linux distro>-<release version>-<kernel
+            version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+            and ubuntu-22.04-5.15.0-94-generic-6.1.3 NOTE: Updating the driver image
+            repository is not supported. Please delete the existing DeviceConfig and
+            create a new one with the updated image repository'
+          displayName: Image
+          path: driver.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image build configs
+          displayName: ImageBuild
+          path: driver.imageBuild
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageBuild
+        - description: 'image registry to fetch base image for building driver image,
+            default value is docker.io, the builder will search for corresponding
+            OS base image from given registry e.g. if your worker node is using Ubuntu
+            22.04, by default the base image would be docker.io/ubuntu:22.04 Use spec.driver.imageRegistrySecret
+            for authentication with private registries. NOTE: this field won''t apply
+            for OpenShift since OpenShift is using its own DriverToolKit image to
+            build driver image'
+          displayName: BaseImageRegistry
+          path: driver.imageBuild.baseImageRegistry
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:baseImageRegistry
+        - description: TLS settings for fetching base image this field will be applied
+            to SourceImageRepo as well
+          displayName: BaseImageRegistryTLS
+          path: driver.imageBuild.baseImageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:baseImageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageBuild.baseImageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageBuild.baseImageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: 'GPGKeyURL specifies the full URL to the GPG key used to verify
+            packages during driver image build. When specified, this URL completely
+            overrides the default GPG key URL. This is useful when using a custom
+            package repository that has its own GPG key, or when the GPG key location
+            does not follow the standard repo.radeon.com scheme. Examples: - "https://custom-mirror.example.com/keys/amdgpu.gpg.key"
+            - "https://repo.example.com/rocm/rocm.gpg.key" When empty (default), the
+            URL is constructed as: ${amdgpuInstallerRepoURL}/rocm/rocm.gpg.key'
+          displayName: GPGKeyURL
+          path: driver.imageBuild.gpgKeyURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:gpgKeyURL
+        - description: 'PackageRepoURL specifies the full URL to the package repository
+            used during driver image build. When specified, this URL completely overrides
+            the default URL constructed from spec.driver.amdgpuInstallerRepoURL. This
+            is useful when the package repository does not follow the standard repo.radeon.com
+            URL scheme, or when using a custom mirror/proxy that requires a different
+            URL structure. The URL should point directly to the repository base (without
+            trailing slash). Examples: - For Ubuntu: "https://custom-mirror.example.com/repos/amdgpu/6.1.3/ubuntu
+            jammy main" This will be used as: "deb [arch=amd64 ...] ${PACKAGE_REPO_URL}"
+            - For CoreOS/RHEL: "https://custom-mirror.example.com/repos/amdgpu/6.2.2/el/9.4/main/x86_64"
+            This will be used as: "baseurl=${PACKAGE_REPO_URL}" When empty (default),
+            the URL is constructed as: ${amdgpuInstallerRepoURL}/amdgpu/${DRIVERS_VERSION}/${os}/${distro}'
+          displayName: PackageRepoURL
+          path: driver.imageBuild.packageRepoURL
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:packageRepoURL
+        - description: 'SourceImageRepo specifies the image repository for the driver
+            source code (OpenShift only). Used when spec.driver.useSourceImage is
+            true. The operator automatically determines the image tag based on cluster
+            RHEL version and spec.driver.version (format: coreos-<rhel>-<driver version>).
+            Default: docker.io/rocm/amdgpu-driver Use spec.driver.imageRegistrySecret
+            for authentication with private registries.'
+          displayName: SourceImageRepo
+          path: driver.imageBuild.sourceImageRepo
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:sourceImageRepo
+        - description: secrets used for pull/push images from/to private registry
+            specified in driversImage
+          displayName: ImageRegistrySecret
+          path: driver.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: driver image registry TLS setting for the container image
+          displayName: ImageRegistryTLS
+          path: driver.imageRegistryTLS
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+        - description: If true, check if the container image already exists using
+            plain HTTP.
+          displayName: Insecure
+          path: driver.imageRegistryTLS.insecure
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+        - description: If true, skip any TLS server certificate validation
+          displayName: InsecureSkipTLSVerify
+          path: driver.imageRegistryTLS.insecureSkipTLSVerify
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+        - description: image signing config to sign the driver image when building
+            driver image on the fly image signing is required for installing driver
+            on secure boot enabled system
+          displayName: ImageSign
+          path: driver.imageSign
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+        - description: ImageSignCertSecret the public key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignCertSecret
+          path: driver.imageSign.certSecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+        - description: ImageSignKeySecret the private key used to sign kernel modules
+            within image necessary for secure boot enabled system
+          displayName: ImageSignKeySecret
+          path: driver.imageSign.keySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+        - description: advanced arguments, parameters and more configs to manage tne
+            driver
+          displayName: KernelModuleConfig
+          path: driver.kernelModuleConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:kernelModuleConfig
+        - description: LoadArg are the arguments when modprobe is executed to load
+            the kernel module. The command will be `modprobe ${Args} module_name`.
+          displayName: LoadArg
+          path: driver.kernelModuleConfig.loadArgs
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:loadArg
+        - description: Parameters is being used for modprobe commands. The command
+            will be `modprobe ${Args} module_name ${Parameters}`.
+          displayName: Parameters
+          path: driver.kernelModuleConfig.parameters
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:parameters
+        - description: UnloadArg are the arguments when modprobe is executed to unload
+            the kernel module. The command will be `modprobe -r ${Args} module_name`.
+          displayName: UnloadArg
+          path: driver.kernelModuleConfig.unloadArgs
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:unloadArg
+        - description: tolerations for kmm module object
+          displayName: Tolerations
+          path: driver.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: policy to upgrade the drivers
+          displayName: UpgradePolicy
+          path: driver.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: enable upgrade policy, disabled by default If disabled, user
+            has to manually upgrade all the nodes.
+          displayName: Enable
+          path: driver.upgradePolicy.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: MaxParallelUpgrades indicates how many nodes can be upgraded
+            in parallel 0 means no limit, all nodes will be upgraded in parallel
+          displayName: MaxParallelUpgrades
+          path: driver.upgradePolicy.maxParallelUpgrades
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelUpgrades
+        - description: 'MaxUnavailableNodes indicates maximum number of nodes that
+            can be in a failed upgrade state beyond which upgrades will stop to keep
+            cluster at a minimal healthy state Value can be an integer (ex: 2) which
+            would mean atmost 2 nodes can be in failed state after which new upgrades
+            will not start. Or it can be a percentage string(ex: "50%") from which
+            absolute number will be calculated and round up'
+          displayName: MaxUnavailableNodes
+          path: driver.upgradePolicy.maxUnavailableNodes
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailableNodes
+        - description: Node draining policy
+          displayName: NodeDrainPolicy
+          path: driver.upgradePolicy.nodeDrainPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+        - description: Pod Deletion policy. If both NodeDrainPolicy and PodDeletionPolicy
+            config is available, NodeDrainPolicy(if enabled) will take precedence.
+          displayName: PodDeletionPolicy
+          path: driver.upgradePolicy.podDeletionPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podDeletionPolicy
+        - description: reboot between driver upgrades, enabled by default, if enabled
+            spec.commonConfig.utilsContainer will be used to perform reboot on worker
+            nodes
+          displayName: RebootRequired
+          path: driver.upgradePolicy.rebootRequired
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rebootRequired
+        - description: 'NOTE: currently only for OpenShift cluster set to true to
+            use source image to build driver image on the fly otherwise use installer
+            debian/rpm packages from radeon repo to build driver image'
+          displayName: UseSourceImage
+          path: driver.useSourceImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:useSourceImage
+        - description: 'version of the drivers source code, can be used as part of
+            image of dockerfile source image default value for different OS is: ubuntu:
+            6.1.3, coreOS: 6.2.2'
+          displayName: Version
+          path: driver.version
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:version
+        - description: vfio config specify the specific configs for binding PCI devices
+            to vfio-pci kernel module, applies for driver type vf-passthrough and
+            pf-passthrough
+          displayName: VFIOConfig
+          path: driver.vfioConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:vfioConfig
+        - description: metrics exporter
+          displayName: MetricsExporter
+          path: metricsExporter
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+        - description: optional configuration for metrics
+          displayName: Config
+          path: metricsExporter.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: Name of the configMap that defines the list of metrics default
+            list:[]
+          displayName: Name
+          path: metricsExporter.config.name
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:name
+        - description: enable metrics exporter, disabled by default
+          displayName: Enable
+          path: metricsExporter.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: HostNetwork specifies whether to use host network namespace
+            for the metrics exporter DaemonSet pods.
+          displayName: HostNetwork
+          path: metricsExporter.hostNetwork
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostNetwork
+        - description: metrics exporter image
+          displayName: Image
+          path: metricsExporter.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for metrics exporter
+          displayName: ImagePullPolicy
+          path: metricsExporter.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: metrics exporter image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: metricsExporter.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: NodePort is the external port for pulling metrics from outside
+            the cluster, in the range 30000-32767 (assigned automatically by default)
+          displayName: NodePort
+          path: metricsExporter.nodePort
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+        - description: Set PodAnnotations for metrics exporter
+          displayName: PodAnnotations
+          path: metricsExporter.podAnnotations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podAnnotations
+        - description: Set the host path for pod-resource kubelet.socket, vanila kubernetes
+            path is /var/lib/kubelet/pod-resources microk8s path is /var/snap/microk8s/common/var/lib/kubelet/pod-resources/
+            path is an absolute unix path that allows a trailing slash
+          displayName: PodResourceAPISocketPath
+          path: metricsExporter.podResourceAPISocketPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:podResourceAPISocketPath
+        - description: Port is the internal port used for in-cluster and node access
+            to pull metrics from the metrics-exporter (default 5000).
+          displayName: Port
+          path: metricsExporter.port
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:port
+        - description: Prometheus configuration for metrics exporter
+          displayName: Prometheus
+          path: metricsExporter.prometheus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:prometheus
+        - description: ServiceMonitor configuration for Prometheus integration
+          displayName: ServiceMonitor
+          path: metricsExporter.prometheus.serviceMonitor
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceMonitor
+        - description: AttachMetadata defines if Prometheus should attach node metadata
+            to the target
+          displayName: AttachMetadata
+          path: metricsExporter.prometheus.serviceMonitor.attachMetadata
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:attachMetadata
+        - description: Optional Prometheus authorization configuration for accessing
+            the endpoint
+          displayName: Authorization
+          path: metricsExporter.prometheus.serviceMonitor.authorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:authorization
+        - description: 'Path to bearer token file to be used by Prometheus (e.g.,
+            service account token path) Deprecated: Use Authorization instead. This
+            field is kept for backward compatibility.'
+          displayName: BearerTokenFile
+          path: metricsExporter.prometheus.serviceMonitor.bearerTokenFile
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:bearerTokenFile
+        - description: Enable or disable ServiceMonitor creation (default false)
+          displayName: Enable
+          path: metricsExporter.prometheus.serviceMonitor.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: HonorLabels chooses the metric's labels on collisions with
+            target labels (default true)
+          displayName: HonorLabels
+          path: metricsExporter.prometheus.serviceMonitor.honorLabels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorLabels
+        - description: HonorTimestamps controls whether the scrape endpoints honor
+            timestamps (default false)
+          displayName: HonorTimestamps
+          path: metricsExporter.prometheus.serviceMonitor.honorTimestamps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:honorTimestamps
+        - description: 'How frequently to scrape metrics. Accepts values with time
+            unit suffix: "30s", "1m", "2h", "500ms"'
+          displayName: Interval
+          path: metricsExporter.prometheus.serviceMonitor.interval
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:interval
+        - description: 'Additional labels to add to the ServiceMonitor (default release:
+            prometheus)'
+          displayName: Labels
+          path: metricsExporter.prometheus.serviceMonitor.labels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:labels
+        - description: Relabeling rules applied to individual scraped metrics
+          displayName: MetricRelabelings
+          path: metricsExporter.prometheus.serviceMonitor.metricRelabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:metricRelabelings
+        - description: RelabelConfigs to apply to samples before ingestion
+          displayName: Relabelings
+          path: metricsExporter.prometheus.serviceMonitor.relabelings
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:relabelings
+        - description: TLS settings used by Prometheus to connect to the metrics endpoint
+          displayName: TLSConfig
+          path: metricsExporter.prometheus.serviceMonitor.tlsConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tlsConfig
+        - description: optional kube-rbac-proxy config to provide rbac services
+          displayName: RbacConfig
+          path: metricsExporter.rbacConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+        - description: 'Reference to a configmap containing the client CA (key: ca.crt)
+            for mTLS client validation'
+          displayName: ClientCAConfigMap
+          path: metricsExporter.rbacConfig.clientCAConfigMap
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientCAConfigMap
+        - description: disable https protecting the proxy endpoint
+          displayName: DisableHttps
+          path: metricsExporter.rbacConfig.disableHttps
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+        - description: enable kube-rbac-proxy, disabled by default
+          displayName: Enable
+          path: metricsExporter.rbacConfig.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: kube-rbac-proxy image
+          displayName: Image
+          path: metricsExporter.rbacConfig.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: certificate secret to mount in kube-rbac container for TLS,
+            self signed certificates will be generated by default
+          displayName: Secret
+          path: metricsExporter.rbacConfig.secret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:secret
+        - description: Optional static RBAC rules based on client certificate Common
+            Name (CN)
+          displayName: StaticAuthorization
+          path: metricsExporter.rbacConfig.staticAuthorization
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:staticAuthorization
+        - description: Expected CN (Common Name) from client cert (e.g., Prometheus
+            SA identity)
+          displayName: ClientName
+          path: metricsExporter.rbacConfig.staticAuthorization.clientName
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:clientName
+        - description: Enables static authorization using client certificate CN
+          displayName: Enable
+          path: metricsExporter.rbacConfig.staticAuthorization.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: Set resource config for metrics exporter
+          displayName: Resource
+          path: metricsExporter.resource
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:resource
+        - description: Selector describes on which nodes to enable metrics exporter
+          displayName: Selector
+          path: metricsExporter.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: Set ServiceAnnotations for metrics exporter
+          displayName: ServiceAnnotations
+          path: metricsExporter.serviceAnnotations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceAnnotations
+        - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+            by default
+          displayName: ServiceType
+          path: metricsExporter.serviceType
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+        - description: tolerations for metrics exporter
+          displayName: Tolerations
+          path: metricsExporter.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for metrics exporter daemons
+          displayName: UpgradePolicy
+          path: metricsExporter.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: metricsExporter.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: metricsExporter.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        - description: remediation workflow
+          displayName: RemediationWorkflow
+          path: remediationWorkflow
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:remediationWorkflow
+        - description: AutoStartWorkflow specifies the behavior of the remediation
+            workflow. Default value is true. If true, remediation workflow will be
+            automatically started when the node condition matches. If false, remediation
+            workflow will be in suspended state when the node condition matches and
+            needs to be manually started by the user. This field gives users more
+            control and flexibility on when to start the remediation workflow. Default
+            value is set to true if not specified and the remediation workflow automatically
+            starts when the node condition matches.
+          displayName: AutoStartWorkflow
+          path: remediationWorkflow.autoStartWorkflow
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:autoStartWorkflow
+        - description: Name of the ConfigMap that holds condition-to-workflow mappings.
+          displayName: Config
+          path: remediationWorkflow.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:config
+        - description: ConfigMapImage specifies a container image that contains the
+            remediation ConfigMap. When set, the operator runs a Job from this image
+            to apply the ConfigMap to the cluster before the remediation workflow
+            proceeds.
+          displayName: ConfigMapImage
+          path: remediationWorkflow.configMapImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configMapImage
+        - description: enable remediation workflows. disabled by default enable if
+            operator should automatically handle remediation of node incase of gpu
+            issues
+          displayName: Enable
+          path: remediationWorkflow.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: MaxParallelWorkflows specifies limit on how many remediation
+            workflows can be executed in parallel. 0 is the default value and it means
+            no limit.
+          displayName: MaxParallelWorkflows
+          path: remediationWorkflow.maxParallelWorkflows
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelWorkflows
+        - description: Node drain policy during remediation workflow execution
+          displayName: NodeDrainPolicy
+          path: remediationWorkflow.nodeDrainPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+        - description: Node Remediation labels are custom labels that we can apply
+            on the node to specify that the node is undergoing remediation or needs
+            attention by the administrator.
+          displayName: NodeRemediationLabels
+          path: remediationWorkflow.nodeRemediationLabels
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeRemediationLabels
+        - description: Node Remediation taints are custom taints that we can apply
+            on the node to specify that the node is undergoing remediation or needs
+            attention by the administrator. If user does not specify any taints, the
+            operator will apply a taint with key "amd-gpu-unhealthy" and effect "NoSchedule"
+            to the node under remediation.
+          displayName: NodeRemediationTaints
+          path: remediationWorkflow.nodeRemediationTaints
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeRemediationTaints
+        - description: RebootTimeout specifies the duration to wait for the node to
+            reboot. Accepts duration strings like "30s", "4h", "24h". By default,
+            it is set to 15m.
+          displayName: RebootTimeout
+          path: remediationWorkflow.rebootTimeout
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:rebootTimeout
+        - description: Tester image used to run tests and verify if remediation fixed
+            the reported problem.
+          displayName: TesterImage
+          path: remediationWorkflow.testerImage
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:testerImage
+        - description: Time to live for argo workflow object and its pods for a failed
+            workflow. Accepts duration strings like "30s", "4h", "24h". By default,
+            it is set to 24h
+          displayName: TtlForFailedWorkflows
+          path: remediationWorkflow.ttlForFailedWorkflows
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:ttlForFailedWorkflows
+        - description: Selector describes on which nodes the GPU Operator should enable
+            the GPU device.
+          displayName: Selector
+          path: selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: test runner
+          displayName: TestRunner
+          path: testRunner
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:testRunner
+        - description: config map to customize the config for test runner, if not
+            specified default test config will be aplied
+          displayName: Secret
+          path: testRunner.config
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+        - description: enable test runner, disabled by default
+          displayName: Enable
+          path: testRunner.enable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:enable
+        - description: test runner image
+          displayName: Image
+          path: testRunner.image
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:image
+        - description: image pull policy for test runner
+          displayName: ImagePullPolicy
+          path: testRunner.imagePullPolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+        - description: test runner image registry secret used to pull/push images
+          displayName: ImageRegistrySecret
+          path: testRunner.imageRegistrySecret
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+        - description: captures logs location and export config for test runner logs
+          displayName: LogsLocation
+          path: testRunner.logsLocation
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsLocation
+        - description: host path to store test runner internal status db in order
+            to persist test running status
+          displayName: HostPath
+          path: testRunner.logsLocation.hostPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:hostPath
+        - description: LogsExportSecrets is a list of secrets that contain connectivity
+            info to multiple cloud providers
+          displayName: LogsExportSecrets
+          path: testRunner.logsLocation.logsExportSecrets
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:logsExportSecrets
+        - description: volume mount destination within test runner container
+          displayName: MountPath
+          path: testRunner.logsLocation.mountPath
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:mountPath
+        - description: Selector describes on which nodes to enable test runner
+          displayName: Selector
+          path: testRunner.selector
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:selector
+        - description: tolerations for test runner
+          displayName: Tolerations
+          path: testRunner.tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+        - description: upgrade policy for test runner daemonset
+          displayName: UpgradePolicy
+          path: testRunner.upgradePolicy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+        - description: MaxUnavailable specifies the maximum number of Pods that can
+            be unavailable during the update process. Applicable for RollingUpdate
+            only. Default value is 1.
+          displayName: MaxUnavailable
+          path: testRunner.upgradePolicy.maxUnavailable
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+        - description: UpgradeStrategy specifies the type of the DaemonSet update.
+            Valid values are "RollingUpdate" (default) or "OnDelete".
+          displayName: UpgradeStrategy
+          path: testRunner.upgradePolicy.upgradeStrategy
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+        statusDescriptors:
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: configManager.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: configManager.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: configManager.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: devicePlugin.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: devicePlugin.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: devicePlugin.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: driver.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: driver.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: driver.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: metricsExporter.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: metricsExporter.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: metricsExporter.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        - description: NodeModuleStatus contains per node status of driver module
+            installation
+          displayName: NodeModuleStatus
+          path: nodeModuleStatus
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+        - description: number of the actually deployed and running pods
+          displayName: AvailableNumber
+          path: remediationWorkflow.availableNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+        - description: number of the pods that should be deployed for daemonset
+          displayName: DesiredNumber
+          path: remediationWorkflow.desiredNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+        - description: number of nodes that are targeted by the DeviceConfig selector
+          displayName: NodesMatchingSelectorNumber
+          path: remediationWorkflow.nodesMatchingSelectorNumber
+          x-descriptors:
+          - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+        version: v1alpha1
+      - kind: RemediationWorkflowStatus
+        name: remediationworkflowstatuses.amd.com
+        version: v1alpha1
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+      For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+    displayName: amd-gpu-operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AMD
+    - GPU
+    - AI
+    - Deep Learning
+    - Hardware
+    - Driver
+    - Monitoring
+    links:
+    - name: AMD GPU Operator
+      url: https://github.com/ROCm/gpu-operator
+    maintainers:
+    - email: Yan.Sun3@amd.com
+      name: Yan Sun
+    - email: farshad.ghodsian@amd.com
+      name: Farshad Ghodsian
+    - email: shrey.ajmera@amd.com
+      name: Shrey Ajmera
+    maturity: stable
+    provider:
+      name: Advanced Micro Devices, Inc.
+relatedImages:
+- image: docker.io/rocm/device-config-manager@sha256:19b2ed0b408689dd27f42507881b4564f0a65cacbbb4c485fdc7fd8c576e23ad
+  name: device-config-manager-19b2ed0b408689dd27f42507881b4564f0a65cacbbb4c485fdc7fd8c576e23ad-annotation
+- image: docker.io/rocm/device-metrics-exporter@sha256:73f3978ad439c24a45560ad1ee56a759ddfd213ce1f7e0e0503cf91e67205c5e
+  name: device-metrics-exporter-73f3978ad439c24a45560ad1ee56a759ddfd213ce1f7e0e0503cf91e67205c5e-annotation
+- image: docker.io/rocm/gpu-operator-utils@sha256:55e5340839f16661cb818fd67e26bdfa581718ac29929368d50920a7ad3a1e68
+  name: gpu-operator-utils-55e5340839f16661cb818fd67e26bdfa581718ac29929368d50920a7ad3a1e68-annotation
+- image: docker.io/rocm/gpu-operator@sha256:396310d68fe8515ceffe79750c4e0a4141e082f820cd45eff740e8d62d434477
+  name: manager
+- image: docker.io/rocm/gpu-operator@sha256:396310d68fe8515ceffe79750c4e0a4141e082f820cd45eff740e8d62d434477
+  name: gpu-operator-396310d68fe8515ceffe79750c4e0a4141e082f820cd45eff740e8d62d434477-annotation
+- image: docker.io/rocm/k8s-device-plugin@sha256:1e3f592fcf698a35907a4b1058c3e1c135364aaf5066c534d7a7ae7c2af1af61
+  name: k8s-device-plugin-1e3f592fcf698a35907a4b1058c3e1c135364aaf5066c534d7a7ae7c2af1af61-annotation
+- image: docker.io/rocm/k8s-gpu-dra-driver@sha256:ec81d31d85aa26eaecfe6a29f643460d62cdae3f14856040001a861e477f1999
+  name: k8s-gpu-dra-driver-ec81d31d85aa26eaecfe6a29f643460d62cdae3f14856040001a861e477f1999-annotation
+- image: docker.io/rocm/k8s-node-labeller@sha256:059fdad195cfdd7a0caa36cff31acfb725577c8b1ebc81666938f33857e7952e
+  name: k8s-node-labeller-059fdad195cfdd7a0caa36cff31acfb725577c8b1ebc81666938f33857e7952e-annotation
+- image: docker.io/rocm/test-runner@sha256:485418194d71b0aeea1af69a9b5e17ccdc7f6514fabeafdbbabb50987d75eccb
+  name: device-test-runner-485418194d71b0aeea1af69a9b5e17ccdc7f6514fabeafdbbabb50987d75eccb-annotation
+- image: registry.connect.redhat.com/amd/gpu-operator-v1@sha256:1d7767d4e92ec7c13e98ea690658c5a089d6bd2c1e1ede85e085344ed3d088f4
+  name: ""
+schema: olm.bundle

--- a/operators/amd-gpu-operator/catalog-templates/v4.22.yaml
+++ b/operators/amd-gpu-operator/catalog-templates/v4.22.yaml
@@ -1,0 +1,43 @@
+---
+entries:
+- defaultChannel: alpha
+  icon:
+    base64data: 
+      PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MDAiIGhlaWdodD0iMTkwLjgwMyIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIj48cGF0aCBkPSJNMTg3Ljg4OCAxNzguMTIySDE0My41MmwtMTMuNTczLTMyLjczOEg1Ni4wMDNsLTEyLjM2NiAzMi43MzhIMEw2Ni42NjcgMTIuNzc2aDQ3Ljc2MXpNOTEuMTU1IDUyLjI4Nkw2Ni45MTIgMTE2LjUzaDUwLjkxM3ptMjU3LjkwMS0zOS41MWgzNS44OHYxNjUuMzQ2aC00MS4yMTlWNzQuODQybC00NC42MDggNTEuODc3aC02LjMwMWwtNDQuNjA1LTUxLjg3N1YxNzguMTJoLTQxLjIxOVYxMi43NzZoMzUuODhsNTMuMDkyIDYxLjMzNnptMTQwLjMxOSAwYzYwLjM2NCAwIDkxLjM5MSAzNy41NzMgOTEuMzkxIDgyLjkwOSAwIDQ3LjUxNy0zMC4wNTggODIuNDM3LTk2IDgyLjQzN2gtNjguMzY5VjEyLjc3NnptLTMxLjc2MiAxMzUuMDQxaDI2LjkwNmM0MS40NTcgMCA1My44MjMtMjguMTI5IDUzLjgyMy01Mi4zNzcgMC0yOC4zNjgtMTUuMjc2LTUyLjM2My01NC4zMDgtNTIuMzYzaC0yNi40MjJ2MTA0Ljc0em0yMDUuMTU2LTk1LjgzNkw2MTAuNzk3IDBIODAwdjE4OS4yMWwtNTEuOTcyLTUxLjk3NVY1MS45ODF6bS0uMDYxIDEwLjQxNkw2MDkuMiAxMTUuOTAzdjc0Ljg5OWg3NC44ODlsNTMuNTA1LTUzLjUwNmgtNzQuODg2eiIvPjwvc3ZnPg==
+    mediatype: image/svg+xml
+  name: amd-gpu-operator
+  schema: olm.package
+- entries:
+  - name: amd-gpu-operator.v1.1.1
+  - name: amd-gpu-operator.v1.2.1
+    replaces: amd-gpu-operator.v1.1.1
+  - name: amd-gpu-operator.v1.3.1
+    replaces: amd-gpu-operator.v1.2.1
+  - name: amd-gpu-operator.v1.3.2
+    replaces: amd-gpu-operator.v1.3.1
+  - name: amd-gpu-operator.v1.4.1
+    replaces: amd-gpu-operator.v1.3.2
+  - name: amd-gpu-operator.v1.5.0
+    replaces: amd-gpu-operator.v1.4.1
+  name: alpha
+  package: amd-gpu-operator
+  schema: olm.channel
+- image: 
+    registry.connect.redhat.com/amd/gpu-operator-v1@sha256:54cdff8b0d36aa7c47cff1b115a1ee041cf79a6599dd4acba3d1031e0f780dd6
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/amd/gpu-operator-v1@sha256:4ff9f10f18113dc9c0e5473cab361c8fffe99800c660a3fcd50c50b896e2ca2f
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/amd/gpu-operator-v1@sha256:77d65eeb41f7c688b1411c33ea9a61b880ac3f7d0d3a33319dbd2ee188430b32
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/amd/gpu-operator-v1@sha256:8a92a0d18a5ae6a837ca6590c2beb65d889cd744a098c22d3f01d2fffdc4dc57
+  schema: olm.bundle
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/amd/gpu-operator-v1@sha256:4918beef3a778e8e6bb835240f356002a8b41e40ba011112ca360faa88fe57f4
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/amd/gpu-operator-v1@sha256:1d7767d4e92ec7c13e98ea690658c5a089d6bd2c1e1ede85e085344ed3d088f4
+schema: olm.template.basic

--- a/operators/amd-gpu-operator/ci.yaml
+++ b/operators/amd-gpu-operator/ci.yaml
@@ -27,4 +27,8 @@ fbc:
     - v4.21
     template_name: v4.21.yaml
     type: olm.template.basic
+  - catalog_names:
+    - v4.22
+    template_name: v4.22.yaml
+    type: olm.template.basic
   enabled: true


### PR DESCRIPTION
Promote amd-gpu-operator v1.5.0 to OpenShift v4.22 catalog.