### PR TITLE
operator tawon-operator (3.1.0-rc1)

### DIFF
--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: tawon-operator
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: tawon-operator
+    control-plane: controller-manager
+  name: tawon-operator-eob-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/created-by: tawon-operator
+      control-plane: controller-manager

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: tawon-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: tawon-operator
+    control-plane: controller-manager
+  name: tawon-operator-eob-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/created-by: tawon-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-eob-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-eob-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: tawon
+  name: tawon-operator-eob-eob-admin
+rules:
+- apiGroups:
+  - tawon.mantisnet.com
+  resources:
+  - directives
+  - clusterdirectives
+  - streamstores
+  - streams
+  - dashboards
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - '*'
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - '*'

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-eob-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-eob-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: tawon
+  name: tawon-operator-eob-eob-operator
+rules:
+- apiGroups:
+  - tawon.mantisnet.com
+  resources:
+  - directives
+  - streams
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tawon.mantisnet.com
+  resources:
+  - streamstores
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-eob-viewer_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-eob-viewer_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: tawon
+  name: tawon-operator-eob-eob-viewer
+rules:
+- apiGroups:
+  - tawon.mantisnet.com
+  resources:
+  - directives
+  - clusterdirectives
+  - streamstores
+  - streams
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: tawon-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: tawon-operator
+  name: tawon-operator-eob-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-webhook-service_v1_service.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator-eob-webhook-service_v1_service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: tawon-operator
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: tawon-operator
+  name: tawon-operator-eob-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/created-by: tawon-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator.clusterserviceversion.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon-operator.clusterserviceversion.yaml
@@ -1,0 +1,1863 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "ClusterDirective",
+          "metadata": {
+            "name": "capture-coredns"
+          },
+          "spec": {
+            "condition": {
+              "equal": {
+                "field": "process.name",
+                "value": "coredns"
+              }
+            },
+            "debug": {
+              "logLevel": "debug"
+            },
+            "streams": [
+              {
+                "maxage": "6h0m0s",
+                "maxmsgs": 1000,
+                "name": "coredns",
+                "retentionPolicy": "Delete"
+              }
+            ],
+            "tasks": [
+              {
+                "config": {
+                  "filter": "port 53"
+                },
+                "task": "capture"
+              },
+              {
+                "config": {
+                  "name": "coredns",
+                  "type": "stream"
+                },
+                "task": "publish"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "Dashboard",
+          "metadata": {
+            "name": "tawon-dashboard"
+          },
+          "spec": null
+        },
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "Directive",
+          "metadata": {
+            "name": "capture-coredns"
+          },
+          "spec": {
+            "condition": {
+              "equal": {
+                "field": "process.name",
+                "value": "coredns"
+              }
+            },
+            "debug": {
+              "logLevel": "debug"
+            },
+            "streams": [
+              {
+                "maxage": "6h0m0s",
+                "maxmsgs": 1000,
+                "name": "coredns",
+                "retentionPolicy": "Delete"
+              }
+            ],
+            "tasks": [
+              {
+                "config": {
+                  "filter": "port 53"
+                },
+                "task": "capture"
+              },
+              {
+                "config": {
+                  "name": "coredns",
+                  "type": "stream"
+                },
+                "task": "publish"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "DirectiveBinding",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "directivebinding-sample",
+              "app.kubernetes.io/managed-by": "tawon-operator",
+              "app.kubernetes.io/name": "directivebinding",
+              "app.kubernetes.io/part-of": "tawon-operator",
+              "tawon.io/directive": "coredns-capture"
+            },
+            "name": "db-coredns-capture"
+          },
+          "spec": {
+            "directiveName": "coredns-capture",
+            "directiveNamespace": "",
+            "isClusterDirective": true,
+            "nodes": [
+              "worker-node-1",
+              "worker-node-3"
+            ]
+          }
+        },
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "Stream",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "tawon-operator",
+              "app.kubernetes.io/instance": "stream-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "stream",
+              "app.kubernetes.io/part-of": "tawon-operator"
+            },
+            "name": "stream-sample"
+          },
+          "spec": {
+            "maxage": "6h",
+            "maxbytes": "1G",
+            "maxmsgs": 100000,
+            "store": {
+              "name": "mystreamstore"
+            }
+          }
+        },
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "StreamStore",
+          "metadata": {
+            "name": "mystreamstore"
+          },
+          "spec": {
+            "defaults": {
+              "maxage": "240h",
+              "maxbytes": "1Gi",
+              "maxsize": 1000000
+            },
+            "limits": {
+              "max": 10000000,
+              "maxage": "2400h",
+              "maxbytes": "2Gi"
+            },
+            "persistentVolumeClaimRetentionPolicy": {
+              "whenDeleted": "Delete"
+            },
+            "volumeClaimTemplate": {
+              "metadata": {
+                "name": "mypvclaim"
+              },
+              "spec": {
+                "accessModes": [
+                  "ReadWriteOnce"
+                ],
+                "resources": {
+                  "requests": {
+                    "storage": "10Gi"
+                  }
+                },
+                "storageClassName": "ssd-csi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "tawon.mantisnet.com/v1alpha1",
+          "kind": "TopologyAggregator",
+          "metadata": {
+            "name": "topology-aggregator"
+          },
+          "spec": {
+            "messaging": {
+              "nats": {
+                "url": "nats://nats:4222"
+              }
+            },
+            "pod": {
+              "nodeSelector": {
+                "myNodeType": "nodeType1"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Logging & Tracing, Monitoring, Networking
+    containerImage: repo.f5.com/eob/images/tawon-operator@sha256:e8fdbd5f6ac6d16659402a3e1c78546e46b6b78e872e09c651c6f68bb46ed8b4
+    createdAt: "2026-07-03T22:12:55Z"
+    description: Tawon is a cloud-native observability fabric for deeply instrumenting microservice-based applications.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=2.23.0 <3.1.0-rc1'
+    operators.openshift.io/valid-subscription: Mantisnet Tawon Operator Subscription
+    operators.operatorframework.io/builder: operator-sdk-v1.34.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    support: MantisNet
+  name: tawon-operator.v3.1.0-rc1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ClusterDirective is the Schema for the clusterdirectives API.
+      displayName: Cluster Tawon Directive
+      kind: ClusterDirective
+      name: clusterdirectives.tawon.mantisnet.com
+      resources:
+      - kind: ConfigMap
+        name: tawon-directive
+        version: v1
+      - kind: DaemonSet
+        name: tawon-directive
+        version: v1
+      specDescriptors:
+      - description: Conditions are the conditions that must be met for the directive to be applied.
+        displayName: Condition
+        path: condition
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and[0].and
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and[0].and[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].and[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].and[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].and[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.and[0].and[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].and[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].and[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.and[0].or
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and[0].or[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].or[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].or[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].or[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.and[0].or[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].or[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].or[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.or[0].and
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.or[0].and[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].and[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].and[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].and[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or[0].and[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].and[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].and[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or[0].or
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.or[0].or[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].or[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].or[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].or[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or[0].or[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].or[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].or[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.regex
+      - description: Container options. See ContainerSpec.
+        displayName: Container
+        path: container
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: container.securityContext
+      - description: DaemonSet options. See DaemonSetSpec.
+        displayName: Daemon Set
+        path: daemonSet
+      - description: Debugging configuration.
+        displayName: Debug
+        path: debug
+      - description: Enable Deadlock Detector
+        displayName: Deadlock Detector
+        path: debug.deadlockDetector
+      - description: Debug flags enable extra logging in different components. See DebugFlag for the list of available flags.
+        displayName: Debug
+        path: debug.debug
+      - description: Extra flags to pass to the executable.
+        displayName: Extra Flags
+        path: debug.extraFlags
+      - description: Logging level. One of "trace", "debug", "info", "warn", or "error".
+        displayName: Log Level
+        path: debug.logLevel
+      - description: Silent flags disable some non-critical logging in different components. See SilentFlag for the list of available flags.
+        displayName: Silent
+        path: debug.silent
+      - description: DirectiveBindingRef is the name of the DirectiveBinding resource that controls targeted node placement for this directive. When set, the directive's DaemonSet is deployed only on nodes listed in the DirectiveBinding. Set by the operator when directiveBinder.enabled is true.
+        displayName: Directive Binding Ref
+        path: directiveBindingRef
+      - description: Duration is the amount of time the directive should run. If StopAt is specified, StopAt takes precedence over Duration.
+        displayName: Duration
+        path: duration
+      - description: Enabled indicates whether the directive is enabled. If not specified, defaults to true.
+        displayName: Enabled
+        path: enabled
+      - description: Container image options.
+        displayName: Image
+        path: image
+      - description: Kernel Headers options.
+        displayName: Kernel Headers
+        path: kernelHeaders
+      - description: Container image options. This is the image used for the kernel headers container if the strategy is "Container". Container image is required if the strategy is "Container".
+        displayName: Image
+        path: kernelHeaders.image
+      - description: 'Compute Resources required by the kernel headers init container. Only valid with the "container" strategy. Resources required by the kernel headers init container are not very great, and it only runs for a few seconds. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: kernelHeaders.resources
+      - description: Strategy to use for installing kernel headers.
+        displayName: Strategy
+        path: kernelHeaders.strategy
+      - description: Default messaging configuration. This is the default configuration for messaging tasks (subscribe & publish).
+        displayName: Messaging
+        path: messaging
+      - description: Message bus NATS configuration.
+        displayName: NATS
+        path: messaging.nats
+      - description: AuthEnabled controls whether NATS server authentication is enabled. A nil value means no explicit preference. Operator-managed StreamStores set this to true by default, while custom StreamStores remain unauthenticated unless this is explicitly true.
+        displayName: Auth Enabled
+        path: messaging.nats.authEnabled
+      - description: NATS Client name.
+        displayName: Client Name
+        path: messaging.nats.clientName
+      - description: NATS server URL.
+        displayName: URL
+        path: messaging.nats.url
+      - description: "Message bus type. \n Defaults to \"nats\". Currently only \"nats\" is supported."
+        displayName: Type
+        path: messaging.type
+      - description: Prometheus monitoring.
+        displayName: Monitoring
+        path: monitoring
+      - description: Disable monitoring. Monitoring is enabled by default.
+        displayName: Disabled
+        path: monitoring.disabled
+      - description: Namespace if the prefix added to the metrics.
+        displayName: Namespace
+        path: monitoring.namespace
+      - description: Path to expose metrics on.
+        displayName: Path
+        path: monitoring.path
+      - description: Port to expose metrics on.
+        displayName: Port
+        path: monitoring.port
+      - description: Exposed port name.
+        displayName: Port Name
+        path: monitoring.portName
+      - description: Pod options. See PodSpec.
+        displayName: Pod
+        path: pod
+      - description: If specified, the pod's scheduling constraints
+        displayName: Affinity
+        path: pod.affinity
+      - description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations'
+        displayName: Annotations
+        path: pod.annotations
+      - description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. If not set, the default behavior is to not mount the service account token (for security compliance). Set to true to enable access to the Kubernetes API from within the pod.
+        displayName: Automount Service Account Token
+        path: pod.automountServiceAccountToken
+      - description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+        displayName: Labels
+        path: pod.labels
+      - description: Name of the pod.
+        displayName: Name
+        path: pod.name
+      - description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+        displayName: Node Selector
+        path: pod.nodeSelector
+      - description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+        displayName: Service Account Name
+        path: pod.serviceAccountName
+      - description: 'If specified, the pod''s tolerations. More info: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/'
+        displayName: Tolerations
+        path: pod.tolerations
+      - description: StartAt is the time at which the directive should start being applied. If not specified, defaults to the current time.
+        displayName: Start At
+        path: startAt
+      - description: StopAt is the time at which the directive should stop being applied. If not specified, defaults to StartAt plus Duration, or StartAt plus the configured maximum age when Duration is not specified.
+        displayName: Stop At
+        path: stopAt
+      - description: StreamStores refereces StreamStores that will be used by the Directive. The StreamStores referenced can already exist, in which case the Directive could use them, or they can be created/deleted by the Directive. If they are created by this Directive, they will use the limits specified, otherwise, the limits will be ignored. By default, StreamStores created by a Directive persist after the Directive is deleted. This can be changed by setting the autoManage option.
+        displayName: Stream Stores
+        path: streamStores
+      - description: Tasks pipeline.
+        displayName: Tasks
+        path: tasks
+      - description: Config is an opaque map for the task's configuration. Each task has its own configuration schema.
+        displayName: Config
+        path: tasks[0].config
+      - description: Task is the name of the task.
+        displayName: Task
+        path: tasks[0].task
+      statusDescriptors:
+      - description: Directive Conditions.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: Dashboard is the Schema for the dashboards API
+      displayName: Dashboard
+      kind: Dashboard
+      name: dashboards.tawon.mantisnet.com
+      specDescriptors:
+      - description: Auth configures dashboard authentication.
+        displayName: Auth
+        path: auth
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: auth.oauth2Proxy.container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: auth.oauth2Proxy.container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: auth.oauth2Proxy.container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: auth.oauth2Proxy.container.securityContext
+      - description: Dashboard is the internal spec for the dashboard. This configuration use used by the dashboard itself. The container image and log level are examples of the internal spec.
+        displayName: Dashboard
+        path: dashboard
+      - description: Container is the container spec for the dashboard.
+        displayName: Container
+        path: dashboard.container
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: dashboard.container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: dashboard.container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: dashboard.container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: dashboard.container.securityContext
+      - description: Image is the container image for the dashboard.
+        displayName: Image
+        path: dashboard.image
+      - description: LogLevel is the log level for the dashboard.
+        displayName: Log Level
+        path: dashboard.logLevel
+      - description: Service is the service spec for the dashboard.
+        displayName: Service
+        path: dashboard.service
+      - description: Enable is the flag to enable the service creation.
+        displayName: Enable
+        path: dashboard.service.enable
+      - description: Port is the port for the service. Only applicable if the service is enabled.
+        displayName: Port
+        path: dashboard.service.port
+      - description: OAuth is the configuration for OAuth Openshift Proxy.
+        displayName: OAuth
+        path: oauth
+      - description: Container is the container spec for the OAuth.
+        displayName: Container
+        path: oauth.container
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: oauth.container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: oauth.container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: oauth.container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: oauth.container.securityContext
+      - description: Debug enables the debug mode for the OAuth. It adds `debug` in extraArgs. If you set to false, it will remove it.
+        displayName: Debug
+        path: oauth.debug
+      - description: Enabled is the flag to enable OAuth.
+        displayName: Enabled
+        path: oauth.enabled
+      - description: ExtraArgs are the arguments for the OAuth.
+        displayName: Extra Args
+        path: oauth.extraArgs
+      - description: Image is the container image for the OAuth.
+        displayName: Image
+        path: oauth.image
+      - description: PodSpec is the pod spec for the dashboard.
+        displayName: Pod Spec
+        path: pod
+      - description: If specified, the pod's scheduling constraints
+        displayName: Affinity
+        path: pod.affinity
+      - description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations'
+        displayName: Annotations
+        path: pod.annotations
+      - description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. If not set, the default behavior is to not mount the service account token (for security compliance). Set to true to enable access to the Kubernetes API from within the pod.
+        displayName: Automount Service Account Token
+        path: pod.automountServiceAccountToken
+      - description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+        displayName: Labels
+        path: pod.labels
+      - description: Name of the pod.
+        displayName: Name
+        path: pod.name
+      - description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+        displayName: Node Selector
+        path: pod.nodeSelector
+      - description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+        displayName: Service Account Name
+        path: pod.serviceAccountName
+      - description: 'If specified, the pod''s tolerations. More info: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/'
+        displayName: Tolerations
+        path: pod.tolerations
+      - description: Route is the configuration for the route in order to access the dashboard externally.
+        displayName: Route
+        path: route
+      - description: Domain is the fully qualified domain name for the route. If this is set, the SubDomain and IngressControllerName will be ignored.
+        displayName: Domain
+        path: route.domain
+      - description: Ingress controller for the route.
+        displayName: Ingress Controller Name
+        path: route.ingressControllerName
+      - description: SubDomain is the host for the route.
+        displayName: Sub Domain
+        path: route.subDomain
+      statusDescriptors:
+      - description: Conditions represent the latest available observations of an object's state.
+        displayName: Conditions
+        path: conditions
+      - description: Domain is the fully qualified domain name for the route.
+        displayName: Domain
+        path: domain
+      version: v1alpha1
+    - description: DirectiveBinding is the Schema for the directivebindings API DirectiveBinding coordinates between topology pods and the operator to enable targeted directive deployment. Topology pods running on each node evaluate directive conditions against local pods and update this resource to indicate which nodes should run the directive's DaemonSet.
+      displayName: Directive Binding
+      kind: DirectiveBinding
+      name: directivebindings.tawon.mantisnet.com
+      version: v1alpha1
+    - description: A Directive allows to define a Tawon task pipeline that will be applied to a Kubernetes cluster.
+      displayName: Tawon Directive
+      kind: Directive
+      name: directives.tawon.mantisnet.com
+      resources:
+      - kind: ConfigMap
+        name: tawon-directive
+        version: v1
+      - kind: DaemonSet
+        name: tawon-directive
+        version: v1
+      specDescriptors:
+      - description: Conditions are the conditions that must be met for the directive to be applied.
+        displayName: Condition
+        path: condition
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and[0].and
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and[0].and[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].and[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].and[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].and[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.and[0].and[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].and[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].and[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.and[0].or
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.and[0].or[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].or[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].or[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].or[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.and[0].or[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.and[0].or[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].or[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.or[0].and
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.or[0].and[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].and[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].and[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].and[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or[0].and[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].and[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].and[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or[0].or
+      - description: And is a list of conditions that must be met.
+        displayName: And
+        path: condition.or[0].or[0].and
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].or[0].and[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].or[0].and[0].regex
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].or[0].equal
+      - description: Or is a list of conditions, any of which must be met.
+        displayName: Or
+        path: condition.or[0].or[0].or
+      - description: Equal is a textual equality condition.
+        displayName: Equal
+        path: condition.or[0].or[0].or[0].equal
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].or[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.or[0].regex
+      - description: Regex is a regular expression condition.
+        displayName: Regex
+        path: condition.regex
+      - description: Container options. See ContainerSpec.
+        displayName: Container
+        path: container
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: container.securityContext
+      - description: DaemonSet options. See DaemonSetSpec.
+        displayName: Daemon Set
+        path: daemonSet
+      - description: Debugging configuration.
+        displayName: Debug
+        path: debug
+      - description: Enable Deadlock Detector
+        displayName: Deadlock Detector
+        path: debug.deadlockDetector
+      - description: Debug flags enable extra logging in different components. See DebugFlag for the list of available flags.
+        displayName: Debug
+        path: debug.debug
+      - description: Extra flags to pass to the executable.
+        displayName: Extra Flags
+        path: debug.extraFlags
+      - description: Logging level. One of "trace", "debug", "info", "warn", or "error".
+        displayName: Log Level
+        path: debug.logLevel
+      - description: Silent flags disable some non-critical logging in different components. See SilentFlag for the list of available flags.
+        displayName: Silent
+        path: debug.silent
+      - description: DirectiveBindingRef is the name of the DirectiveBinding resource that controls targeted node placement for this directive. When set, the directive's DaemonSet is deployed only on nodes listed in the DirectiveBinding. Set by the operator when directiveBinder.enabled is true.
+        displayName: Directive Binding Ref
+        path: directiveBindingRef
+      - description: Duration is the amount of time the directive should run. If StopAt is specified, StopAt takes precedence over Duration.
+        displayName: Duration
+        path: duration
+      - description: Enabled indicates whether the directive is enabled. If not specified, defaults to true.
+        displayName: Enabled
+        path: enabled
+      - description: Container image options.
+        displayName: Image
+        path: image
+      - description: Kernel Headers options.
+        displayName: Kernel Headers
+        path: kernelHeaders
+      - description: Container image options. This is the image used for the kernel headers container if the strategy is "Container". Container image is required if the strategy is "Container".
+        displayName: Image
+        path: kernelHeaders.image
+      - description: 'Compute Resources required by the kernel headers init container. Only valid with the "container" strategy. Resources required by the kernel headers init container are not very great, and it only runs for a few seconds. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: kernelHeaders.resources
+      - description: Strategy to use for installing kernel headers.
+        displayName: Strategy
+        path: kernelHeaders.strategy
+      - description: Default messaging configuration. This is the default configuration for messaging tasks (subscribe & publish).
+        displayName: Messaging
+        path: messaging
+      - description: Message bus NATS configuration.
+        displayName: NATS
+        path: messaging.nats
+      - description: AuthEnabled controls whether NATS server authentication is enabled. A nil value means no explicit preference. Operator-managed StreamStores set this to true by default, while custom StreamStores remain unauthenticated unless this is explicitly true.
+        displayName: Auth Enabled
+        path: messaging.nats.authEnabled
+      - description: NATS Client name.
+        displayName: Client Name
+        path: messaging.nats.clientName
+      - description: NATS server URL.
+        displayName: URL
+        path: messaging.nats.url
+      - description: "Message bus type. \n Defaults to \"nats\". Currently only \"nats\" is supported."
+        displayName: Type
+        path: messaging.type
+      - description: Prometheus monitoring.
+        displayName: Monitoring
+        path: monitoring
+      - description: Disable monitoring. Monitoring is enabled by default.
+        displayName: Disabled
+        path: monitoring.disabled
+      - description: Namespace if the prefix added to the metrics.
+        displayName: Namespace
+        path: monitoring.namespace
+      - description: Path to expose metrics on.
+        displayName: Path
+        path: monitoring.path
+      - description: Port to expose metrics on.
+        displayName: Port
+        path: monitoring.port
+      - description: Exposed port name.
+        displayName: Port Name
+        path: monitoring.portName
+      - description: Pod options. See PodSpec.
+        displayName: Pod
+        path: pod
+      - description: If specified, the pod's scheduling constraints
+        displayName: Affinity
+        path: pod.affinity
+      - description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations'
+        displayName: Annotations
+        path: pod.annotations
+      - description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. If not set, the default behavior is to not mount the service account token (for security compliance). Set to true to enable access to the Kubernetes API from within the pod.
+        displayName: Automount Service Account Token
+        path: pod.automountServiceAccountToken
+      - description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+        displayName: Labels
+        path: pod.labels
+      - description: Name of the pod.
+        displayName: Name
+        path: pod.name
+      - description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+        displayName: Node Selector
+        path: pod.nodeSelector
+      - description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+        displayName: Service Account Name
+        path: pod.serviceAccountName
+      - description: 'If specified, the pod''s tolerations. More info: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/'
+        displayName: Tolerations
+        path: pod.tolerations
+      - description: StartAt is the time at which the directive should start being applied. If not specified, defaults to the current time.
+        displayName: Start At
+        path: startAt
+      - description: StopAt is the time at which the directive should stop being applied. If not specified, defaults to StartAt plus Duration, or StartAt plus the configured maximum age when Duration is not specified.
+        displayName: Stop At
+        path: stopAt
+      - description: StreamStores refereces StreamStores that will be used by the Directive. The StreamStores referenced can already exist, in which case the Directive could use them, or they can be created/deleted by the Directive. If they are created by this Directive, they will use the limits specified, otherwise, the limits will be ignored. By default, StreamStores created by a Directive persist after the Directive is deleted. This can be changed by setting the autoManage option.
+        displayName: Stream Stores
+        path: streamStores
+      - description: Tasks pipeline.
+        displayName: Tasks
+        path: tasks
+      - description: Config is an opaque map for the task's configuration. Each task has its own configuration schema.
+        displayName: Config
+        path: tasks[0].config
+      - description: Task is the name of the task.
+        displayName: Task
+        path: tasks[0].task
+      statusDescriptors:
+      - description: Directive Conditions.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: Stream is a persistent Tawon data stream.
+      displayName: Stream
+      kind: Stream
+      name: streams.tawon.mantisnet.com
+      statusDescriptors:
+      - description: Stream Conditions.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: StreamStore is the Schema for the streamstores API
+      displayName: Stream Store
+      kind: StreamStore
+      name: streamstores.tawon.mantisnet.com
+      specDescriptors:
+      - description: Container options.
+        displayName: Container
+        path: jetstream.container
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: jetstream.container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: jetstream.container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: jetstream.container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: jetstream.container.securityContext
+      - description: StatefulSet options.
+        displayName: Stateful Set
+        path: jetstream.daemonSet
+      - description: Container image options.
+        displayName: Image
+        path: jetstream.image
+      - description: NATS server configuration including authentication settings.
+        displayName: NATS
+        path: jetstream.nats
+      - description: AuthEnabled controls whether NATS server authentication is enabled. A nil value means no explicit preference. Operator-managed StreamStores set this to true by default, while custom StreamStores remain unauthenticated unless this is explicitly true.
+        displayName: Auth Enabled
+        path: jetstream.nats.authEnabled
+      - description: NATS Client name.
+        displayName: Client Name
+        path: jetstream.nats.clientName
+      - description: NATS server URL.
+        displayName: URL
+        path: jetstream.nats.url
+      - description: NetworkPolicy enables or disables the creation of a NetworkPolicy for the JetStream.
+        displayName: Network Policy
+        path: jetstream.networkPolicy
+      - description: Pod options.
+        displayName: Pod
+        path: jetstream.pod
+      - description: If specified, the pod's scheduling constraints
+        displayName: Affinity
+        path: jetstream.pod.affinity
+      - description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations'
+        displayName: Annotations
+        path: jetstream.pod.annotations
+      - description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. If not set, the default behavior is to not mount the service account token (for security compliance). Set to true to enable access to the Kubernetes API from within the pod.
+        displayName: Automount Service Account Token
+        path: jetstream.pod.automountServiceAccountToken
+      - description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+        displayName: Labels
+        path: jetstream.pod.labels
+      - description: Name of the pod.
+        displayName: Name
+        path: jetstream.pod.name
+      - description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+        displayName: Node Selector
+        path: jetstream.pod.nodeSelector
+      - description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+        displayName: Service Account Name
+        path: jetstream.pod.serviceAccountName
+      - description: 'If specified, the pod''s tolerations. More info: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/'
+        displayName: Tolerations
+        path: jetstream.pod.tolerations
+      statusDescriptors:
+      - description: StreamStore Conditions.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: TopologyAggregator is a deprecated no-op CRD retained for compatibility.
+      displayName: Tawon Topology Aggregator
+      kind: TopologyAggregator
+      name: topologyaggregators.tawon.mantisnet.com
+      specDescriptors:
+      - description: Container options. See TawonContainerSpec.
+        displayName: Container
+        path: container
+      - description: Disable container. If enabled, this will cause the container to do nothing. It will not start tawon, it will just sleep indefinitely. Only useful for debugging.
+        displayName: Disabled
+        path: container.disabled
+      - description: Name of container.
+        displayName: Name
+        path: container.name
+      - description: 'Compute Resources required by the container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: container.resources
+      - description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+        displayName: Security Context
+        path: container.securityContext
+      - description: debugging configuration.
+        displayName: Debug
+        path: debug
+      - description: Enable Deadlock Detector
+        displayName: Deadlock Detector
+        path: debug.deadlockDetector
+      - description: Debug flags enable extra logging in different components. See DebugFlag for the list of available flags.
+        displayName: Debug
+        path: debug.debug
+      - description: Extra flags to pass to the executable.
+        displayName: Extra Flags
+        path: debug.extraFlags
+      - description: Logging level. One of "trace", "debug", "info", "warn", or "error".
+        displayName: Log Level
+        path: debug.logLevel
+      - description: Silent flags disable some non-critical logging in different components. See SilentFlag for the list of available flags.
+        displayName: Silent
+        path: debug.silent
+      - description: Deployment options. See TopologyDeploymentSpec.
+        displayName: Deployment
+        path: deployment
+      - description: "Container image options. \n Container image defaults to \"repo.f5.com/eob/images/tawon:ubi-build-xx\"."
+        displayName: Image
+        path: image
+      - description: Default messaging configuration. This is the default configuration for subscribing to the topology stream.
+        displayName: Messaging
+        path: messaging
+      - description: Message bus NATS configuration.
+        displayName: NATS
+        path: messaging.nats
+      - description: AuthEnabled controls whether NATS server authentication is enabled. A nil value means no explicit preference. Operator-managed StreamStores set this to true by default, while custom StreamStores remain unauthenticated unless this is explicitly true.
+        displayName: Auth Enabled
+        path: messaging.nats.authEnabled
+      - description: NATS Client name.
+        displayName: Client Name
+        path: messaging.nats.clientName
+      - description: NATS server URL.
+        displayName: URL
+        path: messaging.nats.url
+      - description: "Message bus type. \n Defaults to \"nats\". Currently only \"nats\" is supported."
+        displayName: Type
+        path: messaging.type
+      - description: Prometheus monitoring.
+        displayName: Monitoring
+        path: monitoring
+      - description: Disable monitoring. Monitoring is enabled by default.
+        displayName: Disabled
+        path: monitoring.disabled
+      - description: Namespace if the prefix added to the metrics.
+        displayName: Namespace
+        path: monitoring.namespace
+      - description: Path to expose metrics on.
+        displayName: Path
+        path: monitoring.path
+      - description: Port to expose metrics on.
+        displayName: Port
+        path: monitoring.port
+      - description: Exposed port name.
+        displayName: Port Name
+        path: monitoring.portName
+      - description: Pod options. See TawonPodSpec.
+        displayName: Pod
+        path: pod
+      - description: If specified, the pod's scheduling constraints
+        displayName: Affinity
+        path: pod.affinity
+      - description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations'
+        displayName: Annotations
+        path: pod.annotations
+      - description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. If not set, the default behavior is to not mount the service account token (for security compliance). Set to true to enable access to the Kubernetes API from within the pod.
+        displayName: Automount Service Account Token
+        path: pod.automountServiceAccountToken
+      - description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+        displayName: Labels
+        path: pod.labels
+      - description: Name of the pod.
+        displayName: Name
+        path: pod.name
+      - description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+        displayName: Node Selector
+        path: pod.nodeSelector
+      - description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+        displayName: Service Account Name
+        path: pod.serviceAccountName
+      - description: 'If specified, the pod''s tolerations. More info: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/'
+        displayName: Tolerations
+        path: pod.tolerations
+      - description: Controller service options.
+        displayName: Service
+        path: service
+      statusDescriptors:
+      - description: Conditions describe that TopologyAggregator is deprecated and no longer creates topology aggregation resources.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+  description: Tawon is a cloud-native observability fabric for deeply instrumenting microservice-based applications.
+  displayName: Tawon
+  icon:
+  - base64data: PHN2ZyB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgdmlld0JveD0iMCAwIDUxMiA1MTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMF8yMTZfOTYpIj4KPHBhdGggZD0iTTI4OC4xMjEgMjY2LjQxN0MzMjAgMjY2LjQxNyAyNTYuNjIgNDMzLjA4MyA0NDQuNTA0IDM4OS4xMTVDMzE5LjYyMiA0OTUuNTgzIDIyNS4xMTggNDIyLjY2NyAxOTguOTA5IDM4Mi43NUMxNzEuMDQxIDM0MC4zMTMgMTYyLjExNSAyNjYuNDE3IDIxMy40OTQgMjQzLjI4MUMyMzQuODczIDIzMy42NTYgMjU2LjYxOSAyNjYuNDE3IDI4OC4xMjEgMjY2LjQxN1oiIGZpbGw9IiM5Q0M0NTgiLz4KPHBhdGggZD0iTTM4NC44NCAyMjYuMzMzQzM5Mi45MzYgMjMwLjA3MyAzOTMuMzU2IDIwMi42ODcgMzgxLjAwOCAxNzQuMjcxQzM4MS4wMDggMTc0LjI3MSAzNzIuMTI0IDE3Mi42NjcgMzYxLjYyNCAxOTMuNUMzNjEuNjI0IDE5My41IDM3Mi4xMjQgMjAzLjkxNyAzODQuODQgMjI2LjMzM1oiIGZpbGw9IiM5Q0M0NTgiLz4KPHBhdGggZD0iTTM3NC43OTIgNDMyLjU5NEMzNzQuNTE5IDQzMS4wOTQgMzc0LjQzNSA0MjkuNTYzIDM3NC4wOTkgNDI4LjA3M0MzNzEuODgzIDQxOC4zNjUgMzY4LjAyOSA0MDguNjg4IDM2MS42MjQgNDAxLjgyM0MzNjMuMTk5IDQxMC45NjkgMzYxLjIzNSA0MTkuNTIxIDM1OC4zNDggNDI3LjQ1OEMzNTYuODY3IDQzMS40MjcgMzU1LjEwMyA0MzUuMjYgMzUzLjExOSA0MzguOTQ4QzM1Mi45NzIgNDM5LjIwOCAzNTIuODA0IDQzOS40OSAzNTIuNjU3IDQzOS43NUMzNTkuODYgNDM3Ljk1OCAzNjcuMjQyIDQzNS41OTQgMzc0Ljc5MiA0MzIuNTk0WiIgZmlsbD0iIzQyNDI0MiIvPgo8cGF0aCBkPSJNMjEwLjE2NiAzMTAuMzg1QzIzMy4yMTQgMzEyLjIxOSAyNTYuNTc4IDMxMC41MSAyNzcuNjMxIDMwMy41MzFDMjU1LjQ0MyAzMDMuNTk0IDIzNC40MDEgMjk4LjE3NyAyMTQuOTg1IDI5MC4xMDRDMjA1LjI2MiAyODYuMDczIDE5NS45MjcgMjgxLjI4MSAxODYuOTgxIDI3Ni4wMUMxODUuNzg0IDI3NS4yOTIgMTg0LjU3NiAyNzQuNTMxIDE4My4zNjggMjczLjc4MUMxNzkuMTA1IDI4My4zNjUgMTc2Ljg2OSAyOTQuMDgzIDE3Ni41MjIgMzA1LjMxMkMxODcuNjc0IDMwNy43NCAxOTguOTA5IDMwOS41MSAyMTAuMTY2IDMxMC4zODVaIiBmaWxsPSIjNDI0MjQyIi8+CjxwYXRoIGQ9Ik0zMTkuNjIyIDQwMS44MzNDMzE2IDQxMy43NSAzMDguNDgxIDQyMi44NjUgMzAwLjI0OSA0MzAuNjg4QzI5Ni4wOTEgNDM0LjU1MiAyOTEuNjkxIDQzOC4wOTQgMjg3LjExMyA0NDEuMzIzQzI5Ni42ODkgNDQzLjM3NSAzMDYuODU0IDQ0NC41MSAzMTcuNTg1IDQ0NC40MDZDMzE3LjkzMiA0NDMuMTg4IDMxOC4zNDEgNDQxLjk2OSAzMTguNjU2IDQ0MC43MTlDMzIxLjg4IDQyNy43NzEgMzIzLjEyOSA0MTMuODc1IDMxOS42MjIgNDAxLjgzM1oiIGZpbGw9IiM0MjQyNDIiLz4KPHBhdGggZD0iTTI2Mi42MzYgNDE4Ljk2OUMyNzAuNTEyIDQxMi4yODEgMjc3LjkxNCA0MDUuMDEgMjg0LjI1NyAzOTYuOTQ4QzI5MC41NzggMzg4LjkxNyAyOTUuODQ5IDM3OS45OSAyOTguNjMyIDM3MC41OTRDMjg2LjUzNSAzODYuMTM1IDI2OS4yMiAzOTQuNjU2IDI1MS44ODQgNDAxLjA4M0MyNDMuMTE2IDQwNC4yMjkgMjM0LjE0OSA0MDYuNzQgMjI1LjA4NyA0MDguNzZDMjI0LjM2MiA0MDguOTI3IDIyMy41ODUgNDA5LjA0MiAyMjIuODUgNDA5LjE4OEMyMzAuODQxIDQxNi4wMjEgMjQwLjIzOSA0MjIuNTgzIDI1MC45MzkgNDI4LjE4OEMyNTQuOTE4IDQyNS4yMjkgMjU4LjgzNSA0MjIuMTY3IDI2Mi42MzYgNDE4Ljk2OVoiIGZpbGw9IiM0MjQyNDIiLz4KPHBhdGggZD0iTTI3Ny42MiAzMzkuMzMzQzI2MC4wMzIgMzQ5LjI4MSAyNDAuNzk1IDM1My43ODEgMjIyLjAxIDM1NC40MTdDMjEyLjYwMiAzNTQuNzcxIDIwMy4yNTYgMzU0LjE1NiAxOTQuMTMxIDM1Mi44NDRDMTkwLjcyOSAzNTIuMzMzIDE4Ny4yMjIgMzUxLjY4OCAxODMuNzY3IDM1MC45NDhDMTg3LjYzMiAzNjIuNDY5IDE5Mi43NjYgMzczLjM4NSAxOTguOTA5IDM4Mi43NUMxOTguOTkzIDM4Mi44ODUgMTk5LjEwOSAzODMuMDEgMTk5LjE4MiAzODMuMTU2QzIwOC42MDEgMzgxIDIxNy44MzEgMzc4LjMxMyAyMjYuNjUxIDM3NC43MjlDMjQ2LjU5MiAzNjYuNzYgMjY0LjU4OSAzNTQuNjM1IDI3Ny42MiAzMzkuMzMzWiIgZmlsbD0iIzQyNDI0MiIvPgo8cGF0aCBkPSJNMjg4LjEyMSAyNjYuNDE3QzI4NC4yMjUgMjY2LjQxNyAyODAuNDc3IDI2NS45MDYgMjc2Ljg2NCAyNjUuMDUyQzI4Ni45NzYgMjc1LjgwMiAyOTguNjExIDI5My41NDIgMjc3LjYyIDMwMy41MjFDMjc3LjYyIDMwMy41MjEgMjk4LjYyMSAzMTguNSAyNzcuNjIgMzM5LjMzM0MyNzcuNjIgMzM5LjMzMyAzMDkuMTIyIDMzOS4zMzMgMjk4LjYyMSAzNzAuNTgzQzI5OC42MjEgMzcwLjU4MyAzMzAuMTIzIDM3MC41ODMgMzE5LjYyMiA0MDEuODMzQzMxOS42MjIgNDAxLjgzMyAzNDAuNjIzIDM5MS40MTcgMzYxLjYyNCA0MDEuODMzQzM2MS42MjQgNDAxLjgzMyAzOTkuNjg4IDM5Mi40NTggNDAzLjI2OSA0MTguNjE0QzQxNi42MDQgNDEwLjg0NCA0MzAuMzM5IDQwMS4xODcgNDQ0LjUwNCAzODkuMTE0QzI1Ni42MiA0MzMuMDgzIDMyMC4wMTEgMjY2LjQxNyAyODguMTIxIDI2Ni40MTdaIiBmaWxsPSIjNDI0MjQyIi8+CjxwYXRoIGQ9Ik0yOTIuNzUyIDIyNC44NjVMMjkyLjg2NyAyMjQuNzVDMjkyLjg2NyAyMjQuNzUgMjIyLjA0MiA4MS43MDgzIDE5MS4xMDcgNjkuNzE4N0MxNzEuNTU1IDYyLjEzNTQgMTU0LjU5NyAxMzMuODU0IDE4Mi4yNjYgMTc4LjEyNUMyMDUuNzQ1IDIxNS42NzcgMjc3LjYzMSAyMzguNDE3IDI3Ny42MzEgMjM4LjQxN0wyNzcuNzg4IDIzOC4yNzFDMjc4LjQ4MSAyMzguNzgxIDI3OS4xMjIgMjM5LjM0NCAyNzkuOTYyIDIzOS42NjdDMjg1LjM3IDI0MS43NSAyOTEuNDUgMjM5LjEwNCAyOTMuNTYgMjMzLjc2QzI5NC43NDcgMjMwLjcwOCAyOTQuMjc0IDIyNy41MSAyOTIuNzUyIDIyNC44NjVaIiBmaWxsPSIjQTBDMTY4Ii8+CjxwYXRoIGQ9Ik0zMzAuMTIzIDI2Ni40MTdDMzA4LjI4MiAyODguMDk0IDI3Ny42MiAyNjYuNDE3IDI2Ny4xMiAyNTZDMjQ2LjExOSAyMzUuMTY3IDIyNi43MzUgMjE3LjU4MyAyNDguNTY2IDE5NS45MzdDMjcwLjQwNyAxNzQuMjYgMjk3LjkxOCAxODIuMTA0IDMxOS43NDggMjAzLjc4MUMzNDEuNjEgMjI1LjQ1OCAzNTEuOTY0IDI0NC43NzEgMzMwLjEyMyAyNjYuNDE3WiIgZmlsbD0iIzRCNEI0QiIvPgo8cGF0aCBkPSJNMzUxLjEyNCAxNDEuNDM4TDM2MS42MjQgMTIwLjYwNEw0MTQuMTI2IDExMC4xODgiIHN0cm9rZT0iIzRCNEI0QiIgc3Ryb2tlLXdpZHRoPSIyMC44MzMzIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KPHBhdGggZD0iTTMzMC4xMjMgMTMxLjAyMUwzMTkuNjIyIDk5Ljc3MDhMMzgyLjYyNSA3OC45Mzc1IiBzdHJva2U9IiM0QjRCNEIiIHN0cm9rZS13aWR0aD0iMjAuODMzMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CjxwYXRoIGQ9Ik0zNjEuNjI0IDE5My41QzM3Mi4xMTQgMTcyLjY3NyAzODAuOTk3IDE3NC4yNzEgMzgxLjAwOCAxNzQuMjcxQzM3Mi41NTUgMTU0LjgyMyAzNTguMTM4IDEzNC45MTcgMzM2LjA4NyAxMjQuMjVDMzE1LjU4IDExNC4zNDQgMjkxLjExNCAxMjQuMzQ0IDI4MS44ODQgMTQ1LjcwOEMyNzIuNjY0IDE2Ny4wNzMgMjgxLjk5OSAxOTIuMDUyIDMwMi42NzUgMjAxLjYyNUMzMzAuMTIzIDIxNC4zMzMgMzcyLjEyNCAyMTQuMzMzIDM4Mi42MjUgMjI0Ljc1QzM4My40MjMgMjI1LjU0MiAzODQuMTU4IDIyNi4wMjEgMzg0Ljg0MSAyMjYuMzMzQzM3Mi4xMjUgMjAzLjkxNyAzNjEuNjI0IDE5My41IDM2MS42MjQgMTkzLjVaIiBmaWxsPSIjNzc3Nzc3Ii8+CjxwYXRoIGQ9Ik0zMjQuNzM2IDIwOC44MDJDMzE2LjY2MSAyMDYuNDE3IDMwOS42ODkgMjA0Ljg3NSAzMDIuNjc0IDIwMS42MzVDMjk0LjI3NCAxOTcuNzUgMjg3Ljg3OSAxOTEuMjYgMjgzLjcgMTgzLjU2M0MyNzYuMzUgMTgyLjQ3OSAyNjAuMjMyIDE4My43NSAyNTMuMDA3IDE5Mi41MzFDMjU4Ljc5MyAyMDcuMDk0IDI2MS40MjkgMjI5LjM3NSAyNzYuOTU5IDIzNS4xNzdDMzA3LjQ3MyAyNDYuNTczIDMyOS40ODIgMjQyLjYyNSAzNDEuNDYzIDIzNS4zNDRDMzM4Ljg0OSAyMjQuNzUgMzMxLjIzNiAyMTYuNTczIDMyNC43MzYgMjA4LjgwMloiIGZpbGw9IiMzMjMyMzIiLz4KPHBhdGggZD0iTTM2MC4yOSAxNzguNjg4QzM1NS40OTIgMTg2LjQ0OCAzNDUuNTA2IDE3My40NTggMzMwLjEyMyAxNjIuMjVDMzE0Ljc0IDE1MS4wNDIgMjk5Ljc2NiAxNDUuODU0IDMwNC41NjUgMTM4LjA4M0MzMDkuMzUzIDEzMC4zMzMgMzI1Ljc0NCAxMzMuMTI1IDM0MS4xMTcgMTQ0LjM0NEMzNTYuNDg5IDE1NS41NjMgMzY1LjEgMTcwLjkxNyAzNjAuMjkgMTc4LjY4OFoiIGZpbGw9IiMzMjMyMzIiLz4KPHBhdGggZD0iTTI4NC4xMiAyMTYuNzVMMjg0LjE5NCAyMTYuNjA0QzI4NC4xODMgMjE2LjYxNSAxMTEuMzI1IDY4LjUgNzguMTExOSA2OC41QzU3LjExMSA2OC41IDY3LjYxMTUgMTQxLjQxNyAxMDkuNjEzIDE3Mi42NjdDMTQ1LjI2MiAxOTkuMTg4IDI3NC45OTUgMjM0Ljg0NCAyNzQuOTk1IDIzNC44NDRMMjc1LjA5IDIzNC42NTZDMjc1LjkxOSAyMzQuODc1IDI3Ni43MTcgMjM1LjE2NyAyNzcuNjIgMjM1LjE2N0MyODMuNDI3IDIzNS4xNjcgMjg4LjEyMSAyMzAuNTEgMjg4LjEyMSAyMjQuNzVDMjg4LjEyMSAyMjEuNDc5IDI4Ni41MDQgMjE4LjY2NyAyODQuMTIgMjE2Ljc1WiIgZmlsbD0iI0E2RDM1QiIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzIxNl85NiI+CjxyZWN0IHdpZHRoPSIzNzYiIGhlaWdodD0iMzc2IiBmaWxsPSJ3aGl0ZSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNjggNjgpIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          - services/status
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - groups
+          - users
+          verbs:
+          - impersonate
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - resourcequotas
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets/status
+          - statefulsets/status
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - delete
+          - deletecollection
+          - get
+          - list
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - podmonitors
+          verbs:
+          - create
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies/status
+          verbs:
+          - get
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - tawon.mantisnet.com
+          resources:
+          - clusterdirectives
+          - dashboards
+          - directivebindings
+          - directives
+          - streams
+          - streamstores
+          - topologyaggregators
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - tawon.mantisnet.com
+          resources:
+          - clusterdirectives/finalizers
+          - dashboards/finalizers
+          - directivebindings/finalizers
+          - directives/finalizers
+          - streams/finalizers
+          - streamstores/finalizers
+          - topologyaggregators/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - tawon.mantisnet.com
+          resources:
+          - clusterdirectives/status
+          - dashboards/status
+          - directivebindings/status
+          - directives/status
+          - streams/status
+          - streamstores/status
+          - topologyaggregators/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - groups
+          - users
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: tawon-operator-eob-controller-manager
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: default
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: tawon-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: tawon-operator
+          control-plane: controller-manager
+        name: tawon-operator-eob-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/created-by: tawon-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/created-by: tawon-operator
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: repo.f5.com/eob/images/kube-rbac-proxy@sha256:8b162ebd0e435fe15d0d5aba9bd534b68f4cf569f41b7f2ff0dc10b3e3c46518
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --licensing-enabled=true
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: TAWON_OPERATOR_DEFAULT_TAWON_IMAGE
+                  value: repo.f5.com/eob/images/tawon:ubi-build-xx
+                - name: TAWON_OPERATOR_DEFAULT_JETSTREAM_IMAGE
+                  value: repo.f5.com/eob/images/nats@sha256:cca28bcdb3b4ee176031fabb73154eed1f5f847d3507c4f77c747d2a84e4a439
+                - name: TAWON_OPERATOR_DEFAULT_DASHBOARD_IMAGE
+                  value: repo.f5.com/eob/images/sengat:xx
+                - name: TAWON_OPERATOR_OPERATOR_NAMESPACE
+                  value: system
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: repo.f5.com/eob/images/tawon-operator@sha256:e8fdbd5f6ac6d16659402a3e1c78546e46b6b78e872e09c651c6f68bb46ed8b4
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: 2Gi
+                  requests:
+                    cpu: 500m
+                    memory: 1Gi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: tawon-operator-eob-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 384
+                  secretName: webhook-server-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: tawon-operator-eob-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - monitoring
+  - networking
+  - metrics
+  - ebpf
+  links:
+  - name: Tawon Docs
+    url: https://docs.tawon.xmantis.net
+  maintainers:
+  - email: elliott@mantisnet.com
+    name: Elliott Starin
+  - email: nicolas@mantisnet.com
+    name: Nicolas Paton
+  - email: thiago@mantisnet.com
+    name: Thiago Navarro
+  maturity: alpha
+  provider:
+    name: Mantisnet
+    url: https://www.mantisnet.com
+  relatedImages:
+  - image: repo.f5.com/eob/images/kube-rbac-proxy@sha256:8b162ebd0e435fe15d0d5aba9bd534b68f4cf569f41b7f2ff0dc10b3e3c46518
+    name: kube-rbac-proxy
+  - image: repo.f5.com/eob/images/tawon-operator@sha256:e8fdbd5f6ac6d16659402a3e1c78546e46b6b78e872e09c651c6f68bb46ed8b4
+    name: manager
+  - image: repo.f5.com/eob/images/tawon@sha256:51433adc610e32979a22ec11e9b16112092f428bcbd77f99c5ecc0176f548767
+    name: tawon-debug
+  - image: repo.f5.com/eob/images/tawon@sha256:82f8a76b1a4ea63b0fa560c5e4b4c3eb5832576d582e396bba408d60ea7dffb9
+    name: tawon
+  - image: repo.f5.com/eob/images/nats@sha256:cca28bcdb3b4ee176031fabb73154eed1f5f847d3507c4f77c747d2a84e4a439
+    name: nats
+  - image: repo.f5.com/eob/images/kernel-headers@sha256:9290eb56b186ee0edf65da615c1a8aabc66f7d290168e49ad8764ab8fc2d209a
+    name: kernel-headers-ocp-4.12.45
+  - image: repo.f5.com/eob/images/kernel-headers@sha256:ca3baeba7ab8ce968c1ee129112532fc8b8d6fb6741e42831b6100f0a2451629
+    name: kernel-headers-ocp-4.12.53
+  - image: repo.f5.com/eob/images/kernel-headers@sha256:5d00bfa9f60c95afcfa363ede59a9625fef9925cd1cb4235327a1de94a0fc632
+    name: kernel-headers-ocp-4.12.58
+  - image: repo.f5.com/eob/images/kernel-headers@sha256:b0975a44cc94bc1d75679f288a9e23a65c2c0b350ce1fb2f5eb421a76a9567c6
+    name: kernel-headers-ocp-4.12.74
+  - image: repo.f5.com/eob/images/tawonctl@sha256:7a5023d21f3777e77afb999ba03c5e661ea281b4b3a46203fd01649d8c032afa
+    name: tawonctl
+  - image: repo.f5.com/eob/images/diagnose@sha256:8105d1bf7539113d35f494e7db266e0563ba7b5cd77e4e9155aea607f8028f76
+    name: diagnose
+  - image: repo.f5.com/eob/images/sengat@sha256:d18017b6bcac70d90c3cf952c83506de7ab086b53d27d721291a0e35d446ab20
+    name: dashboard
+  - image: repo.f5.com/eob/images/oauth-proxy@sha256:d478e0201134e3f8794b34556f4f6917c0a4c68310a9dccecbc673d7fd6c1ec7
+    name: oauth-proxy
+  - image: repo.f5.com/eob/images/oauth2-proxy@sha256:bc9a7e613c45a691c8780be532b19f8fd0cac0d307c3b765151acfc95e894e18
+    name: oauth2-proxy
+  replaces: tawon-operator.v3.0.0-rc8
+  version: 3.1.0-rc1
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: mclusterdirective.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - clusterdirectives
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-tawon-mantisnet-com-v1alpha1-clusterdirective
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: mdashboard.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - dashboards
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-tawon-mantisnet-com-v1alpha1-dashboard
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: mdirective.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - directives
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-tawon-mantisnet-com-v1alpha1-directive
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: vclusterdirective.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      - DELETE
+      resources:
+      - clusterdirectives
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-tawon-mantisnet-com-v1alpha1-clusterdirective
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: vdirective.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      - DELETE
+      resources:
+      - directives
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-tawon-mantisnet-com-v1alpha1-directive
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: vstream.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - streams
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-tawon-mantisnet-com-v1alpha1-stream
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: vstreamstore.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - streamstores
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-tawon-mantisnet-com-v1alpha1-streamstore
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: tawon-operator-eob-controller-manager
+    failurePolicy: Fail
+    generateName: vtopologyaggregator.kb.io
+    rules:
+    - apiGroups:
+      - tawon.mantisnet.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - topologyaggregators
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-tawon-mantisnet-com-v1alpha1-topologyaggregator

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_clusterdirectives.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_clusterdirectives.yaml
@@ -1,0 +1,2678 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: clusterdirectives.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: ClusterDirective
+    listKind: ClusterDirectiveList
+    plural: clusterdirectives
+    singular: clusterdirective
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.tasks[0].task
+      name: Source
+      type: string
+    - jsonPath: .spec.tasks[-1].task
+      name: Sink
+      type: string
+    - jsonPath: .spec.tasks[-1].config.name
+      name: Stream
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.numberReady
+      name: Nodes Ready
+      type: string
+    - jsonPath: .status.desiredNumberScheduled
+      name: Nodes Desired
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterDirective is the Schema for the clusterdirectives API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Directive `json:",inline"`
+            properties:
+              condition:
+                description: |-
+                  Conditions are the conditions that must be met for the directive to be
+                  applied.
+                properties:
+                  and:
+                    description: And is a list of conditions that must be met.
+                    items:
+                      properties:
+                        and:
+                          description: And is a list of conditions that must be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        equal:
+                          description: Equal is a textual equality condition.
+                          properties:
+                            field:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - field
+                          - value
+                          type: object
+                        or:
+                          description: Or is a list of conditions, any of which must
+                            be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        regex:
+                          description: Regex is a regular expression condition.
+                          properties:
+                            field:
+                              type: string
+                            regex:
+                              type: string
+                          required:
+                          - field
+                          - regex
+                          type: object
+                      type: object
+                    type: array
+                  equal:
+                    description: Equal is a textual equality condition.
+                    properties:
+                      field:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - field
+                    - value
+                    type: object
+                  or:
+                    description: Or is a list of conditions, any of which must be
+                      met.
+                    items:
+                      properties:
+                        and:
+                          description: And is a list of conditions that must be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        equal:
+                          description: Equal is a textual equality condition.
+                          properties:
+                            field:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - field
+                          - value
+                          type: object
+                        or:
+                          description: Or is a list of conditions, any of which must
+                            be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        regex:
+                          description: Regex is a regular expression condition.
+                          properties:
+                            field:
+                              type: string
+                            regex:
+                              type: string
+                          required:
+                          - field
+                          - regex
+                          type: object
+                      type: object
+                    type: array
+                  regex:
+                    description: Regex is a regular expression condition.
+                    properties:
+                      field:
+                        type: string
+                      regex:
+                        type: string
+                    required:
+                    - field
+                    - regex
+                    type: object
+                type: object
+              container:
+                description: Container options. See ContainerSpec.
+                properties:
+                  disabled:
+                    description: |-
+                      Disable container.
+                      If enabled, this will cause the container to do nothing. It will not
+                      start tawon, it will just sleep indefinitely. Only useful for debugging.
+                    type: boolean
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key
+                      exists in multiplesources, the value associated with the last source will
+                      take precedence. Values defined by an Env with a duplicate key will take
+                      precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  name:
+                    description: Name of container.
+                    type: string
+                  resources:
+                    description: |-
+                      Compute Resources required by the container.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info:
+                      https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              daemonSet:
+                description: DaemonSet options. See DaemonSetSpec.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of daemonset.
+                    type: string
+                type: object
+              debug:
+                description: Debugging configuration.
+                properties:
+                  deadlockDetector:
+                    description: Enable Deadlock Detector
+                    type: boolean
+                  debug:
+                    description: |-
+                      Debug flags enable extra logging in different components.
+                      See DebugFlag for the list of available flags.
+                    items:
+                      description: |-
+                        Debug flags enable extra logging in different components.
+                        Notably it enables BPF logging for the respective components.
+                      enum:
+                      - Exec
+                      - Payload
+                      - TLS
+                      - Flows
+                      - ResetConn
+                      - Feedback
+                      type: string
+                    type: array
+                  extraFlags:
+                    description: Extra flags to pass to the executable.
+                    items:
+                      type: string
+                    type: array
+                  logLevel:
+                    description: |-
+                      Logging level.
+                      One of "trace", "debug", "info", "warn", or "error".
+                    type: string
+                  silent:
+                    description: |-
+                      Silent flags disable some non-critical logging in different components.
+                      See SilentFlag for the list of available flags.
+                    items:
+                      description: Silent flags disable some non-critical logging
+                        in different components.
+                      enum:
+                      - Exec
+                      - Flows
+                      type: string
+                    type: array
+                type: object
+              directiveBindingRef:
+                description: |-
+                  DirectiveBindingRef is the name of the DirectiveBinding resource that controls
+                  targeted node placement for this directive. When set, the directive's DaemonSet
+                  is deployed only on nodes listed in the DirectiveBinding. Set by the operator
+                  when directiveBinder.enabled is true.
+                type: string
+              duration:
+                description: |-
+                  Duration is the amount of time the directive should run. If StopAt is
+                  specified, StopAt takes precedence over Duration.
+                type: string
+              enabled:
+                description: |-
+                  Enabled indicates whether the directive is enabled. If not specified,
+                  defaults to true.
+                type: boolean
+              image:
+                description: Container image options.
+                properties:
+                  credentialsSecret:
+                    description: |-
+                      Reference to the secret containing the Image registry credentials used to
+                      pull the image.
+
+                      Defaults to looking for a secret with the name
+                      "tawon-registry-credentials" in the same namespace. If not present, the
+                      image pull will not be authenticated.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  image:
+                    description: Container image name.
+                    type: string
+                  pullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      More info:
+                      https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                      Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                      otherwise.
+                    type: string
+                type: object
+              kernelHeaders:
+                description: Kernel Headers options.
+                properties:
+                  image:
+                    description: |-
+                      Container image options. This is the image used for the kernel headers
+                      container if the strategy is "Container".
+                      Container image is required if the strategy is "Container".
+                    properties:
+                      credentialsSecret:
+                        description: |-
+                          Reference to the secret containing the Image registry credentials used to
+                          pull the image.
+
+                          Defaults to looking for a secret with the name
+                          "tawon-registry-credentials" in the same namespace. If not present, the
+                          image pull will not be authenticated.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      image:
+                        description: Container image name.
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          More info:
+                          https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                          otherwise.
+                        type: string
+                    type: object
+                  resources:
+                    description: |-
+                      Compute Resources required by the kernel headers init container.
+                      Only valid with the "container" strategy.
+                      Resources required by the kernel headers init container are not very
+                      great, and it only runs for a few seconds.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  strategy:
+                    description: Strategy to use for installing kernel headers.
+                    enum:
+                    - Host
+                    - None
+                    - Container
+                    type: string
+                type: object
+              messaging:
+                description: |-
+                  Default messaging configuration. This is the default configuration for
+                  messaging tasks (subscribe & publish).
+                properties:
+                  nats:
+                    description: Message bus NATS configuration.
+                    properties:
+                      authEnabled:
+                        description: |-
+                          AuthEnabled controls whether NATS server authentication is enabled.
+                          A nil value means no explicit preference. Operator-managed StreamStores set
+                          this to true by default, while custom StreamStores remain unauthenticated
+                          unless this is explicitly true.
+                        type: boolean
+                      clientName:
+                        description: ' NATS Client name.'
+                        type: string
+                      credentialsSecret:
+                        description: |-
+                          NATS credentials secret. The secret must contain a "token" key.
+                          Operator-managed StreamStores default this to the generated StreamStore auth secret.
+                          If auth is enabled and this field is empty, clients derive the generated
+                          secret name from the referenced StreamStore name.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      url:
+                        description: NATS server URL.
+                        type: string
+                    type: object
+                  type:
+                    description: |-
+                      Message bus type.
+
+                      Defaults to "nats". Currently only "nats" is supported.
+                    enum:
+                    - nats
+                    type: string
+                type: object
+              monitoring:
+                description: Prometheus monitoring.
+                properties:
+                  disabled:
+                    description: Disable monitoring. Monitoring is enabled by default.
+                    type: boolean
+                  namespace:
+                    description: Namespace if the prefix added to the metrics.
+                    type: string
+                  path:
+                    description: Path to expose metrics on.
+                    type: string
+                  port:
+                    description: Port to expose metrics on.
+                    format: int32
+                    type: integer
+                  portName:
+                    description: Exposed port name.
+                    type: string
+                type: object
+              pod:
+                description: Pod options. See PodSpec.
+                properties:
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  automountServiceAccountToken:
+                    description: |-
+                      AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                      If not set, the default behavior is to not mount the service account token (for security compliance).
+                      Set to true to enable access to the Kubernetes API from within the pod.
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of the pod.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is a selector which must be true for the pod to fit on a
+                      node.
+                      Selector which must match a node's labels for the pod to be scheduled on
+                      that node.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext holds pod-level security attributes and common container settings.
+                      Optional: Defaults to empty.  See type description for default values of
+                      each field.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in addition
+                          to the container's primary GID, the fsGroup (if specified), and group memberships
+                          defined in the container image for the uid of the container process. If unspecified,
+                          no additional groups are added to any container. Note that group memberships
+                          defined in the container image for the uid of the container process are still effective,
+                          even if they are not included in this list.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                    type: string
+                  tolerations:
+                    description: |-
+                      If specified, the pod's tolerations.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              secrets:
+                description: |-
+                  Secrets is a list of secret refs that will be mounted in the pod.
+                  They can be used in the task config maps by prefacing the secret name
+                  with "secret.<name of secret>." and adding the path of the secret key you
+                  want to use.
+                  For example, with a secret ref named mtls:
+
+                   secrets:
+                     - name: mtls
+                       secretName: tawon
+                       namespace: openshift-operators
+
+                  ...
+
+                   config:
+                     tls:
+                       certpath: secrets.mtls.user.crt
+                       keypath: secrets.mtls.user.key
+                items:
+                  description: SecretRef is a reference to a secret.
+                  properties:
+                    name:
+                      description: Name of the secret in the directive's context for
+                        the task to use.
+                      type: string
+                    secretName:
+                      description: SecretName is the name of the Secret resource.
+                      type: string
+                  required:
+                  - name
+                  - secretName
+                  type: object
+                type: array
+              startAt:
+                description: |-
+                  StartAt is the time at which the directive should start being applied.
+                  If not specified, defaults to the current time.
+                format: date-time
+                type: string
+              stopAt:
+                description: |-
+                  StopAt is the time at which the directive should stop being applied. If
+                  not specified, defaults to StartAt plus Duration, or StartAt plus the
+                  configured maximum age when Duration is not specified.
+                format: date-time
+                type: string
+              streamStores:
+                description: |-
+                  StreamStores refereces StreamStores that will be used by the Directive.
+                  The StreamStores referenced can already exist, in which case the Directive
+                  could use them, or they can be created/deleted by the Directive. If they are
+                  created by this Directive, they will use the limits specified, otherwise, the
+                  limits will be ignored. By default, StreamStores created by a Directive persist
+                  after the Directive is deleted. This can be changed by setting the autoManage option.
+                items:
+                  description: |-
+                    StreamStoreRef is a reference to a StreamStore that could be auto management.
+                    It is used to define basics configuration for the StreamStore.
+
+                    Deprecated: This should be manage by the tawon-config.
+                    The system must not allow the tenant to change the streamstore configuration.
+                    The streamstore resource access has its own permission.
+                  properties:
+                    autoManage:
+                      description: |-
+                        AutoManage is how the Operator manages the streamstore.
+                        If true, the operator will create and delete the StreamStore based on whether there is a Directive that uses it.
+                      type: boolean
+                    defaults:
+                      description: |-
+                        Defaults values for Streams created on this StreatmStore, if the Stream
+                        creator does not set these values.
+                      properties:
+                        maxage:
+                          description: |-
+                            MaxAge is the default retention period for Streams created on this
+                            StreamStore.
+                          type: string
+                        maxbytes:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            MaxBytes is the default retention size for Streams created on this
+                            StreamStore.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxmsgs:
+                          description: |-
+                            MaxMsgs is the default retention message count for Streams created on
+                            this StreamStore.
+                          format: int64
+                          type: integer
+                      type: object
+                    limits:
+                      description: |-
+                        Limits for Streams created on this StreamStore. The creator cannot set
+                        these values higher than the limits set here.
+                      properties:
+                        maxage:
+                          description: |-
+                            MaxAge is the default retention period for Streams created on this
+                            StreamStore.
+                          type: string
+                        maxbytes:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            MaxBytes is the default retention size for Streams created on this
+                            StreamStore.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxmsgs:
+                          description: |-
+                            MaxMsgs is the default retention message count for Streams created on
+                            this StreamStore.
+                          format: int64
+                          type: integer
+                      type: object
+                    name:
+                      description: Name is the name of the StreamStore.
+                      type: string
+                    storageClass:
+                      description: StorageClass is the storage class to use for the
+                        StreamStore.
+                      type: string
+                  required:
+                  - autoManage
+                  type: object
+                type: array
+              streams:
+                description: |-
+                  Streams references Streams that will be used by the Directive. The
+                  Streams referenced can already exists, in which case the Directive will
+                  use them, or they can be created by the Directive. If they are created by
+                  this Directive, they will use the limits specified, otherwise, the limits
+                  will be ignored. By default, Streams created by a Directive persist after
+                  the Directive is deleted. This can be changed by setting the retention
+                  policy. Streams existing before the creation of the Directive will not
+                  respect the retention policy.
+                items:
+                  description: StreamRef is a reference to a stream.
+                  properties:
+                    maxage:
+                      description: |-
+                        MaxAge is the default retention period for Streams created on this
+                        StreamStore.
+                      type: string
+                    maxbytes:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        MaxBytes is the default retention size for Streams created on this
+                        StreamStore.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    maxmsgs:
+                      description: |-
+                        MaxMsgs is the default retention message count for Streams created on
+                        this StreamStore.
+                      format: int64
+                      type: integer
+                    name:
+                      description: Name is the name of the Stream.
+                      type: string
+                    retentionPolicy:
+                      description: |-
+                        RetentionPolicy determines whether the Stream will be retained after the
+                        directive is deleted. Defaults to Retain.
+                      type: string
+                    store:
+                      description: |-
+                        Store is the name of the StreamStore. Defaults to the Stream default.
+                        This field is overwritten by streamStore.name if streamStore.autoManage is set.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              tasks:
+                description: Tasks pipeline.
+                items:
+                  description: Task represents a named task in a directive task pipeline.
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Config is an opaque map for the task's configuration. Each task has its
+                        own configuration schema.
+                      type: object
+                    task:
+                      description: Task is the name of the task.
+                      type: string
+                  required:
+                  - task
+                  type: object
+                minItems: 2
+                type: array
+            required:
+            - tasks
+            type: object
+          status:
+            description: DirectiveStatus defines the observed state of Directive
+            properties:
+              collisionCount:
+                description: |-
+                  Count of hash collisions for the DaemonSet. The DaemonSet controller
+                  uses this field as a collision avoidance mechanism when it needs to
+                  create the name for the newest ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Directive Conditions.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentNumberScheduled:
+                description: |-
+                  The number of nodes that are running at least 1
+                  daemon pod and are supposed to run the daemon pod.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+                format: int32
+                type: integer
+              desiredNumberScheduled:
+                description: |-
+                  The total number of nodes that should be running the daemon
+                  pod (including nodes correctly running the daemon pod).
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+                format: int32
+                type: integer
+              numberAvailable:
+                description: |-
+                  The number of nodes that should be running the
+                  daemon pod and have one or more of the daemon pod running and
+                  available (ready for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              numberMisscheduled:
+                description: |-
+                  The number of nodes that are running the daemon pod, but are
+                  not supposed to run the daemon pod.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+                format: int32
+                type: integer
+              numberReady:
+                description: |-
+                  numberReady is the number of nodes that should be running the daemon pod and have one
+                  or more of the daemon pod running with a Ready Condition.
+                format: int32
+                type: integer
+              numberUnavailable:
+                description: |-
+                  The number of nodes that should be running the
+                  daemon pod and have none of the daemon pod running and available
+                  (ready for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The most recent generation observed by the daemon set
+                  controller.
+                format: int64
+                type: integer
+              updatedNumberScheduled:
+                description: The total number of nodes that are running updated daemon
+                  pod
+                format: int32
+                type: integer
+            required:
+            - currentNumberScheduled
+            - desiredNumberScheduled
+            - numberMisscheduled
+            - numberReady
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_dashboards.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_dashboards.yaml
@@ -1,0 +1,2658 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: dashboards.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: Dashboard
+    listKind: DashboardList
+    plural: dashboards
+    singular: dashboard
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.domain
+      name: Host/Port
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dashboard is the Schema for the dashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DashboardSpec defines the desired state of Dashboard
+            properties:
+              auth:
+                description: Auth configures dashboard authentication.
+                properties:
+                  oauth2Proxy:
+                    description: OAuth2Proxy configures the CNCF oauth2-proxy sidecar.
+                    properties:
+                      configSecret:
+                        description: ConfigSecret is the Secret containing oauth2_proxy.cfg.
+                        type: string
+                      container:
+                        description: Container configures the oauth2-proxy container.
+                        properties:
+                          disabled:
+                            description: |-
+                              Disable container.
+                              If enabled, this will cause the container to do nothing. It will not
+                              start tawon, it will just sleep indefinitely. Only useful for debugging.
+                            type: boolean
+                          env:
+                            description: |-
+                              List of environment variables to set in the container.
+                              Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            description: |-
+                              List of sources to populate environment variables in the container.
+                              The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                              will be reported as an event when the container is starting. When a key
+                              exists in multiplesources, the value associated with the last source will
+                              take precedence. Values defined by an Env with a duplicate key will take
+                              precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                          name:
+                            description: Name of container.
+                            type: string
+                          resources:
+                            description: |-
+                              Compute Resources required by the container.
+                              More info:
+                              https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          securityContext:
+                            description: |-
+                              SecurityContext defines the security options the container should be run with.
+                              If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                              More info:
+                              https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: |-
+                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                  privileges than its parent process. This bool directly controls if
+                                  the no_new_privs flag will be set on the container process.
+                                  AllowPrivilegeEscalation is true always when the container is:
+                                  1) run as Privileged
+                                  2) has CAP_SYS_ADMIN
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              capabilities:
+                                description: |-
+                                  The capabilities to add/drop when running containers.
+                                  Defaults to the default set of capabilities granted by the container runtime.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: |-
+                                  Run container in privileged mode.
+                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                  Defaults to false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: |-
+                                  procMount denotes the type of proc mount to use for the containers.
+                                  The default is DefaultProcMount which uses the container runtime defaults for
+                                  readonly paths and masked paths.
+                                  This requires the ProcMountType feature flag to be enabled.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: |-
+                                  Whether this container has a read-only root filesystem.
+                                  Default is false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to the container.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: |-
+                                  The seccomp options to use by this container. If seccomp options are
+                                  provided at both the pod & container level, the container options
+                                  override the pod options.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options from the PodSecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      image:
+                        description: Image is the container image for oauth2-proxy.
+                        properties:
+                          credentialsSecret:
+                            description: |-
+                              Reference to the secret containing the Image registry credentials used to
+                              pull the image.
+
+                              Defaults to looking for a secret with the name
+                              "tawon-registry-credentials" in the same namespace. If not present, the
+                              image pull will not be authenticated.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          image:
+                            description: Container image name.
+                            type: string
+                          pullPolicy:
+                            description: |-
+                              Image pull policy.
+                              One of Always, Never, IfNotPresent.
+                              More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                              otherwise.
+                            type: string
+                        type: object
+                    type: object
+                  type:
+                    description: Type sets the authentication method.
+                    enum:
+                    - none
+                    - openshift
+                    - oauth2-proxy
+                    type: string
+                type: object
+              dashboard:
+                description: |-
+                  Dashboard is the internal spec for the dashboard. This configuration use used by the dashboard itself.
+                  The container image and log level are examples of the internal spec.
+                properties:
+                  container:
+                    description: Container is the container spec for the dashboard.
+                    properties:
+                      disabled:
+                        description: |-
+                          Disable container.
+                          If enabled, this will cause the container to do nothing. It will not
+                          start tawon, it will just sleep indefinitely. Only useful for debugging.
+                        type: boolean
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key
+                          exists in multiplesources, the value associated with the last source will
+                          take precedence. Values defined by an Env with a duplicate key will take
+                          precedence.
+                          Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      name:
+                        description: Name of container.
+                        type: string
+                      resources:
+                        description: |-
+                          Compute Resources required by the container.
+                          More info:
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      securityContext:
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info:
+                          https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  image:
+                    description: Image is the container image for the dashboard.
+                    properties:
+                      credentialsSecret:
+                        description: |-
+                          Reference to the secret containing the Image registry credentials used to
+                          pull the image.
+
+                          Defaults to looking for a secret with the name
+                          "tawon-registry-credentials" in the same namespace. If not present, the
+                          image pull will not be authenticated.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      image:
+                        description: Container image name.
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          More info:
+                          https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                          otherwise.
+                        type: string
+                    type: object
+                  logLevel:
+                    description: LogLevel is the log level for the dashboard.
+                    type: string
+                  service:
+                    description: Service is the service spec for the dashboard.
+                    properties:
+                      enable:
+                        description: Enable is the flag to enable the service creation.
+                        type: boolean
+                      port:
+                        description: |-
+                          Port is the port for the service.
+                          Only applicable if the service is enabled.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              oauth:
+                description: OAuth is the configuration for OAuth Openshift Proxy.
+                properties:
+                  container:
+                    description: Container is the container spec for the OAuth.
+                    properties:
+                      disabled:
+                        description: |-
+                          Disable container.
+                          If enabled, this will cause the container to do nothing. It will not
+                          start tawon, it will just sleep indefinitely. Only useful for debugging.
+                        type: boolean
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key
+                          exists in multiplesources, the value associated with the last source will
+                          take precedence. Values defined by an Env with a duplicate key will take
+                          precedence.
+                          Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      name:
+                        description: Name of container.
+                        type: string
+                      resources:
+                        description: |-
+                          Compute Resources required by the container.
+                          More info:
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      securityContext:
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info:
+                          https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  debug:
+                    description: |-
+                      Debug enables the debug mode for the OAuth.
+                      It adds `debug` in extraArgs.
+                      If you set to false, it will remove it.
+                    type: boolean
+                  enabled:
+                    description: Enabled is the flag to enable OAuth.
+                    type: boolean
+                  extraArgs:
+                    description: ExtraArgs are the arguments for the OAuth.
+                    items:
+                      type: string
+                    type: array
+                  image:
+                    description: Image is the container image for the OAuth.
+                    properties:
+                      credentialsSecret:
+                        description: |-
+                          Reference to the secret containing the Image registry credentials used to
+                          pull the image.
+
+                          Defaults to looking for a secret with the name
+                          "tawon-registry-credentials" in the same namespace. If not present, the
+                          image pull will not be authenticated.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      image:
+                        description: Container image name.
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          More info:
+                          https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                          otherwise.
+                        type: string
+                    type: object
+                type: object
+              pod:
+                description: PodSpec is the pod spec for the dashboard.
+                properties:
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  automountServiceAccountToken:
+                    description: |-
+                      AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                      If not set, the default behavior is to not mount the service account token (for security compliance).
+                      Set to true to enable access to the Kubernetes API from within the pod.
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of the pod.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is a selector which must be true for the pod to fit on a
+                      node.
+                      Selector which must match a node's labels for the pod to be scheduled on
+                      that node.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext holds pod-level security attributes and common container settings.
+                      Optional: Defaults to empty.  See type description for default values of
+                      each field.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in addition
+                          to the container's primary GID, the fsGroup (if specified), and group memberships
+                          defined in the container image for the uid of the container process. If unspecified,
+                          no additional groups are added to any container. Note that group memberships
+                          defined in the container image for the uid of the container process are still effective,
+                          even if they are not included in this list.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                    type: string
+                  tolerations:
+                    description: |-
+                      If specified, the pod's tolerations.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              route:
+                description: Route is the configuration for the route in order to
+                  access the dashboard externally.
+                properties:
+                  domain:
+                    description: |-
+                      Domain is the fully qualified domain name for the route.
+                      If this is set, the SubDomain and IngressControllerName will be ignored.
+                    type: string
+                  ingressControllerName:
+                    description: Ingress controller for the route.
+                    type: string
+                  subDomain:
+                    description: SubDomain is the host for the route.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DashboardStatus defines the observed state of Dashboard
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              domain:
+                description: Domain is the fully qualified domain name for the route.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_directivebindings.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_directivebindings.yaml
@@ -1,0 +1,163 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: directivebindings.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: DirectiveBinding
+    listKind: DirectiveBindingList
+    plural: directivebindings
+    singular: directivebinding
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.directiveName
+      name: Directive
+      type: string
+    - jsonPath: .spec.directiveNamespace
+      name: Namespace
+      type: string
+    - jsonPath: .spec.nodes
+      name: Nodes
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DirectiveBinding is the Schema for the directivebindings API
+          DirectiveBinding coordinates between topology pods and the operator to enable
+          targeted directive deployment. Topology pods running on each node evaluate
+          directive conditions against local pods and update this resource to indicate
+          which nodes should run the directive's DaemonSet.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DirectiveBindingSpec defines the desired state of DirectiveBinding
+            properties:
+              directiveName:
+                description: DirectiveName is the name of the Directive or ClusterDirective
+                  this binding applies to
+                type: string
+              directiveNamespace:
+                description: DirectiveNamespace is the namespace of the Directive
+                  (empty for ClusterDirectives)
+                type: string
+              isClusterDirective:
+                description: IsClusterDirective indicates whether this binding is
+                  for a ClusterDirective
+                type: boolean
+              nodes:
+                description: |-
+                  Nodes is the list of node names where the directive conditions are matched
+                  Each node name should correspond to a kubernetes.io/hostname label value
+                items:
+                  type: string
+                type: array
+            required:
+            - directiveName
+            type: object
+          status:
+            description: DirectiveBindingStatus defines the observed state of DirectiveBinding
+            properties:
+              boundNodeCount:
+                description: BoundNodeCount is the number of nodes currently in the
+                  binding
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the DirectiveBinding's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdateTime:
+                description: LastUpdateTime is the last time the binding was updated
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_directives.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_directives.yaml
@@ -1,0 +1,2680 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: directives.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: Directive
+    listKind: DirectiveList
+    plural: directives
+    singular: directive
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.tasks[0].task
+      name: Source
+      type: string
+    - jsonPath: .spec.tasks[-1].task
+      name: Sink
+      type: string
+    - jsonPath: .spec.tasks[-1].config.name
+      name: Stream
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.numberReady
+      name: Nodes Ready
+      type: string
+    - jsonPath: .status.desiredNumberScheduled
+      name: Nodes Desired
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          A Directive allows to define a Tawon task pipeline that will be applied to a
+          Kubernetes cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DirectiveSpec defines the desired state of Directive
+            properties:
+              condition:
+                description: |-
+                  Conditions are the conditions that must be met for the directive to be
+                  applied.
+                properties:
+                  and:
+                    description: And is a list of conditions that must be met.
+                    items:
+                      properties:
+                        and:
+                          description: And is a list of conditions that must be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        equal:
+                          description: Equal is a textual equality condition.
+                          properties:
+                            field:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - field
+                          - value
+                          type: object
+                        or:
+                          description: Or is a list of conditions, any of which must
+                            be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        regex:
+                          description: Regex is a regular expression condition.
+                          properties:
+                            field:
+                              type: string
+                            regex:
+                              type: string
+                          required:
+                          - field
+                          - regex
+                          type: object
+                      type: object
+                    type: array
+                  equal:
+                    description: Equal is a textual equality condition.
+                    properties:
+                      field:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - field
+                    - value
+                    type: object
+                  or:
+                    description: Or is a list of conditions, any of which must be
+                      met.
+                    items:
+                      properties:
+                        and:
+                          description: And is a list of conditions that must be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        equal:
+                          description: Equal is a textual equality condition.
+                          properties:
+                            field:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - field
+                          - value
+                          type: object
+                        or:
+                          description: Or is a list of conditions, any of which must
+                            be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        regex:
+                          description: Regex is a regular expression condition.
+                          properties:
+                            field:
+                              type: string
+                            regex:
+                              type: string
+                          required:
+                          - field
+                          - regex
+                          type: object
+                      type: object
+                    type: array
+                  regex:
+                    description: Regex is a regular expression condition.
+                    properties:
+                      field:
+                        type: string
+                      regex:
+                        type: string
+                    required:
+                    - field
+                    - regex
+                    type: object
+                type: object
+              container:
+                description: Container options. See ContainerSpec.
+                properties:
+                  disabled:
+                    description: |-
+                      Disable container.
+                      If enabled, this will cause the container to do nothing. It will not
+                      start tawon, it will just sleep indefinitely. Only useful for debugging.
+                    type: boolean
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key
+                      exists in multiplesources, the value associated with the last source will
+                      take precedence. Values defined by an Env with a duplicate key will take
+                      precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  name:
+                    description: Name of container.
+                    type: string
+                  resources:
+                    description: |-
+                      Compute Resources required by the container.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info:
+                      https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              daemonSet:
+                description: DaemonSet options. See DaemonSetSpec.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of daemonset.
+                    type: string
+                type: object
+              debug:
+                description: Debugging configuration.
+                properties:
+                  deadlockDetector:
+                    description: Enable Deadlock Detector
+                    type: boolean
+                  debug:
+                    description: |-
+                      Debug flags enable extra logging in different components.
+                      See DebugFlag for the list of available flags.
+                    items:
+                      description: |-
+                        Debug flags enable extra logging in different components.
+                        Notably it enables BPF logging for the respective components.
+                      enum:
+                      - Exec
+                      - Payload
+                      - TLS
+                      - Flows
+                      - ResetConn
+                      - Feedback
+                      type: string
+                    type: array
+                  extraFlags:
+                    description: Extra flags to pass to the executable.
+                    items:
+                      type: string
+                    type: array
+                  logLevel:
+                    description: |-
+                      Logging level.
+                      One of "trace", "debug", "info", "warn", or "error".
+                    type: string
+                  silent:
+                    description: |-
+                      Silent flags disable some non-critical logging in different components.
+                      See SilentFlag for the list of available flags.
+                    items:
+                      description: Silent flags disable some non-critical logging
+                        in different components.
+                      enum:
+                      - Exec
+                      - Flows
+                      type: string
+                    type: array
+                type: object
+              directiveBindingRef:
+                description: |-
+                  DirectiveBindingRef is the name of the DirectiveBinding resource that controls
+                  targeted node placement for this directive. When set, the directive's DaemonSet
+                  is deployed only on nodes listed in the DirectiveBinding. Set by the operator
+                  when directiveBinder.enabled is true.
+                type: string
+              duration:
+                description: |-
+                  Duration is the amount of time the directive should run. If StopAt is
+                  specified, StopAt takes precedence over Duration.
+                type: string
+              enabled:
+                description: |-
+                  Enabled indicates whether the directive is enabled. If not specified,
+                  defaults to true.
+                type: boolean
+              image:
+                description: Container image options.
+                properties:
+                  credentialsSecret:
+                    description: |-
+                      Reference to the secret containing the Image registry credentials used to
+                      pull the image.
+
+                      Defaults to looking for a secret with the name
+                      "tawon-registry-credentials" in the same namespace. If not present, the
+                      image pull will not be authenticated.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  image:
+                    description: Container image name.
+                    type: string
+                  pullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      More info:
+                      https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                      Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                      otherwise.
+                    type: string
+                type: object
+              kernelHeaders:
+                description: Kernel Headers options.
+                properties:
+                  image:
+                    description: |-
+                      Container image options. This is the image used for the kernel headers
+                      container if the strategy is "Container".
+                      Container image is required if the strategy is "Container".
+                    properties:
+                      credentialsSecret:
+                        description: |-
+                          Reference to the secret containing the Image registry credentials used to
+                          pull the image.
+
+                          Defaults to looking for a secret with the name
+                          "tawon-registry-credentials" in the same namespace. If not present, the
+                          image pull will not be authenticated.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      image:
+                        description: Container image name.
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          More info:
+                          https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                          otherwise.
+                        type: string
+                    type: object
+                  resources:
+                    description: |-
+                      Compute Resources required by the kernel headers init container.
+                      Only valid with the "container" strategy.
+                      Resources required by the kernel headers init container are not very
+                      great, and it only runs for a few seconds.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  strategy:
+                    description: Strategy to use for installing kernel headers.
+                    enum:
+                    - Host
+                    - None
+                    - Container
+                    type: string
+                type: object
+              messaging:
+                description: |-
+                  Default messaging configuration. This is the default configuration for
+                  messaging tasks (subscribe & publish).
+                properties:
+                  nats:
+                    description: Message bus NATS configuration.
+                    properties:
+                      authEnabled:
+                        description: |-
+                          AuthEnabled controls whether NATS server authentication is enabled.
+                          A nil value means no explicit preference. Operator-managed StreamStores set
+                          this to true by default, while custom StreamStores remain unauthenticated
+                          unless this is explicitly true.
+                        type: boolean
+                      clientName:
+                        description: ' NATS Client name.'
+                        type: string
+                      credentialsSecret:
+                        description: |-
+                          NATS credentials secret. The secret must contain a "token" key.
+                          Operator-managed StreamStores default this to the generated StreamStore auth secret.
+                          If auth is enabled and this field is empty, clients derive the generated
+                          secret name from the referenced StreamStore name.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      url:
+                        description: NATS server URL.
+                        type: string
+                    type: object
+                  type:
+                    description: |-
+                      Message bus type.
+
+                      Defaults to "nats". Currently only "nats" is supported.
+                    enum:
+                    - nats
+                    type: string
+                type: object
+              monitoring:
+                description: Prometheus monitoring.
+                properties:
+                  disabled:
+                    description: Disable monitoring. Monitoring is enabled by default.
+                    type: boolean
+                  namespace:
+                    description: Namespace if the prefix added to the metrics.
+                    type: string
+                  path:
+                    description: Path to expose metrics on.
+                    type: string
+                  port:
+                    description: Port to expose metrics on.
+                    format: int32
+                    type: integer
+                  portName:
+                    description: Exposed port name.
+                    type: string
+                type: object
+              pod:
+                description: Pod options. See PodSpec.
+                properties:
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  automountServiceAccountToken:
+                    description: |-
+                      AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                      If not set, the default behavior is to not mount the service account token (for security compliance).
+                      Set to true to enable access to the Kubernetes API from within the pod.
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of the pod.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is a selector which must be true for the pod to fit on a
+                      node.
+                      Selector which must match a node's labels for the pod to be scheduled on
+                      that node.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext holds pod-level security attributes and common container settings.
+                      Optional: Defaults to empty.  See type description for default values of
+                      each field.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in addition
+                          to the container's primary GID, the fsGroup (if specified), and group memberships
+                          defined in the container image for the uid of the container process. If unspecified,
+                          no additional groups are added to any container. Note that group memberships
+                          defined in the container image for the uid of the container process are still effective,
+                          even if they are not included in this list.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                    type: string
+                  tolerations:
+                    description: |-
+                      If specified, the pod's tolerations.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              secrets:
+                description: |-
+                  Secrets is a list of secret refs that will be mounted in the pod.
+                  They can be used in the task config maps by prefacing the secret name
+                  with "secret.<name of secret>." and adding the path of the secret key you
+                  want to use.
+                  For example, with a secret ref named mtls:
+
+                   secrets:
+                     - name: mtls
+                       secretName: tawon
+                       namespace: openshift-operators
+
+                  ...
+
+                   config:
+                     tls:
+                       certpath: secrets.mtls.user.crt
+                       keypath: secrets.mtls.user.key
+                items:
+                  description: SecretRef is a reference to a secret.
+                  properties:
+                    name:
+                      description: Name of the secret in the directive's context for
+                        the task to use.
+                      type: string
+                    secretName:
+                      description: SecretName is the name of the Secret resource.
+                      type: string
+                  required:
+                  - name
+                  - secretName
+                  type: object
+                type: array
+              startAt:
+                description: |-
+                  StartAt is the time at which the directive should start being applied.
+                  If not specified, defaults to the current time.
+                format: date-time
+                type: string
+              stopAt:
+                description: |-
+                  StopAt is the time at which the directive should stop being applied. If
+                  not specified, defaults to StartAt plus Duration, or StartAt plus the
+                  configured maximum age when Duration is not specified.
+                format: date-time
+                type: string
+              streamStores:
+                description: |-
+                  StreamStores refereces StreamStores that will be used by the Directive.
+                  The StreamStores referenced can already exist, in which case the Directive
+                  could use them, or they can be created/deleted by the Directive. If they are
+                  created by this Directive, they will use the limits specified, otherwise, the
+                  limits will be ignored. By default, StreamStores created by a Directive persist
+                  after the Directive is deleted. This can be changed by setting the autoManage option.
+                items:
+                  description: |-
+                    StreamStoreRef is a reference to a StreamStore that could be auto management.
+                    It is used to define basics configuration for the StreamStore.
+
+                    Deprecated: This should be manage by the tawon-config.
+                    The system must not allow the tenant to change the streamstore configuration.
+                    The streamstore resource access has its own permission.
+                  properties:
+                    autoManage:
+                      description: |-
+                        AutoManage is how the Operator manages the streamstore.
+                        If true, the operator will create and delete the StreamStore based on whether there is a Directive that uses it.
+                      type: boolean
+                    defaults:
+                      description: |-
+                        Defaults values for Streams created on this StreatmStore, if the Stream
+                        creator does not set these values.
+                      properties:
+                        maxage:
+                          description: |-
+                            MaxAge is the default retention period for Streams created on this
+                            StreamStore.
+                          type: string
+                        maxbytes:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            MaxBytes is the default retention size for Streams created on this
+                            StreamStore.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxmsgs:
+                          description: |-
+                            MaxMsgs is the default retention message count for Streams created on
+                            this StreamStore.
+                          format: int64
+                          type: integer
+                      type: object
+                    limits:
+                      description: |-
+                        Limits for Streams created on this StreamStore. The creator cannot set
+                        these values higher than the limits set here.
+                      properties:
+                        maxage:
+                          description: |-
+                            MaxAge is the default retention period for Streams created on this
+                            StreamStore.
+                          type: string
+                        maxbytes:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            MaxBytes is the default retention size for Streams created on this
+                            StreamStore.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxmsgs:
+                          description: |-
+                            MaxMsgs is the default retention message count for Streams created on
+                            this StreamStore.
+                          format: int64
+                          type: integer
+                      type: object
+                    name:
+                      description: Name is the name of the StreamStore.
+                      type: string
+                    storageClass:
+                      description: StorageClass is the storage class to use for the
+                        StreamStore.
+                      type: string
+                  required:
+                  - autoManage
+                  type: object
+                type: array
+              streams:
+                description: |-
+                  Streams references Streams that will be used by the Directive. The
+                  Streams referenced can already exists, in which case the Directive will
+                  use them, or they can be created by the Directive. If they are created by
+                  this Directive, they will use the limits specified, otherwise, the limits
+                  will be ignored. By default, Streams created by a Directive persist after
+                  the Directive is deleted. This can be changed by setting the retention
+                  policy. Streams existing before the creation of the Directive will not
+                  respect the retention policy.
+                items:
+                  description: StreamRef is a reference to a stream.
+                  properties:
+                    maxage:
+                      description: |-
+                        MaxAge is the default retention period for Streams created on this
+                        StreamStore.
+                      type: string
+                    maxbytes:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        MaxBytes is the default retention size for Streams created on this
+                        StreamStore.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    maxmsgs:
+                      description: |-
+                        MaxMsgs is the default retention message count for Streams created on
+                        this StreamStore.
+                      format: int64
+                      type: integer
+                    name:
+                      description: Name is the name of the Stream.
+                      type: string
+                    retentionPolicy:
+                      description: |-
+                        RetentionPolicy determines whether the Stream will be retained after the
+                        directive is deleted. Defaults to Retain.
+                      type: string
+                    store:
+                      description: |-
+                        Store is the name of the StreamStore. Defaults to the Stream default.
+                        This field is overwritten by streamStore.name if streamStore.autoManage is set.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              tasks:
+                description: Tasks pipeline.
+                items:
+                  description: Task represents a named task in a directive task pipeline.
+                  properties:
+                    config:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Config is an opaque map for the task's configuration. Each task has its
+                        own configuration schema.
+                      type: object
+                    task:
+                      description: Task is the name of the task.
+                      type: string
+                  required:
+                  - task
+                  type: object
+                minItems: 2
+                type: array
+            required:
+            - tasks
+            type: object
+          status:
+            description: DirectiveStatus defines the observed state of Directive
+            properties:
+              collisionCount:
+                description: |-
+                  Count of hash collisions for the DaemonSet. The DaemonSet controller
+                  uses this field as a collision avoidance mechanism when it needs to
+                  create the name for the newest ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Directive Conditions.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentNumberScheduled:
+                description: |-
+                  The number of nodes that are running at least 1
+                  daemon pod and are supposed to run the daemon pod.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+                format: int32
+                type: integer
+              desiredNumberScheduled:
+                description: |-
+                  The total number of nodes that should be running the daemon
+                  pod (including nodes correctly running the daemon pod).
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+                format: int32
+                type: integer
+              numberAvailable:
+                description: |-
+                  The number of nodes that should be running the
+                  daemon pod and have one or more of the daemon pod running and
+                  available (ready for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              numberMisscheduled:
+                description: |-
+                  The number of nodes that are running the daemon pod, but are
+                  not supposed to run the daemon pod.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+                format: int32
+                type: integer
+              numberReady:
+                description: |-
+                  numberReady is the number of nodes that should be running the daemon pod and have one
+                  or more of the daemon pod running with a Ready Condition.
+                format: int32
+                type: integer
+              numberUnavailable:
+                description: |-
+                  The number of nodes that should be running the
+                  daemon pod and have none of the daemon pod running and available
+                  (ready for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The most recent generation observed by the daemon set
+                  controller.
+                format: int64
+                type: integer
+              updatedNumberScheduled:
+                description: The total number of nodes that are running updated daemon
+                  pod
+                format: int32
+                type: integer
+            required:
+            - currentNumberScheduled
+            - desiredNumberScheduled
+            - numberMisscheduled
+            - numberReady
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_streams.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_streams.yaml
@@ -1,0 +1,676 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: streams.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: Stream
+    listKind: StreamList
+    plural: streams
+    singular: stream
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.messages
+      name: Msgs
+      type: integer
+    - jsonPath: .status.bytes
+      name: Bytes
+      type: integer
+    - jsonPath: .status.last_ts
+      name: Last Msg
+      type: date
+    - jsonPath: .spec.store
+      name: Store
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Stream is a persistent Tawon data stream.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StreamSpec defines the desired state of Stream
+            properties:
+              maxage:
+                description: |-
+                  MaxAge is the default retention period for Streams created on this
+                  StreamStore.
+                type: string
+              maxbytes:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  MaxBytes is the default retention size for Streams created on this
+                  StreamStore.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              maxmsgs:
+                description: |-
+                  MaxMsgs is the default retention message count for Streams created on
+                  this StreamStore.
+                format: int64
+                type: integer
+              store:
+                description: Name of the StreamStore to use for this Stream. Defaults
+                  to "default".
+                type: string
+            type: object
+          status:
+            description: StreamStatus defines the observed state of Stream
+            properties:
+              bytes:
+                description: The number of bytes stored in the stream.
+                format: int64
+                type: integer
+              conditions:
+                description: Stream Conditions.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              consumer_count:
+                description: The number of consumers for the stream.
+                type: integer
+              directives:
+                description: Directives feeding into this stream.
+                items:
+                  properties:
+                    condition:
+                      description: |-
+                        Conditions are the conditions that must be met for the directive to be
+                        applied.
+                      properties:
+                        and:
+                          description: And is a list of conditions that must be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    and:
+                                      description: And is a list of conditions that
+                                        must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    or:
+                                      description: Or is a list of conditions, any
+                                        of which must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    and:
+                                      description: And is a list of conditions that
+                                        must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    or:
+                                      description: Or is a list of conditions, any
+                                        of which must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        equal:
+                          description: Equal is a textual equality condition.
+                          properties:
+                            field:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - field
+                          - value
+                          type: object
+                        or:
+                          description: Or is a list of conditions, any of which must
+                            be met.
+                          items:
+                            properties:
+                              and:
+                                description: And is a list of conditions that must
+                                  be met.
+                                items:
+                                  properties:
+                                    and:
+                                      description: And is a list of conditions that
+                                        must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    or:
+                                      description: Or is a list of conditions, any
+                                        of which must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              equal:
+                                description: Equal is a textual equality condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - field
+                                - value
+                                type: object
+                              or:
+                                description: Or is a list of conditions, any of which
+                                  must be met.
+                                items:
+                                  properties:
+                                    and:
+                                      description: And is a list of conditions that
+                                        must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    equal:
+                                      description: Equal is a textual equality condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - field
+                                      - value
+                                      type: object
+                                    or:
+                                      description: Or is a list of conditions, any
+                                        of which must be met.
+                                      items:
+                                        properties:
+                                          equal:
+                                            description: Equal is a textual equality
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - field
+                                            - value
+                                            type: object
+                                          regex:
+                                            description: Regex is a regular expression
+                                              condition.
+                                            properties:
+                                              field:
+                                                type: string
+                                              regex:
+                                                type: string
+                                            required:
+                                            - field
+                                            - regex
+                                            type: object
+                                        type: object
+                                      type: array
+                                    regex:
+                                      description: Regex is a regular expression condition.
+                                      properties:
+                                        field:
+                                          type: string
+                                        regex:
+                                          type: string
+                                      required:
+                                      - field
+                                      - regex
+                                      type: object
+                                  type: object
+                                type: array
+                              regex:
+                                description: Regex is a regular expression condition.
+                                properties:
+                                  field:
+                                    type: string
+                                  regex:
+                                    type: string
+                                required:
+                                - field
+                                - regex
+                                type: object
+                            type: object
+                          type: array
+                        regex:
+                          description: Regex is a regular expression condition.
+                          properties:
+                            field:
+                              type: string
+                            regex:
+                              type: string
+                          required:
+                          - field
+                          - regex
+                          type: object
+                      type: object
+                    finished_at:
+                      description: FinishedAt is the time when the directive was finished.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name of the Directive to use.
+                      type: string
+                    started_at:
+                      description: StartedAt is the time when the directive was started.
+                      format: date-time
+                      type: string
+                    tasks:
+                      description: Tasks pipeline.
+                      items:
+                        description: Task represents a named task in a directive task
+                          pipeline.
+                        properties:
+                          config:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Config is an opaque map for the task's configuration. Each task has its
+                              own configuration schema.
+                            type: object
+                          task:
+                            description: Task is the name of the task.
+                            type: string
+                        required:
+                        - task
+                        type: object
+                      type: array
+                  required:
+                  - tasks
+                  type: object
+                type: array
+              first_seq:
+                description: The first sequence number in the stream.
+                format: int64
+                type: integer
+              first_ts:
+                description: The time of the first message in the stream.
+                format: date-time
+                type: string
+              last_seq:
+                description: The last sequence number in the stream.
+                format: int64
+                type: integer
+              last_ts:
+                description: The time of the last message in the stream.
+                format: date-time
+                type: string
+              messages:
+                description: The number of messages in the stream.
+                format: int64
+                type: integer
+              num_deleted:
+                description: The number of deleted messages in the stream.
+                type: integer
+              num_subjects:
+                description: The number of subjects for the stream.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_streamstores.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_streamstores.yaml
@@ -1,0 +1,2361 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: streamstores.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: StreamStore
+    listKind: StreamStoreList
+    plural: streamstores
+    singular: streamstore
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StreamStore is the Schema for the streamstores API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StreamStoreSpec defines the desired state of StreamStore
+            properties:
+              defaults:
+                description: |-
+                  Defaults values for Streams created on this StreatmStore, if the Stream
+                  creator does not set these values.
+                properties:
+                  maxage:
+                    description: |-
+                      MaxAge is the default retention period for Streams created on this
+                      StreamStore.
+                    type: string
+                  maxbytes:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxBytes is the default retention size for Streams created on this
+                      StreamStore.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxmsgs:
+                    description: |-
+                      MaxMsgs is the default retention message count for Streams created on
+                      this StreamStore.
+                    format: int64
+                    type: integer
+                type: object
+              jetstream:
+                description: JetStream defines the NATS JetStream configuration for
+                  this StreamStore.
+                properties:
+                  container:
+                    description: Container options.
+                    properties:
+                      disabled:
+                        description: |-
+                          Disable container.
+                          If enabled, this will cause the container to do nothing. It will not
+                          start tawon, it will just sleep indefinitely. Only useful for debugging.
+                        type: boolean
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key
+                          exists in multiplesources, the value associated with the last source will
+                          take precedence. Values defined by an Env with a duplicate key will take
+                          precedence.
+                          Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      name:
+                        description: Name of container.
+                        type: string
+                      resources:
+                        description: |-
+                          Compute Resources required by the container.
+                          More info:
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      securityContext:
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info:
+                          https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  daemonSet:
+                    description: StatefulSet options.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that
+                          may be set by external tools to store and retrieve arbitrary metadata.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication
+                          controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: Name of StatefulSet.
+                        type: string
+                      serviceName:
+                        description: ServiceName of StatefulSet.
+                        type: string
+                    type: object
+                  image:
+                    description: Container image options.
+                    properties:
+                      credentialsSecret:
+                        description: |-
+                          Reference to the secret containing the Image registry credentials used to
+                          pull the image.
+
+                          Defaults to looking for a secret with the name
+                          "tawon-registry-credentials" in the same namespace. If not present, the
+                          image pull will not be authenticated.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      image:
+                        description: Container image name.
+                        type: string
+                      pullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          More info:
+                          https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                          otherwise.
+                        type: string
+                    type: object
+                  nats:
+                    description: NATS server configuration including authentication
+                      settings.
+                    properties:
+                      authEnabled:
+                        description: |-
+                          AuthEnabled controls whether NATS server authentication is enabled.
+                          A nil value means no explicit preference. Operator-managed StreamStores set
+                          this to true by default, while custom StreamStores remain unauthenticated
+                          unless this is explicitly true.
+                        type: boolean
+                      clientName:
+                        description: ' NATS Client name.'
+                        type: string
+                      credentialsSecret:
+                        description: |-
+                          NATS credentials secret. The secret must contain a "token" key.
+                          Operator-managed StreamStores default this to the generated StreamStore auth secret.
+                          If auth is enabled and this field is empty, clients derive the generated
+                          secret name from the referenced StreamStore name.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      url:
+                        description: NATS server URL.
+                        type: string
+                    type: object
+                  networkPolicy:
+                    description: NetworkPolicy enables or disables the creation of
+                      a NetworkPolicy for the JetStream.
+                    type: boolean
+                  pod:
+                    description: Pod options.
+                    properties:
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that
+                          may be set by external tools to store and retrieve arbitrary metadata.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      automountServiceAccountToken:
+                        description: |-
+                          AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          If not set, the default behavior is to not mount the service account token (for security compliance).
+                          Set to true to enable access to the Kubernetes API from within the pod.
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication
+                          controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: Name of the pod.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a
+                          node.
+                          Selector which must match a node's labels for the pod to be scheduled on
+                          that node.
+                          More info:
+                          https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
+                      securityContext:
+                        description: |-
+                          SecurityContext holds pod-level security attributes and common container settings.
+                          Optional: Defaults to empty.  See type description for default values of
+                          each field.
+                        properties:
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod.
+                              Some volume types allow the Kubelet to change the ownership of that volume
+                              to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup
+                              2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                              3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: |-
+                              fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                              before being exposed inside Pod. This field will only apply to
+                              volume types which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such as: secret, configmaps
+                              and emptydir.
+                              Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in SecurityContext.  If set in
+                              both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: |-
+                              A list of groups applied to the first process run in each container, in addition
+                              to the container's primary GID, the fsGroup (if specified), and group memberships
+                              defined in the container image for the uid of the container process. If unspecified,
+                              no additional groups are added to any container. Note that group memberships
+                              defined in the container image for the uid of the container process are still effective,
+                              even if they are not included in this list.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: |-
+                              Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                              sysctls (by the container runtime) might fail to launch.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options within a container's SecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccountName:
+                        description: |-
+                          ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                        type: string
+                      tolerations:
+                        description: |-
+                          If specified, the pod's tolerations.
+                          More info:
+                          https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              limits:
+                description: |-
+                  Limits for Streams created on this StreamStore. The creator cannot set
+                  these values higher than the limits set here.
+                properties:
+                  maxage:
+                    description: |-
+                      MaxAge is the default retention period for Streams created on this
+                      StreamStore.
+                    type: string
+                  maxbytes:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxBytes is the default retention size for Streams created on this
+                      StreamStore.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxmsgs:
+                    description: |-
+                      MaxMsgs is the default retention message count for Streams created on
+                      this StreamStore.
+                    format: int64
+                    type: integer
+                type: object
+              persistentVolumeClaimRetentionPolicy:
+                description: |-
+                  persistentVolumeClaimRetentionPolicy describes the lifecycle of
+                  persistent volume claims created from volumeClaimTemplate. By default,
+                  all persistent volume claims are created as needed and retained until
+                  manually deleted. This policy allows the lifecycle to be altered, for
+                  example by deleting persistent volume claims when their StreamStore is
+                  deleted, or when their pod is scaled down.
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
+              tls:
+                description: |-
+                  TLS configures the trust strategy clients use to verify the
+                  StreamStore's NATS server. When unset, the operator falls back to
+                  the historical behavior (insecure connections logging a warning)
+                  for one release; a later release will flip the default to
+                  operator-ca / openshift-service-ca based on platform detection.
+                properties:
+                  caConfigMapRef:
+                    description: |-
+                      CAConfigMapRef references a ConfigMap key holding a PEM-encoded CA
+                      bundle. Optional; used when the trusted CA is delivered separately
+                      from the cert Secret (for example with cert-manager + external CA).
+                    properties:
+                      key:
+                        description: |-
+                          Key within the ConfigMap holding the value of interest. Defaults to
+                          "ca.crt" when consumers expect a CA bundle.
+                        type: string
+                      name:
+                        description: Name of the ConfigMap.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  mode:
+                    description: |-
+                      Mode selects the trust strategy. When unset, the operator picks a
+                      default based on platform detection: openshift-service-ca on
+                      OpenShift clusters, operator-ca otherwise.
+                    enum:
+                    - openshift-service-ca
+                    - operator-ca
+                    - provided
+                    - insecure
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef references a Secret holding tls.crt, tls.key, and
+                      optionally ca.crt. Required when mode is "provided".
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  serverName:
+                    description: |-
+                      ServerName overrides the SNI / verification hostname clients use
+                      when connecting. Defaults to the StreamStore's in-cluster service
+                      DNS.
+                    type: string
+                type: object
+              volumeClaimTemplate:
+                description: |-
+                  VolumeClaimTemplate is a template for the volume claims that will be
+                  created for this StreamStore. The template allows users to specify
+                  customization such as storageClassName, resources, mountPropagation, and
+                  labels for the volume claims. By default, no persistence will be enabled
+                  and it will work as a non-persistent queue (NATS without JetStream).
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: |-
+                      spec defines the desired characteristics of a volume requested by a pod author.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                          will be set by the persistentvolume controller if it exists.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  status:
+                    description: |-
+                      status represents the current information/status of a persistent volume claim.
+                      Read-only.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the actual access modes the volume backing the PVC has.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                      allocatedResourceStatuses:
+                        additionalProperties:
+                          description: |-
+                            When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                            that it does not recognizes, then it should ignore that update and let other controllers
+                            handle it.
+                          type: string
+                        description: "allocatedResourceStatuses stores status of resource
+                          being resized for the given PVC.\nKey names follow standard
+                          Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed
+                          keys:\n\t\t- storage - the capacity of the volume.\n\t*
+                          Custom resources must use implementation-defined prefixed
+                          names such as \"example.com/my-custom-resource\"\nApart
+                          from above values - keys that are unprefixed or have kubernetes.io
+                          prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus
+                          can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState
+                          set when resize controller starts resizing the volume in
+                          control-plane.\n\t- ControllerResizeFailed:\n\t\tState set
+                          when resize has failed in resize controller with a terminal
+                          error.\n\t- NodeResizePending:\n\t\tState set when resize
+                          controller has finished resizing the volume but further
+                          resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState
+                          set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState
+                          set when resizing has failed in kubelet with a terminal
+                          error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor
+                          example: if expanding a PVC for more capacity - this field
+                          can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage']
+                          = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                          = \"NodeResizeFailed\"\nWhen this field is not set, it means
+                          that no resize operation is in progress for the given PVC.\n\nA
+                          controller that receives PVC update with previously unknown
+                          resourceName or ClaimResourceStatus\nshould ignore the update
+                          for the purpose it was designed. For example - a controller
+                          that\nonly is responsible for resizing capacity of the volume,
+                          should ignore PVC updates that change other valid\nresources
+                          associated with PVC.\n\nThis is an alpha field and requires
+                          enabling RecoverVolumeExpansionFailure feature."
+                        type: object
+                        x-kubernetes-map-type: granular
+                      allocatedResources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: "allocatedResources tracks the resources allocated
+                          to a PVC including its capacity.\nKey names follow standard
+                          Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed
+                          keys:\n\t\t- storage - the capacity of the volume.\n\t*
+                          Custom resources must use implementation-defined prefixed
+                          names such as \"example.com/my-custom-resource\"\nApart
+                          from above values - keys that are unprefixed or have kubernetes.io
+                          prefix are considered\nreserved and hence may not be used.\n\nCapacity
+                          reported here may be larger than the actual capacity when
+                          a volume expansion operation\nis requested.\nFor storage
+                          quota, the larger value from allocatedResources and PVC.spec.resources
+                          is used.\nIf allocatedResources is not set, PVC.spec.resources
+                          alone is used for quota calculation.\nIf a volume expansion
+                          capacity request is lowered, allocatedResources is only\nlowered
+                          if there are no expansion operations in progress and if
+                          the actual volume capacity\nis equal or lower than the requested
+                          capacity.\n\nA controller that receives PVC update with
+                          previously unknown resourceName\nshould ignore the update
+                          for the purpose it was designed. For example - a controller
+                          that\nonly is responsible for resizing capacity of the volume,
+                          should ignore PVC updates that change other valid\nresources
+                          associated with PVC.\n\nThis is an alpha field and requires
+                          enabling RecoverVolumeExpansionFailure feature."
+                        type: object
+                      capacity:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: capacity represents the actual resources of the
+                          underlying volume.
+                        type: object
+                      conditions:
+                        description: |-
+                          conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
+                          resized then the Condition will be set to 'ResizeStarted'.
+                        items:
+                          description: PersistentVolumeClaimCondition contains details
+                            about state of pvc
+                          properties:
+                            lastProbeTime:
+                              description: lastProbeTime is the time we probed the
+                                condition.
+                              format: date-time
+                              type: string
+                            lastTransitionTime:
+                              description: lastTransitionTime is the time the condition
+                                transitioned from one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: message is the human-readable message indicating
+                                details about last transition.
+                              type: string
+                            reason:
+                              description: |-
+                                reason is a unique, this should be a short, machine understandable string that gives the reason
+                                for condition's last transition. If it reports "ResizeStarted" that means the underlying
+                                persistent volume is being resized.
+                              type: string
+                            status:
+                              type: string
+                            type:
+                              description: PersistentVolumeClaimConditionType is a
+                                valid value of PersistentVolumeClaimCondition.Type
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentVolumeAttributesClassName:
+                        description: |-
+                          currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
+                          When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                          This is an alpha field and requires enabling VolumeAttributesClass feature.
+                        type: string
+                      modifyVolumeStatus:
+                        description: |-
+                          ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
+                          When this is unset, there is no ModifyVolume operation being attempted.
+                          This is an alpha field and requires enabling VolumeAttributesClass feature.
+                        properties:
+                          status:
+                            description: "status is the status of the ControllerModifyVolume
+                              operation. It can be in any of following states:\n -
+                              Pending\n   Pending indicates that the PersistentVolumeClaim
+                              cannot be modified due to unmet requirements, such as\n
+                              \  the specified VolumeAttributesClass not existing.\n
+                              - InProgress\n   InProgress indicates that the volume
+                              is being modified.\n - Infeasible\n  Infeasible indicates
+                              that the request has been rejected as invalid by the
+                              CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass
+                              needs to be specified.\nNote: New statuses can be added
+                              in the future. Consumers should check for unknown statuses
+                              and fail appropriately."
+                            type: string
+                          targetVolumeAttributesClassName:
+                            description: targetVolumeAttributesClassName is the name
+                              of the VolumeAttributesClass the PVC currently being
+                              reconciled
+                            type: string
+                        required:
+                        - status
+                        type: object
+                      phase:
+                        description: phase represents the current phase of PersistentVolumeClaim.
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: StreamStoreStatus defines the observed state of StreamStore
+            properties:
+              conditions:
+                description: StreamStore Conditions.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              tls:
+                description: |-
+                  TLS surfaces the resolved trust material clients should consume.
+                  In-cluster controllers and tawonctl read this rather than
+                  re-deriving the configuration from spec.
+                properties:
+                  caConfigMapKey:
+                    description: |-
+                      CAConfigMapKey is the key within CAConfigMapName holding the CA
+                      bundle. Defaults to "ca.crt".
+                    type: string
+                  caConfigMapName:
+                    description: |-
+                      CAConfigMapName is the ConfigMap in the StreamStore's namespace
+                      that holds the trusted CA bundle clients should consume. Empty in
+                      insecure mode.
+                    type: string
+                  mode:
+                    description: Mode is the resolved trust mode after defaulting.
+                    enum:
+                    - openshift-service-ca
+                    - operator-ca
+                    - provided
+                    - insecure
+                    type: string
+                  notAfter:
+                    description: NotAfter is the expiry of the currently issued serving
+                      cert.
+                    format: date-time
+                    type: string
+                  serverName:
+                    description: |-
+                      ServerName is the value clients should use for SNI and
+                      certificate verification.
+                    type: string
+                required:
+                - mode
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_topologyaggregators.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/manifests/tawon.mantisnet.com_topologyaggregators.yaml
@@ -1,0 +1,2202 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: topologyaggregators.tawon.mantisnet.com
+spec:
+  group: tawon.mantisnet.com
+  names:
+    kind: TopologyAggregator
+    listKind: TopologyAggregatorList
+    plural: topologyaggregators
+    singular: topologyaggregator
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TopologyAggregator is a deprecated no-op CRD retained for compatibility.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TopologyAggregatorSpec defines the desired state of TopologyAggregator
+            properties:
+              container:
+                description: Container options. See TawonContainerSpec.
+                properties:
+                  disabled:
+                    description: |-
+                      Disable container.
+                      If enabled, this will cause the container to do nothing. It will not
+                      start tawon, it will just sleep indefinitely. Only useful for debugging.
+                    type: boolean
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key
+                      exists in multiplesources, the value associated with the last source will
+                      take precedence. Values defined by an Env with a duplicate key will take
+                      precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  name:
+                    description: Name of container.
+                    type: string
+                  resources:
+                    description: |-
+                      Compute Resources required by the container.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info:
+                      https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              debug:
+                description: debugging configuration.
+                properties:
+                  deadlockDetector:
+                    description: Enable Deadlock Detector
+                    type: boolean
+                  debug:
+                    description: |-
+                      Debug flags enable extra logging in different components.
+                      See DebugFlag for the list of available flags.
+                    items:
+                      description: |-
+                        Debug flags enable extra logging in different components.
+                        Notably it enables BPF logging for the respective components.
+                      enum:
+                      - Exec
+                      - Payload
+                      - TLS
+                      - Flows
+                      - ResetConn
+                      - Feedback
+                      type: string
+                    type: array
+                  extraFlags:
+                    description: Extra flags to pass to the executable.
+                    items:
+                      type: string
+                    type: array
+                  logLevel:
+                    description: |-
+                      Logging level.
+                      One of "trace", "debug", "info", "warn", or "error".
+                    type: string
+                  silent:
+                    description: |-
+                      Silent flags disable some non-critical logging in different components.
+                      See SilentFlag for the list of available flags.
+                    items:
+                      description: Silent flags disable some non-critical logging
+                        in different components.
+                      enum:
+                      - Exec
+                      - Flows
+                      type: string
+                    type: array
+                type: object
+              deployment:
+                description: Deployment options. See TopologyDeploymentSpec.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of deployment.
+                    type: string
+                type: object
+              image:
+                description: |-
+                  Container image options.
+
+                  Container image defaults to "repo.f5.com/eob/images/tawon:ubi-build-xx".
+                properties:
+                  credentialsSecret:
+                    description: |-
+                      Reference to the secret containing the Image registry credentials used to
+                      pull the image.
+
+                      Defaults to looking for a secret with the name
+                      "tawon-registry-credentials" in the same namespace. If not present, the
+                      image pull will not be authenticated.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  image:
+                    description: Container image name.
+                    type: string
+                  pullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      More info:
+                      https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                      Defaults to "Always" if :latest tag is specified, or "IfNotPresent"
+                      otherwise.
+                    type: string
+                type: object
+              messaging:
+                description: |-
+                  Default messaging configuration. This is the default configuration for
+                  subscribing to the topology stream.
+                properties:
+                  nats:
+                    description: Message bus NATS configuration.
+                    properties:
+                      authEnabled:
+                        description: |-
+                          AuthEnabled controls whether NATS server authentication is enabled.
+                          A nil value means no explicit preference. Operator-managed StreamStores set
+                          this to true by default, while custom StreamStores remain unauthenticated
+                          unless this is explicitly true.
+                        type: boolean
+                      clientName:
+                        description: ' NATS Client name.'
+                        type: string
+                      credentialsSecret:
+                        description: |-
+                          NATS credentials secret. The secret must contain a "token" key.
+                          Operator-managed StreamStores default this to the generated StreamStore auth secret.
+                          If auth is enabled and this field is empty, clients derive the generated
+                          secret name from the referenced StreamStore name.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      url:
+                        description: NATS server URL.
+                        type: string
+                    type: object
+                  type:
+                    description: |-
+                      Message bus type.
+
+                      Defaults to "nats". Currently only "nats" is supported.
+                    enum:
+                    - nats
+                    type: string
+                type: object
+              monitoring:
+                description: Prometheus monitoring.
+                properties:
+                  disabled:
+                    description: Disable monitoring. Monitoring is enabled by default.
+                    type: boolean
+                  namespace:
+                    description: Namespace if the prefix added to the metrics.
+                    type: string
+                  path:
+                    description: Path to expose metrics on.
+                    type: string
+                  port:
+                    description: Port to expose metrics on.
+                    format: int32
+                    type: integer
+                  portName:
+                    description: Exposed port name.
+                    type: string
+                type: object
+              pod:
+                description: Pod options. See TawonPodSpec.
+                properties:
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  automountServiceAccountToken:
+                    description: |-
+                      AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                      If not set, the default behavior is to not mount the service account token (for security compliance).
+                      Set to true to enable access to the Kubernetes API from within the pod.
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of the pod.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is a selector which must be true for the pod to fit on a
+                      node.
+                      Selector which must match a node's labels for the pod to be scheduled on
+                      that node.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
+                  securityContext:
+                    description: |-
+                      SecurityContext holds pod-level security attributes and common container settings.
+                      Optional: Defaults to empty.  See type description for default values of
+                      each field.
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in addition
+                          to the container's primary GID, the fsGroup (if specified), and group memberships
+                          defined in the container image for the uid of the container process. If unspecified,
+                          no additional groups are added to any container. Note that group memberships
+                          defined in the container image for the uid of the container process are still effective,
+                          even if they are not included in this list.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                    type: string
+                  tolerations:
+                    description: |-
+                      If specified, the pod's tolerations.
+                      More info:
+                      https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              service:
+                description: Controller service options.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations is an unstructured key value map stored with a resource that
+                      may be set by external tools to store and retrieve arbitrary metadata.
+                      More info: http://kubernetes.io/docs/user-guide/annotations
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication
+                      controllers and services.
+                      More info: http://kubernetes.io/docs/user-guide/labels
+                    type: object
+                  name:
+                    description: Name of the service.
+                    type: string
+                  spec:
+                    description: Service spec.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: |-
+                          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                          allocated for services with type LoadBalancer.  Default is "true". It
+                          may be set to "false" if the cluster load-balancer does not rely on
+                          NodePorts.  If the caller requests specific NodePorts (by specifying a
+                          value), those requests will be respected, regardless of this field.
+                          This field may only be set for services with type LoadBalancer and will
+                          be cleared if the type is changed to any other type.
+                        type: boolean
+                      clusterIP:
+                        description: |-
+                          clusterIP is the IP address of the service and is usually assigned
+                          randomly. If an address is specified manually, is in-range (as per
+                          system configuration), and is not in use, it will be allocated to the
+                          service; otherwise creation of the service will fail. This field may not
+                          be changed through updates unless the type field is also being changed
+                          to ExternalName (which requires this field to be blank) or the type
+                          field is being changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values are "None",
+                          empty string (""), or a valid IP address. Setting this to "None" makes a
+                          "headless service" (no virtual IP), which is useful when direct endpoint
+                          connections are preferred and proxying is not required.  Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                          when creating a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        type: string
+                      clusterIPs:
+                        description: |-
+                          ClusterIPs is a list of IP addresses assigned to this service, and are
+                          usually assigned randomly.  If an address is specified manually, is
+                          in-range (as per system configuration), and is not in use, it will be
+                          allocated to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the type field is
+                          also being changed to ExternalName (which requires this field to be
+                          empty) or the type field is being changed from ExternalName (in which
+                          case this field may optionally be specified, as describe above).  Valid
+                          values are "None", empty string (""), or a valid IP address.  Setting
+                          this to "None" makes a "headless service" (no virtual IP), which is
+                          useful when direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort, and
+                          LoadBalancer. If this field is specified when creating a Service of type
+                          ExternalName, creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified, it will
+                          be initialized from the clusterIP field.  If this field is specified,
+                          clients must ensure that clusterIPs[0] and clusterIP have the same
+                          value.
+
+                          This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies field. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: |-
+                          externalIPs is a list of IP addresses for which nodes in the cluster
+                          will also accept traffic for this service.  These IPs are not managed by
+                          Kubernetes.  The user is responsible for ensuring that traffic arrives
+                          at a node with this IP.  A common example is external load-balancers
+                          that are not part of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: |-
+                          externalName is the external reference that discovery mechanisms will
+                          return as an alias for this service (e.g. a DNS CNAME record). No
+                          proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                        type: string
+                      externalTrafficPolicy:
+                        description: |-
+                          externalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on one of the Service's "externally-facing" addresses (NodePorts,
+                          ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                          the service in a way that assumes that external load balancers will take care
+                          of balancing the service traffic between nodes, and so each node will deliver
+                          traffic only to the node-local endpoints of the service, without masquerading
+                          the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                          be dropped.) The default value, "Cluster", uses the standard behavior of
+                          routing to all endpoints evenly (possibly modified by topology and other
+                          features). Note that traffic sent to an External IP or LoadBalancer IP from
+                          within the cluster will always get "Cluster" semantics, but clients sending to
+                          a NodePort from within the cluster may need to take traffic policy into account
+                          when picking a node.
+                        type: string
+                      healthCheckNodePort:
+                        description: |-
+                          healthCheckNodePort specifies the healthcheck nodePort for the service.
+                          This only applies when type is set to LoadBalancer and
+                          externalTrafficPolicy is set to Local. If a value is specified, is
+                          in-range, and is not in use, it will be used.  If not specified, a value
+                          will be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints for this
+                          service or not.  If this field is specified when creating a Service
+                          which does not need it, creation will fail. This field will be wiped
+                          when updating a Service to no longer need it (e.g. changing type).
+                          This field cannot be updated once set.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: |-
+                          InternalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                          only want to talk to endpoints of the service on the same node as the pod,
+                          dropping the traffic if there are no local endpoints. The default value,
+                          "Cluster", uses the standard behavior of routing to all endpoints evenly
+                          (possibly modified by topology and other features).
+                        type: string
+                      ipFamilies:
+                        description: |-
+                          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                          service. This field is usually assigned automatically based on cluster
+                          configuration and the ipFamilyPolicy field. If this field is specified
+                          manually, the requested family is available in the cluster,
+                          and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                          the service will fail. This field is conditionally mutable: it allows
+                          for adding or removing a secondary IP family, but it does not allow
+                          changing the primary IP family of the Service. Valid values are "IPv4"
+                          and "IPv6".  This field only applies to Services of types ClusterIP,
+                          NodePort, and LoadBalancer, and does apply to "headless" services.
+                          This field will be wiped when updating a Service to type ExternalName.
+
+                          This field may hold a maximum of two entries (dual-stack families, in
+                          either order).  These families must correspond to the values of the
+                          clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                          governed by the ipFamilyPolicy field.
+                        items:
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: |-
+                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                          this Service. If there is no value provided, then this field will be set
+                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                          a single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise fail). The
+                          ipFamilies and clusterIPs fields depend on the value of this field. This
+                          field will be wiped when updating a service to type ExternalName.
+                        type: string
+                      loadBalancerClass:
+                        description: |-
+                          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                          If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                          e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                          This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                          balancer implementation is used, today this is typically done through the cloud provider integration,
+                          but should apply for any default implementation. If set, it is assumed that a load balancer
+                          implementation is watching for Services with a matching class. Any default load balancer
+                          implementation (e.g. cloud providers) should ignore Services that set this field.
+                          This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                        type: string
+                      loadBalancerIP:
+                        description: |-
+                          Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider supports specifying
+                          the loadBalancerIP when a load balancer is created.
+                          This field will be ignored if the cloud-provider does not support the feature.
+                          Deprecated: This field was under-specified and its meaning varies across implementations.
+                          Using it is non-portable and it may not support dual-stack.
+                          Users are encouraged to use implementation-specific annotations when available.
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: |-
+                          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                          load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                          cloud-provider does not support the feature."
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: |-
+                          The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: |-
+                                The application protocol for this port.
+                                This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                This field follows standard Kubernetes label syntax.
+                                Valid values are either:
+
+                                * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                                * Kubernetes-defined prefixed names:
+                                  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                                * Other protocols should use implementation-defined prefixed names such as
+                                mycompany.com/my-custom-protocol.
+                              type: string
+                            name:
+                              description: |-
+                                The name of this port within the service. This must be a DNS_LABEL.
+                                All ports within a ServiceSpec must have unique names. When considering
+                                the endpoints for a Service, this must match the 'name' field in the
+                                EndpointPort.
+                                Optional if only one ServicePort is defined on this service.
+                              type: string
+                            nodePort:
+                              description: |-
+                                The port on each node on which this service is exposed when type is
+                                NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                specified, in-range, and not in use it will be used, otherwise the
+                                operation will fail.  If not specified, a port will be allocated if this
+                                Service requires one.  If this field is specified when creating a
+                                Service which does not need it, creation will fail. This field will be
+                                wiped when updating a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP).
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: |-
+                                The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the pods targeted by the service.
+                                Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named port in the
+                                target Pod's container ports. If this is not specified, the value
+                                of the 'port' field is used (an identity map).
+                                This field is ignored for services with clusterIP=None, and should be
+                                omitted or set equal to the 'port' field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: |-
+                          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                          Service should disregard any indications of ready/not-ready.
+                          The primary use case for setting this field is for a StatefulSet's Headless Service to
+                          propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                          The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                          Services interpret this to mean that all endpoints are considered "ready" even if the
+                          Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                          through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Route service traffic to pods with label keys and values matching this
+                          selector. If empty or not present, the service is assumed to have an
+                          external process managing its endpoints, which Kubernetes will not
+                          modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                          Ignored if type is ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: |-
+                          Supports "ClientIP" and "None". Used to maintain session affinity.
+                          Enable client IP based session affinity.
+                          Must be ClientIP or None.
+                          Defaults to None.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: |-
+                                  timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                  The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                  Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: |-
+                          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                          options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                          "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                          to endpoints. Endpoints are determined by the selector or if that is not
+                          specified, by manual construction of an Endpoints object or
+                          EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                          allocated and the endpoints are published as a set of endpoints rather
+                          than a virtual IP.
+                          "NodePort" builds on ClusterIP and allocates a port on every node which
+                          routes to the same endpoints as the clusterIP.
+                          "LoadBalancer" builds on NodePort and creates an external load-balancer
+                          (if supported in the current cloud) which routes to the same endpoints
+                          as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: TopologyAggregatorStatus defines the observed state of TopologyAggregator.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describe that TopologyAggregator is deprecated and no longer
+                  creates topology aggregation resources.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/tawon-operator/3.1.0-rc1/metadata/annotations.yaml
+++ b/operators/tawon-operator/3.1.0-rc1/metadata/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: tawon-operator
+  operators.operatorframework.io.bundle.channels.v1: candidate-v3
+  operators.operatorframework.io.bundle.channel.default.v1: candidate-v3
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.12-v4.17


### PR DESCRIPTION
Submitting tawon-operator version 3.1.0-rc1 for certification.

**Certification Project ID:** 643d5bbf2621b24cf11a0364

This submission was validated locally using the operator-ci-pipeline on OCP 4.14.
All preflight checks passed (DeployableByOLM, ValidateOperatorBundle, ScorecardBasicSpecCheck, ScorecardOlmSuiteCheck).

Test results have been uploaded to Pyxis.