### PR TITLE
operator truenas-csi (1.1.1)

### DIFF
--- a/operators/truenas-csi/1.1.1/manifests/csi.truenas.io_truenascsis.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/csi.truenas.io_truenascsis.yaml
@@ -1,0 +1,283 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: truenascsis.csi.truenas.io
+spec:
+  group: csi.truenas.io
+  names:
+    kind: TrueNASCSI
+    listKind: TrueNASCSIList
+    plural: truenascsis
+    shortNames:
+    - tnc
+    singular: truenascsi
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Controller ready
+      jsonPath: .status.controllerReady
+      name: Controller
+      type: boolean
+    - description: Nodes ready
+      jsonPath: .status.nodeDaemonSetReady
+      name: Nodes
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrueNASCSI is the Schema for the truenascsis API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TrueNASCSISpec defines the desired state of TrueNASCSI.
+            properties:
+              controllerReplicas:
+                default: 1
+                description: ControllerReplicas is the number of controller pod replicas
+                format: int32
+                maximum: 3
+                minimum: 1
+                type: integer
+              credentialsSecret:
+                description: |-
+                  CredentialsSecret is the name of the Secret containing the TrueNAS API key
+                  The secret must have a key named "api-key"
+                type: string
+              defaultPool:
+                description: DefaultPool is the default ZFS pool to use for volume
+                  provisioning
+                type: string
+              driverImage:
+                default: quay.io/truenas_solutions/truenas-csi:latest
+                description: DriverImage is the container image for the TrueNAS CSI
+                  driver
+                type: string
+              insecureSkipTLS:
+                default: false
+                description: |-
+                  InsecureSkipTLS skips TLS certificate verification when connecting to TrueNAS
+                  Use only for testing or when using self-signed certificates
+                type: boolean
+              iscsiIQNBase:
+                default: iqn.2000-01.io.truenas
+                description: ISCSIIQNBase is the base IQN for iSCSI targets (e.g.,
+                  "iqn.2000-01.io.truenas")
+                type: string
+              iscsiPortal:
+                description: |-
+                  ISCSIPortal is the iSCSI portal address in the format "ip:port" (e.g., "192.168.1.100:3260")
+                  Required if using iSCSI storage classes
+                type: string
+              logLevel:
+                default: 4
+                description: LogLevel sets the verbosity of the CSI driver logs (1-5)
+                format: int32
+                maximum: 5
+                minimum: 1
+                type: integer
+              managementState:
+                default: Managed
+                description: |-
+                  ManagementState controls whether the operator manages this resource
+                  Valid values: "Managed", "Unmanaged", "Removed"
+                enum:
+                - Managed
+                - Unmanaged
+                - Removed
+                type: string
+              namespace:
+                default: truenas-csi
+                description: Namespace for deploying CSI driver components
+                type: string
+              nfsServer:
+                description: |-
+                  NFSServer is the IP address or hostname of the TrueNAS NFS server
+                  Required if using NFS storage classes
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector for the CSI node pods
+                type: object
+              nvmeofPortal:
+                description: |-
+                  NVMeOFPortal is the NVMe-oF/TCP portal address in the format "ip:port" (e.g., "192.168.1.100:4420")
+                  Optional; auto-derived from the TrueNAS URL host (port 4420) if omitted
+                type: string
+              tolerations:
+                description: Tolerations for the CSI node pods
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              truenasURL:
+                description: TrueNASURL is the WebSocket URL to the TrueNAS API (e.g.,
+                  wss://truenas.example.com/api/current)
+                pattern: ^wss?://
+                type: string
+            required:
+            - credentialsSecret
+            - defaultPool
+            - truenasURL
+            type: object
+          status:
+            description: TrueNASCSIStatus defines the observed state of TrueNASCSI.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the TrueNASCSI's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerReady:
+                description: ControllerReady indicates if the controller deployment
+                  is ready
+                type: boolean
+              controllerReplicas:
+                description: ControllerReplicas is the number of ready controller
+                  replicas
+                format: int32
+                type: integer
+              driverVersion:
+                description: DriverVersion is the version of the deployed CSI driver
+                type: string
+              nodeDaemonSetReady:
+                description: NodeDaemonSetReady indicates if the node daemonset is
+                  ready
+                type: boolean
+              nodeReplicas:
+                description: NodeReplicas is the number of ready node replicas
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the generation last processed by
+                  the controller
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of the CSI driver
+                  deployment
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/truenas-csi/1.1.1/manifests/operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: operator
+    control-plane: controller-manager
+  name: operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/truenas-csi/1.1.1/manifests/operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/truenas-csi/1.1.1/manifests/operator-truenascsi-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/operator-truenascsi-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: operator
+  name: operator-truenascsi-admin-role
+rules:
+- apiGroups:
+  - csi.truenas.io
+  resources:
+  - truenascsis
+  verbs:
+  - '*'
+- apiGroups:
+  - csi.truenas.io
+  resources:
+  - truenascsis/status
+  verbs:
+  - get

--- a/operators/truenas-csi/1.1.1/manifests/operator-truenascsi-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/operator-truenascsi-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: operator
+  name: operator-truenascsi-editor-role
+rules:
+- apiGroups:
+  - csi.truenas.io
+  resources:
+  - truenascsis
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - csi.truenas.io
+  resources:
+  - truenascsis/status
+  verbs:
+  - get

--- a/operators/truenas-csi/1.1.1/manifests/operator-truenascsi-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/operator-truenascsi-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: operator
+  name: operator-truenascsi-viewer-role
+rules:
+- apiGroups:
+  - csi.truenas.io
+  resources:
+  - truenascsis
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - csi.truenas.io
+  resources:
+  - truenascsis/status
+  verbs:
+  - get

--- a/operators/truenas-csi/1.1.1/manifests/truenas-csi.clusterserviceversion.yaml
+++ b/operators/truenas-csi/1.1.1/manifests/truenas-csi.clusterserviceversion.yaml
@@ -1,0 +1,665 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "csi.truenas.io/v1alpha1",
+          "kind": "TrueNASCSI",
+          "metadata": {
+            "name": "truenas"
+          },
+          "spec": {
+            "credentialsSecret": "truenas-api-credentials",
+            "defaultPool": "tank",
+            "insecureSkipTLS": false,
+            "iscsiPortal": "192.168.1.100:3260",
+            "nfsServer": "192.168.1.100",
+            "truenasURL": "wss://truenas.example.com/api/current"
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Storage
+    containerImage: quay.io/truenas_solutions/truenas-csi-operator@sha256:b2fa8796028e6517b0856f6c6e806b6b53ac04ba694ce868d2872f0b83c967af
+    createdAt: "2026-06-22T20:53:33Z"
+    description: Deploys and manages the TrueNAS CSI driver for dynamic volume provisioning
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "true"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/truenas/truenas-csi
+    support: TrueNAS
+  name: truenas-csi.v1.1.1
+  namespace: placeholder
+spec:
+  replaces: truenas-csi.v1.0.0
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: TrueNASCSI is the Schema for the truenascsis API.
+        displayName: TrueNAS CSI
+        kind: TrueNASCSI
+        name: truenascsis.csi.truenas.io
+        resources:
+          - kind: CSIDriver
+            name: ""
+            version: v1
+          - kind: ClusterRole
+            name: ""
+            version: v1
+          - kind: ClusterRoleBinding
+            name: ""
+            version: v1
+          - kind: ConfigMap
+            name: ""
+            version: v1
+          - kind: DaemonSet
+            name: ""
+            version: v1
+          - kind: Deployment
+            name: ""
+            version: v1
+          - kind: ServiceAccount
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: ControllerReplicas is the number of controller pod replicas
+            displayName: Controller Replicas
+            path: controllerReplicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - description: |-
+              CredentialsSecret is the name of the Secret containing the TrueNAS API key
+              The secret must have a key named "api-key"
+            displayName: Credentials Secret
+            path: credentialsSecret
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - description: DefaultPool is the default ZFS pool to use for volume provisioning
+            displayName: Default Pool
+            path: defaultPool
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: DriverImage is the container image for the TrueNAS CSI driver
+            displayName: Driver Image
+            path: driverImage
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              InsecureSkipTLS skips TLS certificate verification when connecting to TrueNAS
+              Use only for testing or when using self-signed certificates
+            displayName: Skip TLS Verification
+            path: insecureSkipTLS
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: ISCSIIQNBase is the base IQN for iSCSI targets (e.g., "iqn.2000-01.io.truenas")
+            displayName: iSCSI IQN Base
+            path: iscsiIQNBase
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              ISCSIPortal is the iSCSI portal address in the format "ip:port" (e.g., "192.168.1.100:3260")
+              Required if using iSCSI storage classes
+            displayName: iSCSI Portal
+            path: iscsiPortal
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: LogLevel sets the verbosity of the CSI driver logs (1-5)
+            displayName: Log Level
+            path: logLevel
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+          - description: |-
+              ManagementState controls whether the operator manages this resource
+              Valid values: "Managed", "Unmanaged", "Removed"
+            displayName: Management State
+            path: managementState
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:Managed
+              - urn:alm:descriptor:com.tectonic.ui:select:Unmanaged
+              - urn:alm:descriptor:com.tectonic.ui:select:Removed
+          - description: Namespace for deploying CSI driver components
+            displayName: Namespace
+            path: namespace
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: |-
+              NFSServer is the IP address or hostname of the TrueNAS NFS server
+              Required if using NFS storage classes
+            displayName: NFS Server
+            path: nfsServer
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: NodeSelector for the CSI node pods
+            displayName: Node Selector
+            path: nodeSelector
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:selector:Node
+          - description: |-
+              NVMeOFPortal is the NVMe-oF/TCP portal address in the format "ip:port" (e.g., "192.168.1.100:4420")
+              Optional; auto-derived from the TrueNAS URL host (port 4420) if omitted
+            displayName: NVMe-oF Portal
+            path: nvmeofPortal
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Tolerations for the CSI node pods
+            displayName: Tolerations
+            path: tolerations
+          - description: TrueNASURL is the WebSocket URL to the TrueNAS API (e.g., wss://truenas.example.com/api/current)
+            displayName: TrueNAS URL
+            path: truenasURL
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - description: Conditions represent the latest available observations of the TrueNASCSI's state
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - description: ControllerReady indicates if the controller deployment is ready
+            displayName: Controller Ready
+            path: controllerReady
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: ControllerReplicas is the number of ready controller replicas
+            displayName: Controller Replicas
+            path: controllerReplicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - description: DriverVersion is the version of the deployed CSI driver
+            displayName: Driver Version
+            path: driverVersion
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: NodeDaemonSetReady indicates if the node daemonset is ready
+            displayName: Node DaemonSet Ready
+            path: nodeDaemonSetReady
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: NodeReplicas is the number of ready node replicas
+            displayName: Node Replicas
+            path: nodeReplicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - description: Phase represents the current phase of the CSI driver deployment
+            displayName: Phase
+            path: phase
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+        version: v1alpha1
+  description: |
+    ## TrueNAS CSI Driver Operator
+
+    The TrueNAS CSI Driver Operator deploys and manages the Container Storage Interface (CSI) driver
+    for TrueNAS storage systems on Kubernetes and OpenShift clusters.
+
+    ### Features
+
+    * **Dynamic Provisioning**: Automatically provision persistent volumes from TrueNAS storage pools
+    * **NFS Support**: Create NFS-backed volumes with ReadWriteMany access mode
+    * **iSCSI Support**: Create block storage volumes with ReadWriteOnce access mode
+    * **Snapshots**: Create and restore volume snapshots using ZFS snapshots
+    * **Cloning**: Fast volume cloning using ZFS clone functionality
+    * **Volume Expansion**: Online expansion of persistent volumes
+    * **Encryption**: Support for ZFS native encryption
+    * **Compression**: Support for various ZFS compression algorithms
+
+    ### Prerequisites
+
+    * TrueNAS SCALE 25.10.0+
+    * API key with appropriate permissions
+    * Network connectivity between cluster nodes and TrueNAS
+
+    ### Quick Start
+
+    1. Create a Secret with your TrueNAS API key:
+       ```yaml
+       apiVersion: v1
+       kind: Secret
+       metadata:
+         name: truenas-api-credentials
+         namespace: truenas-csi
+       stringData:
+         api-key: "your-truenas-api-key"
+       ```
+
+    2. Create a TrueNASCSI resource:
+       ```yaml
+       apiVersion: csi.truenas.io/v1alpha1
+       kind: TrueNASCSI
+       metadata:
+         name: truenas
+       spec:
+         truenasURL: "wss://your-truenas-ip/api/current"
+         credentialsSecret: "truenas-api-credentials"
+         defaultPool: "tank"
+         nfsServer: "your-truenas-ip"
+       ```
+
+    3. Create a StorageClass and provision volumes!
+  displayName: TrueNAS CSI Driver
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAYfUlEQVR4nOzdbWyTV5o38P9JkR4+OFL6lM7jPFPNZrRx2o5NbbYkvDirbaCjNgkthLZxOtOJQ+mKEJsS2Ly0Gkpb2qqJQ4MpcUglGGx2quK0FNKSwGgoYbVQXswIR7WngLMCzaKJd6FtJPIhWpGc1e04TKDkJn67X+zr92mkaX2ftlw+5+/7nOtkgRAyLSoQQkRQgRAiggqEEBFUIISIoAIhRAQVCCEiqEAIEUEFQogIKhBCRFCBECKCCoQQEVQghIigAiFEBBUIISKoQAgRQQVCiAgqEEJEUIEQIoIKhBARVCCEiKACIUQEFQghIqhACBFBBUKICCoQQkRQgRAiggqEEBFUIISIoAKRkNbamKe1Nq2J+wPKbAtRVvdEUgdFRFGBSMTU/0NebnXzAaFO4v8UPhvltgMotz2SzLGR6VGBpJjGaJ6jaz+4k/Gxb8FgSsJH5qBs7Sl0/nkbSmsfTsLnERGz5B5AutJam2drjItXZ5vM70b+UCcVywHn9Vi2zo6CBU70ut7D4Lnh5D6DgAok+TTGxTlaa/Nvs01mO4DZKX7cLBQUNaCg6CUw5sY260cI+a6k+JkZhZZYSaS1Nufo2r/ozzaZGyQojtseDc5fQ737POWT5KIZJAmEnJG/7YvVjI+/AoZ8GYcykU908zfh29O78YePRmUcS1qgGSQBGqN5Vn77wfW6bT0hBt4CxuQsjiiWA11RB5599Qes39OG/PlJzj+ZhWaQOAg5Q2Mqtmirm+oZg1KXNLNv5ZOQbxOcNbvlHpAa0QwSo2jOOJVrbepScHFMpYWucBdcwcuUT2JHBRKD/Pae5bnVDT6oozDulBfJJ+v3rMffP04rhxmiArmHyZwx79j1y9km80Fl5Ix4sRwUFDmxYe83KKtbQ/nk3qhARGitjU/lt/d8k20qdka+gdOFMAOW27qwwRNCvXs1zSjTowK5CyFnzPvq+oFca/MRleSMeM2J5JONe3fIPRClogK5Q357z3O51Q3nwbBC7rFIqBauwGXKJz9GBRLNGbnVTctNx679Mdtk/gyMpc9yasZY3pR8slTu0ShFxn9bCDlDW93sTPOl1MxN5JOjKLddQMi3FV/u8OA//nRT7mHJJaMLxHTsuzUMvEvucSjUI9F8Mh82/Vq5ByOXjFxiCTlj3lfX+qk4ZkTIJ39Eed1TmZhPMqpAtNYmvenYtf5ozqCjqzPGnkSZ7Ugm5pOMKBAhZwgzRq61yc9AhRG3yXziCn4ZORufATNK2v8Dmo59t56BO+UeR5pZhnLbMpTXuWEzrJJ7MKmUtjOItrrJNO/Y9T1UHKnEaiL5pHStXu6RpEraFchkzsitaToPoEbu8aQ/9iSW2f3oCB5GWd1Tco8m2dKmQLTWxjxd+8GdlDNkMQsMT6PcdiSST0rXqnhD5+3SIoNQzlCUZVhmL8Yy2wbYDG65B5MoVc8gGqNZazp2/V+pOBQnB2B70iGfqHIG0VqbjFprYz0De16oE7nHQ6YTzScFC7pw6cwHOLxTdS2JVDWDTHYpzLU2nWNgNVQcqjALBYV2LLNfVmM+Uc0MYur/IY/xsf60OriUeSbyCWMl6Ov0yz2YmVD8DHIrZ/Cxy1QcaSEH5XX9cAV2qiGfKHYG0VqbczTGRbZsU/FrtJRKNywnsglymf0VFBTtQq/rdaX2FlZcgURyxrae9wG8JHH7TiK9WSgoqkVBYRVYlhtf7nDh8M5BuQc1laKWWFpro1a3rccH4BUqjkwy2a3e/g3K6pJxRUTSKGIG0RjND+Vv+2I1MC4UxkNyj4fIZnYkn+gKW3Dh9HYl9BaWdQbRGM2z89sP/la3redbBv4WA6PiyHiR3l0t0d7CO+Xu3SXLDHJ7N3Q1N2IjKTT7Vj4JnXsN357yyDGjSF4gQs7ItTafAngeGJP68UR1WA50hV2RZdd990n+/kTSJVZ+e8+vc6ubz2f4+4xEvgVlX5PLaOL9yfo9zVKeZLwv1Q8QcsbPmnc0/11zxxf/R/uzX4Fl6DsNDv+NgZOb/uJYF38Xw5DvKoATKCj8B4D9JKnjUwU2Gw/89EksqvhV5Mud84v4/q8p/dJI6Ronv73nuWzj4q2Z2YhtAucIhPe22sOetn9L2ocK36CPLFiKMls9gKeT9rmqw4cj+eTLHbtT1bsrJQUSzRmfAMjsg0ucHx/au7U07GlN3becK7gz8lY6o/F9sBleTMUnJ71AhJyRbTRvBUvkwnx14+Cnw562rhH/Se/IwMnU54Z692roCu1AUu5hVyl+BZd8Xejr3I6QL2n/zpNaIBMv/Ho+YUBxMj9XNTjCNwZOvja4cblHlueX1S1FeZ0TYAZZni83jgvYXlOFkG8gWR+ZkiVWfnuPJdu4uDZTmrNxDn94r8M54j/RMzLwtbyb7oR88ox9DXSFDZGG1BmBH0Vf51ZcOPNVsrNISkN6RpwVlyJnxCsz8klXKnsHp/Q9iH/JA9uHPK1Pg3NF7dBMkuEb/hObQhtXKLM4BMIfnJDvFQBhuYeSAv7IP1t79bpUPkSSV9kao3lWttFczhlM2uqmFYypNkwKRbFrxP/1ufBeh1fuwcxY/vwcFBRZkD//ITxcVAPV7nnjV3HxrBuD546jr/MrKZ4o+V4PbXXTco3JvDDbaF6hmttiOR/kLOuzsKc1POI/sXtk4OsRuYcUFyGfPLzAioIiE3SFL010H1GFc+h1HQJwFRfPSHpfiSybobTW5pzc6sY9qrnmjPMjPGvWi/6S+xV56i1m5bZHUFZ3WEVbflKaM8TIultQBbc7jdzwn2gJe9o+kOR9htRe/Z0VDy9oEf5TyD2UaYQR8m2Cs2a3XAOQfTutkE+01sb12aZiu1K+0biw1kXWrsENz+4eGTh5Ve7xpJSQT8ptzSgoqlfOKU4eQG9nBy6d9cp9Vl32Apkqv71neXTvllxnREZv+E9uDXtaW6XMGXq9fpZBb1hqsVgaOPhD3fu67d5PvZKE0FueWjMbjy6yQje/JdpUQQZ8ODJjfNnxkVLuRVRUgeBv+eSUDAF+OOxurRja23Zc4udi//79BxjYbXmMgx/s7u5e5fV6pf0GLV2bh2X28zIE+Cs41FGitO6LKd/uHithrT8ycOLj//mv/7yiMZrzGEOqt3ULOWPz93/w/ia813Ehxc+6jcViefydt9/5nDH25J3/HwN7RK/XP2/QG/7Sf7z/omSDEpY0IZ8Xhc8MIyvrEQlaLoVx8Ywdbz61Su7l1N0obgaZaiKfNK3JNpnfTcU3Ggd+P7hheePIwElJX6Rt2bLlOb1eb4/hmoaj+7z7OoLBYG8wGJRu6fG3fNKQgtOno7h01oleV6sSC2NSbAXydO0/oaAoDx++LOlmPI3RPEdjMv86t7rRnoR8EskZIwNffxD2tEr6H8ZisegtlRYngB/NGDPBwS90e7vrvd3ePyR/dCJK1+bjmXU28PGaxPNJ9AyHDGfMtdbGp8Ketpj+3cVWIGV1b6Lc9hY4d8Ju2BDrABMVzSf9iP9N/GjY3VoqU86oZ2DvJ+WXIobalStXfpSUgcUi8XwyjEMd86TOGVPfu51fMiemP/Px7cVirB6uwGXUu9dIeT5Y+MYPbXy25Ib/ZEuM57OHObh7yOOYL3VxCDnj888+P8XAtiXtZ1SOrv379/cLS7WkfN5MCX+wnTXzMD6+L8a/M4yxsbcif6/ExZHf3vNcbnXD+XhfSsc3g9yGB9DrsqNvZ/KOlM6A1to8W2NcbM02mVvu8Y3mDm1Y/rrUOaOystJUZamyRbtEptJRb7e33uv1BlP8nNsJs0lB0Zp75JOJnNHX+R5CPsl+Np/c+/f/ahqFnHfbcjbWGSQJBXKLHyFfh9RvPTXGxTm51qb3Nabiminf0KMcfF/Y09YV9jjOSDmeSM54wdIBJulx45sc/Gi3t9spSz5ZZt9xx9n462Ds93L02r3X7gw5C2SSLPtmTP0/5LDxMSGfPDLkdpSE9zpOSz2GysrKJ6osVYdlfSMtVz7Z8c0TyMo6EPnfMuQMTJw/WsPAu8T+GiUUiOAI+lzOVJzwEqMxLtZoTMXasMch6beWxWJZYHnBUguGKoVs19i1z7vP1d3dLe0lNbrCPGE2i7Ynkky0e459JidYlVIgUZE9NfVS7d2Xml6v176z5Z33FXwfuzz5RCJaa5Nea2103pkzxCisQG45iF7Xdlw8c0Ipe2wSEc0ZDdFfRpR+puJmIBDoCgaCH3g/9SpqG0e8ojmjnrHI+6SYfkVVaoFMkm1ff7IoImfEi6F+5cqV2+UeRiJmkjPESPMeJH61E3dn1z4s8XMTZrFYcra8veUd1RYHIu9PnJ/v/3yPsDSUeyix0lY3meYdu74nkeKIh9QzyKSb4DiKPtdWpeeTaM5oi14Jly6GwXHQ+6l3q9LzSTRndMSwb02U0pdYd3MIhzo2KO1uOmHG0P9Cv8agN2xK44bbQj7Z5fV6Xw/+OaioDYNaa2NettHcrDEVv5LMjZJqLBBEvtHAN8BmcKfgs2MWzRkHVBDAk+UKy2IlFRUVigjxqeynpvQMMp0cgO2ZyCfy3Z2t1+tnT8kZmVIcgjw+zi/LnU80RrM2mjMU02xQKQUSxZ7EMrsf6907Int9pDfHYDAYVBvCE8Uh/OP/VOrHCjnDdOzaHt22nm+V9k5JKUus6ciSTywvWJZWVlU2RF9AKeIm4BT7LPrmXdKdzlP20SU1Z4hRawYRM4pe1yKp76YTHPj8wHLO+UGpnyupcbSsfGHl61I/1tT/Qx7jY/1Sd7JRawYRM3F3dkdgj9T5pGJlRY+321sMjnNSPlcipwPBQJXUxXErZ/Cxy0pp8yRGDTPIVDdx6ewu9Lpel/Ics16vn6XX64urLFXrAZV0g5wOxznvp1671+uV9BiA1tqcozEuWpNtKt4kQSOIaaXjEusu+DBYlluO8wbRfNLBwJTaDfKuOLg/GAx2bN68WeLzOuY5udbGd+44ryObWAtEpQGU5YDzeiyz14IxSfNJpKFbFuZVVVa9z8HrpXpuQsbR8twLz0meMyJnwa2NPjUspaajhgwiZvatu7OfWiPZt5PX6x2teK5ig7fbu1DJ+YSDX5ErZ5iOffem1trwjZqLA+pdYt3VKC6ddUudTzDR52p1tM+VMu494Tjt/dTbFQgEvMFgULLWOhqjeXa0z7KsOUNMhmQQMdH+rt+e3i1136VoPnEymS7R5ODhYDD42ubNm9XctyylMiSDiGE50BV1QFf0Lu67r0SGfFJoqbT0A1go1XMjGI53f9K9SupDUemQM8TE1ptXV/gECorUcnPtbBQUvQRd4Ti+/+uf8P1fJTnJGAwGbwaCgY+vXbs2aPiF4SEw/P9UPk/IGcFgsLa2trZR6h25+e09lv/7tOUgA/uZlM9NRNjjeDuWvz4Nl1h3NYheVwdCvo8R8l2X8sHRfPIuA0v2JsDhQCDg9HZ7W2XKGfUKvnhnWpRBRMlz/4T+F/ocw1zD8srKyP6uhPKJXDkDyri/JWGUQURF88lGTzFshheleqqw9An+OSj8gfZWVlYeTuB03JXufd0l0ueMRm2utfkTQNJmeIqg9vcgcWJVcAWHIu9PdIWSvj/ZvHlzaSAQeGvikNjMCDkDDG+9sfmNRVIXR357z6+11iZfJhYHMm+JdVdCPqlHX2ev1A/esmWLVa/Xt4jkk9FAINAiR87QGM3LtTVNdgYUS/VcKVAGiRu/gks+Jw51uKTOJxaLpdlgMNy6RFPIGYyxrjfeeMMTDAalnjFUnzPEUIEkiuMg7PoKqR974MCBnPHx8QMMLM/b7V3k9Xol7UaPyFnwa80MrEXq50qJQnqiGFagI/Dv6OvsQMjXg5BPkqVNRUXFsF6vLwWQEwwGJS0OIWdoTIvtDEzal5sqQAVyN4wVo9xWHMknF8804MOXe6R4bDRnSFYcWmvT41prkzPdckYyUYGIy8fDCw7CFTiKvs6tUnerT5Up3dCL6c+AuAz9mTdW7EmU2Y5gw95P5R5JooSckW0yfxa9KoCK4x5iLZCwlEsAxZnMJ+W2x+UeSqy01U0L5x27/km6h/B7iPkauPjuSS+rM6HcdiBdd3DOHHfDZlgl9yjEJNoNPR1w8NNgs0r9JffHvJkzvgKZVG7LQVndKeDu98FljLGxKrz6mFfuYUxl+up6DWPYlmEdIu80PORxLAp7HBfi/YDECmRSmW0hyusyrV3nj8l0f/xU8459ZwF4rNc0pxcOP8+6r8Jfcn/CL1mTE9JDZ69ibMyZ0flkwkI584nGaH4I4OpuS5S4kRsDJ/aF3S1JORuTnBlkkq5Qg7K636KgqF4JLV5kMz6+C4d3uqQ6zTjxPiNyJ7hSLhGVS9LvxE9ugUwqXZuPZ9bZwPlLAOak5BmqwI/ikKseh3em5JIajdGs1W3reQfAK6n4fJUYveE/0TIycGp72NOa9BOVqSmQSaVr87DMfkqNJ8+SaBS9nSXocyX13nZT/3+bGM/K9F8SR8Pu1tKhvW0pa7od25n0WA2eG0bI50XRsz8BY4+l9FnKNQsFhS+hrC4fjF1FyDeUyIdpjIvz9J+c38nAOjL4R5FhDr4v7GmrCe9t86XyQamdQaYqq9OioNAGXVFDRq+Te1016OuM67istrrRkFvT7Mvof38pyBlipNtq0tcZhnPVGzjUMTdyb3rmintJxCbyXCYWxygHdw95HAvPL5mzSqrigCx7sQ7vHIRNX4Hx8RL6WZjMQCRn+Jc8uCrscUjakR6yblZcN/c4nDWFGB//vWxjIIrGwY8PeRzzUxnC70Xe3bwh31Wsm/sb9LqKAeyL/OJDCOAecjvm+Zc8WBL2OGS9x10Z2937Ok/Cpn8RzppHAXwm93CIPDj4aWHGEHJGeK9D8iv37kYZBTIp5LsCm/4FcJ7JW7Iz0SjnbIN/yYOLwh7Hn+QezFTKKpBJdsPr6HXNo3yS/jj4UWHW8C99QDF3o0+lzAJBZNnlj+STPtdCQLmX1JA4cX78hv/k8/4lD/5S7pwhRrkFMqm38wxs+kL0ukoon6jfrZyx9MGSwY3L98s9nntRfoFM6us8PpFPxtO7L1ca4xwHlZgzxKinQCbZ576NS2cbAMj22ziJjZAzwm7HisGNy1+QeyyxUmdXi+2rPgDwAcrrFqC0zglGDc8UifMrNwa+blDDUmo66ptBphLyid2wCBfP1ABQxO/mJJoz3I6q0MYVj6q5OKDaGeROH77sAeBBR2APGKuReziZLJIzlj4oeW/jVFH3DHKn7atex8XTVQAk7YhOIq7c8J+oV2POEJMeM8ikkC8cOaClK+yBrtCCsrpayicpxvlgNGdI0r9Yauk1g0wK+UYjh5KEfHLhzEtyDydNhW/4T2wKbVwxN12LA2k3g9zNjpc/hisQBLAN8d8NSKaYyBlz0iZniEnPGeRONoMfNkMJLp5+nvJJQobTMWeISf8ZZKoPV++HrrAXZXX/goLI2fhMbXoQG84HOcvaNbjh2d0jAyclvWdebpkxg0wl5JPtq96DTX8/xsbeomO/okYmc4Z/yQOtmVYcyMgCmerVx96ObKsHp2XXjw0PuR2/HNy44r2RgZMZe9IzswsEt7qtFGJs7LXIlWtk+Ib/pH3I05Yb3utIarM7NcqsDDKdkO86Xn2sFbrC7dF8IhSLRu5hSWx0xH/CPeRpeyMTl1LToQKZajKf6Ao9WLd7Ne7LegVgD8k9rBQTcsa7IwOnPkpFb1u1owK5m5DvaiSflNV9hPK6UwBL1/63o0Nuxz8qpUGCElEGETOZT8bHd6VZS6JhDuYc8jhMVBziaAa5FyGfrJv7zyi3NSJ/vk3l+eTmiP/ELsoZM0cFMlO9LmF9LuST3Xj1d23IylLTHq8RDv5Z2NPmDHscA3IPRk1oiRWrkC8c6baSlfVzlbw/ieSMaG9bKo4YUYHEa+2jVyL55NLZLmHpIvdw7oYDRyhnJIYKJBFCPtm+ai36OueDc3c8F9WngJAzuoY8jkf9S+aUhj2Oi3IPSM2oQJKh1zUAu2EVnDU6ObtBRruhm0IbV6xN5G5w8jcU0pNpMp90Bs+BQ8pWmqOcY61/6YNuCZ+ZEWgGSYU6/XYc6vi5FPkkmjPm+pfOoeJIASqQVDm880oknxzqMIHzZDe5uyl85pCn9elozqBNlkTlyupM2PHNHpTVvRnvR+RWNz5hOnatX2tt0id3cIQQEgdaYhEiggqEEBFUIISIoAIhRAQVCCEiqEAIEUEFQogIKhBCRFCBECKCCoQQEVQghIigAiFEBBUIISKoQAgRQQVCiAgqEEJEUIEQIoIKhBARVCCEiKACIUQEFQghIqhACBFBBUKICCoQQkRQgRAiggqEEBFUIISIoAIhRAQVCCEi/jcAAP//laRc1omyvngAAAAASUVORK5CYII=
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - persistentvolumes
+                - serviceaccounts
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+                - pods
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - csi.truenas.io
+              resources:
+                - truenascsis
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - csi.truenas.io
+              resources:
+                - truenascsis/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - csi.truenas.io
+              resources:
+                - truenascsis/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - use
+                - watch
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshotclasses
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshotcontents
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshotcontents/status
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshots
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshots/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csinodes
+                - storageclasses
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - volumeattachments
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - volumeattachments/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: operator-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: operator
+            control-plane: controller-manager
+          name: operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: operator
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app.kubernetes.io/name: operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-bind-address=:8443
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                    command:
+                      - /manager
+                    env:
+                      - name: PROVISIONER_IMAGE
+                        value: registry.k8s.io/sig-storage/csi-provisioner@sha256:60751c039762f43183f9ec93ed137ea5acae9485f2b8a0fd0e1f26aed9979746
+                      - name: ATTACHER_IMAGE
+                        value: registry.k8s.io/sig-storage/csi-attacher@sha256:4f6b1289ffe62dbe3d2317dd938cd9dd3fb0a7c0088d505cde4effa1e0771dc2
+                      - name: SNAPSHOTTER_IMAGE
+                        value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:f4d58334dc3c0873e544f110a188be47e224ff7e99c6400d2fd7b35de9b962eb
+                      - name: RESIZER_IMAGE
+                        value: registry.k8s.io/sig-storage/csi-resizer@sha256:69e7bf7d929e5d98a5a74e753b45220e6e7b04f35163e48e8a5958bf1d819b4c
+                      - name: NODE_DRIVER_REGISTRAR_IMAGE
+                        value: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:aeecba5b171b50558bab359fdb8e28b9da185f666cef35cd87ac9784e51956c5
+                      - name: LIVENESS_PROBE_IMAGE
+                        value: registry.k8s.io/sig-storage/livenessprobe@sha256:7fe80915b3cb9fb1d09dbd300a0682cafa8ab93947cd3ddc3e15a8250621bf24
+                      - name: DRIVER_IMAGE
+                        value: quay.io/truenas_solutions/truenas-csi@sha256:7c764c16769ef741ecfc4f76b5e6727e371bcc6a7d0cd75dd58f51128a219231
+                    image: quay.io/truenas_solutions/truenas-csi-operator@sha256:b2fa8796028e6517b0856f6c6e806b6b53ac04ba694ce868d2872f0b83c967af
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 10m
+                        memory: 128Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: operator-controller-manager
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: operator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - storage
+    - csi
+    - truenas
+    - nfs
+    - iscsi
+    - zfs
+    - block
+    - file
+  links:
+    - name: TrueNAS
+      url: https://www.truenas.com
+    - name: Documentation
+      url: https://github.com/truenas/truenas-csi
+    - name: Source Code
+      url: https://github.com/truenas/truenas-csi
+  maintainers:
+    - email: support@truenas.com
+      name: TrueNAS
+  maturity: alpha
+  minKubeVersion: 1.26.0
+  provider:
+    name: TrueNAS
+    url: https://www.truenas.com
+  relatedImages:
+    - image: quay.io/truenas_solutions/truenas-csi-operator@sha256:b2fa8796028e6517b0856f6c6e806b6b53ac04ba694ce868d2872f0b83c967af
+      name: truenas-csi-operator
+    - image: quay.io/truenas_solutions/truenas-csi@sha256:7c764c16769ef741ecfc4f76b5e6727e371bcc6a7d0cd75dd58f51128a219231
+      name: truenas-csi
+    - image: registry.k8s.io/sig-storage/csi-attacher@sha256:4f6b1289ffe62dbe3d2317dd938cd9dd3fb0a7c0088d505cde4effa1e0771dc2
+      name: csi-attacher
+    - image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:aeecba5b171b50558bab359fdb8e28b9da185f666cef35cd87ac9784e51956c5
+      name: csi-node-driver-registrar
+    - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:60751c039762f43183f9ec93ed137ea5acae9485f2b8a0fd0e1f26aed9979746
+      name: csi-provisioner
+    - image: registry.k8s.io/sig-storage/csi-resizer@sha256:69e7bf7d929e5d98a5a74e753b45220e6e7b04f35163e48e8a5958bf1d819b4c
+      name: csi-resizer
+    - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:f4d58334dc3c0873e544f110a188be47e224ff7e99c6400d2fd7b35de9b962eb
+      name: csi-snapshotter
+    - image: registry.k8s.io/sig-storage/livenessprobe@sha256:7fe80915b3cb9fb1d09dbd300a0682cafa8ab93947cd3ddc3e15a8250621bf24
+      name: livenessprobe
+  version: 1.1.1

--- a/operators/truenas-csi/1.1.1/metadata/annotations.yaml
+++ b/operators/truenas-csi/1.1.1/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: truenas-csi
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # OpenShift version compatibility
+  com.redhat.openshift.versions: "v4.20"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/


### PR DESCRIPTION
Adds TrueNAS CSI operator v1.1.1 (NVMe-oF support plus security/maintenance updates).

- Channel: `stable`, replaces `truenas-csi.v1.0.0`
- All operator/driver/sidecar images digest-pinned; `relatedImages` populated
- Preflight (container) and OLM scorecard pass; installs cleanly via OLM (DeployableByOLM)