### PR TITLE
operator axera-operator (0.7.4)

### DIFF
--- a/operators/axera-operator/0.7.4/manifests/axera-operator-axera-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator-axera-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+  name: axera-operator-axera-admin-role
+rules:
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras
+  verbs:
+  - '*'
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras/status
+  verbs:
+  - get

--- a/operators/axera-operator/0.7.4/manifests/axera-operator-axera-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator-axera-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+  name: axera-operator-axera-editor-role
+rules:
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras/status
+  verbs:
+  - get

--- a/operators/axera-operator/0.7.4/manifests/axera-operator-axera-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator-axera-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+  name: axera-operator-axera-viewer-role
+rules:
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras/status
+  verbs:
+  - get

--- a/operators/axera-operator/0.7.4/manifests/axera-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+    control-plane: controller-manager
+  name: axera-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: axera-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/axera-operator/0.7.4/manifests/axera-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: axera-operator-metrics-monitor
+  labels:
+    app.kubernetes.io/name: axera-operator
+    control-plane: controller-manager
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: axera-operator

--- a/operators/axera-operator/0.7.4/manifests/axera-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: axera-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/axera-operator/0.7.4/manifests/axera-operator.clusterserviceversion.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-operator.clusterserviceversion.yaml
@@ -1,0 +1,450 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "platform.axerasecurity.com/v1alpha1",
+          "kind": "Axera",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "axera-operator"
+            },
+            "name": "axera"
+          },
+          "spec": {
+            "ai": {
+              "enabled": true,
+              "external": false,
+              "model": "llama3.2:3b"
+            },
+            "app": {
+              "adminUsername": "admin",
+              "corsOrigins": [
+                "http://localhost:3000"
+              ]
+            },
+            "backup": {
+              "enabled": true,
+              "storage": {
+                "type": "pvc",
+                "createPvc": true,
+                "size": "10Gi",
+                "accessMode": "ReadWriteMany"
+              }
+            },
+            "global": {
+              "clusterDomain": "",
+              "imageRegistry": "quay.io/axera",
+              "storageClass": ""
+            },
+            "imagePullSecret": {
+              "enabled": true,
+              "name": "quay-pull-secret"
+            },
+            "kafka": {
+              "external": false
+            },
+            "postgres": {
+              "external": false
+            },
+            "routes": {
+              "frontend": {
+                "enabled": true
+              }
+            },
+            "version": "v9.17.0"
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: Security, Networking, Monitoring, Logging & Tracing
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    containerImage: quay.io/axera/axera-operator@sha256:9342d972a14de1124d8226fd465d2adc3f4d9a65f021c64ede31dc45c4751cdf
+    createdAt: "2026-07-16T20:00:00Z"
+    description: Deploy and lifecycle-manage the Axera Kubernetes microsegmentation
+      & NDR platform on OpenShift through a single Axera custom resource.
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/AxeraSecurity/axera-operator
+    support: Axera Security
+  name: axera-operator.v0.7.4
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Axera is the Schema for the axeras API — one CR deploys the whole
+        platform.
+      displayName: Axera
+      kind: Axera
+      name: axeras.platform.axerasecurity.com
+      version: v1alpha1
+  description: |
+    # Axera Microsegmentation & NDR Operator
+
+    Axera is a Kubernetes-native **microsegmentation** and **Network Detection &
+    Response (NDR)** platform for Red Hat OpenShift. This operator deploys and
+    lifecycle-manages the entire Axera platform — API, radar, network-policy
+    watcher, allow/drop monitor, frontend console, and (optionally) in-cluster
+    PostgreSQL, Kafka and an on-prem Ollama AI assistant — from a single `Axera`
+    custom resource.
+
+    ## What it does
+    - **One CR, whole platform.** Create an `Axera` resource and the operator
+      reconciles all of the platform's workloads, services, routes, RBAC, SCC and
+      NetworkPolicies into your namespace.
+    - **Least-privilege NetworkPolicy from observed traffic.** Axera watches real
+      east-west and egress traffic and synthesizes default-deny NetworkPolicy.
+    - **Seamless upgrades.** Bump `spec.version` and the operator rolls every
+      component to the new image tag; status reports per-component health.
+    - **Deep insights.** The operator exposes platform-health Prometheus metrics
+      and ships a ServiceMonitor + PrometheusRule (not-ready, component-down,
+      upgrade-stuck, no-managed-policies alerts), and reflects live health and
+      managed-policy count into the CR status.
+    - **Backup & restore.** Built-in Backup & Restore of the platform databases
+      (internal OR external) — scheduled + ad-hoc `pg_dump` / `pg_restore` with
+      download and point-in-time restore, driven from the in-product Backup &
+      restore page; the storage backing (PVC or NFS) is set via `spec.backup`.
+    - **On-prem AI incident triage.** Provider-agnostic; everything stays in the
+      cluster — suitable for air-gapped and regulated environments.
+
+    ## Getting started
+    Create an `Axera` CR (see the sample). The operator surfaces progress on the CR
+    status (`Phase`, `Ready`, conditions, per-component health and the console URL).
+
+    > Container images are pulled from a private registry — provide a pull secret
+    > via `spec.imagePullSecret`.
+  displayName: Axera Microsegmentation & NDR
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4NCA4NCIgd2lkdGg9Ijg0IiBoZWlnaHQ9Ijg0Ij4KICA8cmVjdCB3aWR0aD0iODQiIGhlaWdodD0iODQiIHJ4PSIxNCIgZmlsbD0iI2ZmZmZmZiIvPgogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDcsOCkiPgogICAgPHBhdGggZD0iTTMyLDAgTDMyLDY4IEwxMCw2OCBaIiBmaWxsPSIjZTExZDQ4Ii8+CiAgICA8cGF0aCBkPSJNMzgsMCBMMzgsNjggTDYwLDY4IFoiIGZpbGw9IiNmNDNmNWUiLz4KICAgIDxyZWN0IHg9IjMyIiB5PSIwIiB3aWR0aD0iNiIgaGVpZ2h0PSI2OCIgZmlsbD0iI2ZmZmZmZiIvPgogICAgPHJlY3QgeD0iMTgiIHk9IjQyIiB3aWR0aD0iMTQiIGhlaWdodD0iNiIgZmlsbD0iI2ZiNzE4NSIvPgogICAgPHJlY3QgeD0iMzgiIHk9IjQyIiB3aWR0aD0iMTQiIGhlaWdodD0iNiIgZmlsbD0iI2ZiNzE4NSIvPgogIDwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - persistentvolumeclaims
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - platform.axerasecurity.com
+          resources:
+          - axeras
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - platform.axerasecurity.com
+          resources:
+          - axeras/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - platform.axerasecurity.com
+          resources:
+          - axeras/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - use
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: axera-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: axera-operator
+          control-plane: controller-manager
+        name: axera-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: axera-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: axera-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: quay.io/axera/axera-operator@sha256:9342d972a14de1124d8226fd465d2adc3f4d9a65f021c64ede31dc45c4751cdf
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              imagePullSecrets:
+              - name: quay-pull-secret
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: axera-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: axera-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - microsegmentation
+  - ndr
+  - networkpolicy
+  - zero-trust
+  - openshift
+  - security
+  - observability
+  links:
+  - name: Axera Security
+    url: https://axerasecurity.com
+  - name: Source
+    url: https://github.com/AxeraSecurity/axera-operator
+  maintainers:
+  - email: support@axerasecurity.com
+    name: Axera Security
+  maturity: alpha
+  minKubeVersion: 1.25.0
+  provider:
+    name: Axera Security
+    url: https://axerasecurity.com
+  relatedImages:
+    - name: axera-operator
+      image: quay.io/axera/axera-operator@sha256:9342d972a14de1124d8226fd465d2adc3f4d9a65f021c64ede31dc45c4751cdf
+    - name: microsegmentation-api
+      image: quay.io/axera/microsegmentation-api@sha256:35aa88adc98ba65535a171fb646ef3a8342b14c5ab042da4be1c2b46e48023b0
+    - name: microsegmentation-radar
+      image: quay.io/axera/microsegmentation-radar@sha256:85d9339a57261306fe9a48c217d6ac240f75bb9bb66caf93e429b422bc654411
+    - name: microsegmentation-allowdropmonitor
+      image: quay.io/axera/microsegmentation-allowdropmonitor@sha256:011dae247c3a246964f83559ba2e701990cb531f0dbbe6e8002847b0e1a990ee
+    - name: microsegmentation-networkpolicywatcher
+      image: quay.io/axera/microsegmentation-networkpolicywatcher@sha256:4474a10a6cb75c333698137abcbf72683614555cdd964206a2118276263d17cc
+    - name: microsegmentation-frontend
+      image: quay.io/axera/microsegmentation-frontend@sha256:9ec7be713d62ffec207e51d0708b16d54d4c7eac85176e46046e2448fe15ad5d
+    - name: kafka
+      image: quay.io/axera/kafka@sha256:821720633cf189f4852051569f0794ffbb3aeef3de9e5b47684901af81176852
+    - name: microsegmentation-ollama
+      image: quay.io/axera/microsegmentation-ollama@sha256:a4e95f0a14e6773d2507c593336d94dd5f73fe134fb13438ce069a5a1fefd9fe
+  replaces: axera-operator.v0.7.3
+  version: 0.7.4

--- a/operators/axera-operator/0.7.4/manifests/axera-platform-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/operators/axera-operator/0.7.4/manifests/axera-platform-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,42 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: axera-platform-alerts
+  labels:
+    app.kubernetes.io/name: axera-operator
+spec:
+  groups:
+    - name: axera.platform
+      rules:
+        - alert: AxeraPlatformNotReady
+          expr: axera_platform_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Axera platform not Ready in namespace {{ $labels.namespace }}"
+            description: "Axera CR {{ $labels.axera }} has been not-Ready for 15 minutes."
+        - alert: AxeraComponentDown
+          expr: axera_component_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Axera component {{ $labels.component }} down in {{ $labels.namespace }}"
+            description: "Managed component {{ $labels.component }} has 0 ready replicas for 15 minutes."
+        - alert: AxeraUpgradeStuck
+          expr: axera_upgrade_in_progress == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Axera upgrade stuck in namespace {{ $labels.namespace }}"
+            description: "The platform has been Upgrading for over 30 minutes — check component rollouts."
+        - alert: AxeraNoManagedPolicies
+          expr: axera_managed_networkpolicies == 0
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "Axera manages 0 NetworkPolicies in namespace {{ $labels.namespace }}"
+            description: "No segmentation policies are being managed — the platform may not be enforcing yet."

--- a/operators/axera-operator/0.7.4/manifests/platform.axerasecurity.com_axeras.yaml
+++ b/operators/axera-operator/0.7.4/manifests/platform.axerasecurity.com_axeras.yaml
@@ -1,0 +1,962 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: axeras.platform.axerasecurity.com
+spec:
+  group: platform.axerasecurity.com
+  names:
+    categories:
+    - axera
+    kind: Axera
+    listKind: AxeraList
+    plural: axeras
+    shortNames:
+    - axr
+    singular: axera
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.readyComponents
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Axera is the Schema for the axeras API — one CR deploys the whole
+          platform.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AxeraSpec defines the desired state of the Axera platform.
+            properties:
+              ai:
+                description: AISpec selects internal Ollama vs external LLM endpoint
+                  for incident triage.
+                properties:
+                  advisory:
+                    description: AIAdvisorySpec seeds the initial behavioral-anomaly
+                      advisory settings row.
+                    properties:
+                      cron:
+                        default: 0 */6 * * *
+                        type: string
+                      enabled:
+                        type: boolean
+                      lookbackHours:
+                        default: 24
+                        type: integer
+                      maxDestinationsPerWorkload:
+                        default: 40
+                        type: integer
+                      maxWorkloads:
+                        default: 30
+                        type: integer
+                      minConfidence:
+                        default: 70
+                        type: integer
+                    type: object
+                  baseUrl:
+                    type: string
+                  enabled:
+                    default: true
+                    description: Master switch. false → API runs with Ai__Enabled=false.
+                    type: boolean
+                  external:
+                    default: false
+                    description: true → point at ai.baseUrl; false → deploy Ollama
+                      in-cluster.
+                    type: boolean
+                  extraModels:
+                    items:
+                      type: string
+                    type: array
+                  model:
+                    default: llama3.2:3b
+                    type: string
+                  pullModel:
+                    default: true
+                    type: boolean
+                  storage:
+                    default: 20Gi
+                    description: Internal-Ollama PVC size (external=false).
+                    type: string
+                  temperature:
+                    default: "0.2"
+                    type: string
+                  timeoutSeconds:
+                    default: "120"
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: baseUrl is required when ai.external is true
+                  rule: '!self.external || (has(self.baseUrl) && self.baseUrl != '''')'
+              app:
+                description: |-
+                  AppSpec holds application-wide secrets and config. Empty secret values are
+                  auto-generated on first install and re-read from the Secret on upgrades.
+                properties:
+                  accessTokenSecret:
+                    type: string
+                  adminEmail:
+                    default: admin@example.com
+                    type: string
+                  adminPassword:
+                    type: string
+                  adminUsername:
+                    default: admin
+                    type: string
+                  archiverIntervalMinutes:
+                    default: 60
+                    type: integer
+                  corsOrigins:
+                    description: CORS origins added to all .NET services (frontend
+                      Route URL appended automatically).
+                    items:
+                      type: string
+                    type: array
+                  dpKeysStore:
+                    description: |-
+                      DataProtection key-ring store: "FileSystem" (128Mi RWO PVC, default) or "Database"
+                      (keys in the app DB — storage-less, no PVC, survives restarts). Use Database when the
+                      cluster has no StorageClass.
+                    enum:
+                    - FileSystem
+                    - Database
+                    type: string
+                  encryptionIV:
+                    type: string
+                  encryptionKey:
+                    type: string
+                  internalToken:
+                    type: string
+                  ovn:
+                    description: OVNSpec configures the AllowDropMonitor OVN ACL log
+                      collector.
+                    properties:
+                      aggIntervalMin:
+                        default: 1
+                        type: integer
+                      container:
+                        default: ovn-acl-logging
+                        type: string
+                      logPodLabelSelector:
+                        default: app=ovn-k8s-node
+                        type: string
+                      namespace:
+                        default: openshift-ovn-kubernetes
+                        type: string
+                      podListUrl:
+                        type: string
+                      reconnectSeconds:
+                        default: 5
+                        type: integer
+                      recordRetentionHours:
+                        default: 24
+                        type: integer
+                    type: object
+                type: object
+              backup:
+                description: Scheduled PostgreSQL backups (Level 3 full-lifecycle).
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  pgImage:
+                    description: |-
+                      Postgres image the pg_dump / pg_restore Jobs run. Its MAJOR version MUST be
+                      >= your database server's (pg_dump refuses a newer server). Defaults to a
+                      certified rhel9/postgresql image; override for external servers on newer PG.
+                    type: string
+                  storage:
+                    description: Storage backing for the shared /backups volume (mounted
+                      by the API + the Jobs).
+                    properties:
+                      accessMode:
+                        description: PVC access mode — ReadWriteMany when the cluster
+                          supports it.
+                        type: string
+                      createPvc:
+                        default: false
+                        description: |-
+                          Create the shared backup PVC (type=pvc). Defaults FALSE so clusters without a (RWX)
+                          StorageClass install cleanly — the api pod then does NOT mount /backups and can't wedge
+                          on a missing claim. Set true to auto-create the PVC, or set pvcClaimName to bring your own.
+                        type: boolean
+                      nfs:
+                        description: NFS backing (used when type=nfs).
+                        properties:
+                          path:
+                            type: string
+                          server:
+                            type: string
+                        type: object
+                      pvcClaimName:
+                        description: Name of the shared backup PVC.
+                        type: string
+                      size:
+                        description: PVC size (type=pvc).
+                        type: string
+                      storageClass:
+                        description: PVC StorageClass. Empty → cluster default (must
+                          be RWX-capable, e.g. CephFS/NFS).
+                        type: string
+                      type:
+                        default: pvc
+                        description: 'Storage backing: "pvc" (default) or "nfs".'
+                        type: string
+                    type: object
+                type: object
+              frontend:
+                description: FrontendSpec configures the Next.js frontend.
+                properties:
+                  basepath:
+                    type: string
+                type: object
+              global:
+                description: GlobalSpec holds cluster-wide deployment settings.
+                properties:
+                  clusterDomain:
+                    description: OpenShift apps/wildcard domain used to derive Route
+                      hostnames. Empty → OpenShift auto-assigns.
+                    type: string
+                  createSCC:
+                    default: true
+                    description: Create the SecurityContextConstraints + RBAC. Disable
+                      if a cluster admin pre-creates them.
+                    type: boolean
+                  dpKeysFsGroup:
+                    default: 1001
+                    description: GID that owns the API DataProtection key-ring PVC.
+                      Only used when createSCC=true.
+                    format: int64
+                    type: integer
+                  imageRegistry:
+                    default: quay.io/axera
+                    description: Image registry prefix (no trailing slash). Full path
+                      = <registry>/<repo>:<tag>.
+                    type: string
+                  storageClass:
+                    description: PVC StorageClass for stateful workloads. Empty →
+                      cluster default StorageClass.
+                    type: string
+                type: object
+              imagePullSecret:
+                description: ImagePullSecretSpec configures pulling from a private
+                  registry.
+                properties:
+                  dockerconfigjson:
+                    description: base64-encoded ~/.docker/config.json. Leave empty
+                      to reference a pre-created secret.
+                    type: string
+                  enabled:
+                    default: false
+                    type: boolean
+                  name:
+                    default: axera-pull-secret
+                    type: string
+                type: object
+              images:
+                description: |-
+                  ImagesSpec holds optional per-image overrides. Unset images fall back to built-in
+                  defaults; unset Axera-component tags fall back to .spec.version.
+                properties:
+                  allowdropmonitor:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  api:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  frontend:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  kafka:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  kafkaUi:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  networkpolicywatcher:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  ollama:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  postgres:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  radar:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                type: object
+              kafka:
+                description: KafkaSpec selects internal (single-node KRaft) vs external
+                  Kafka.
+                properties:
+                  bootstrapServers:
+                    type: string
+                  caCert:
+                    description: Custom CA certificate (PEM). Empty → system CA bundle.
+                    type: string
+                  enableUI:
+                    default: true
+                    description: Deploy Kafka-UI alongside internal Kafka. Auto-disabled
+                      when external=true.
+                    type: boolean
+                  external:
+                    default: false
+                    type: boolean
+                  processTopics:
+                    items:
+                      description: KafkaProcessTopic is a per-cluster Tetragon process-event
+                        topic for Radar.
+                      properties:
+                        clusterName:
+                          type: string
+                        groupId:
+                          type: string
+                        topic:
+                          minLength: 1
+                          type: string
+                      required:
+                      - topic
+                      type: object
+                    type: array
+                  saslMechanism:
+                    enum:
+                    - PLAIN
+                    - SCRAM-SHA-256
+                    - SCRAM-SHA-512
+                    - GSSAPI
+                    - OAUTHBEARER
+                    type: string
+                  saslPassword:
+                    type: string
+                  saslUsername:
+                    type: string
+                  securityProtocol:
+                    default: Plaintext
+                    enum:
+                    - Plaintext
+                    - Ssl
+                    - SaslPlaintext
+                    - SaslSsl
+                    type: string
+                  storage:
+                    default: 50Gi
+                    type: string
+                  topics:
+                    items:
+                      description: KafkaTopic is a flow topic consumed by Radar.
+                      properties:
+                        groupId:
+                          type: string
+                        topic:
+                          minLength: 1
+                          type: string
+                      required:
+                      - topic
+                      type: object
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: saslMechanism is required when securityProtocol is SaslPlaintext
+                    or SaslSsl
+                  rule: '!(self.securityProtocol in [''SaslPlaintext'',''SaslSsl''])
+                    || (has(self.saslMechanism) && self.saslMechanism != '''')'
+              licensing:
+                description: LicensingSpec configures trial + node-count strategy.
+                properties:
+                  nodeCountStrategy:
+                    default: MonitoredOnly
+                    enum:
+                    - HostOnly
+                    - MonitoredOnly
+                    - HostPlusMonitored
+                    type: string
+                  trial:
+                    description: TrialSpec configures the 15-day trial bootstrap.
+                    properties:
+                      customer:
+                        default: Trial
+                        type: string
+                      days:
+                        default: 15
+                        type: integer
+                      enabled:
+                        default: true
+                        type: boolean
+                      maxWorkerNodes:
+                        default: 999
+                        type: integer
+                    type: object
+                type: object
+              logging:
+                description: Logging controls the platform's Serilog minimum log levels.
+                properties:
+                  level:
+                    default: Error
+                    description: |-
+                      Global minimum level: Verbose | Debug | Information | Warning | Error | Fatal.
+                      Default Error keeps production quiet (errors only); raise to Information/Debug to troubleshoot.
+                    type: string
+                  overrides:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Per-source minimum-level overrides (source-context → level), applied on top of Level —
+                      e.g. keep noisy framework namespaces (Microsoft.AspNetCore, EntityFrameworkCore) quiet
+                      when Level is raised to Information/Debug.
+                    type: object
+                type: object
+              monitoring:
+                description: 'Deep-Insights monitoring: ServiceMonitor + PrometheusRule
+                  (Level 4).'
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                type: object
+              networkPolicies:
+                description: NetworkPoliciesSpec toggles the defensive NetworkPolicies.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                type: object
+              postgres:
+                description: PostgresSpec selects internal (two StatefulSets) vs external
+                  Postgres.
+                properties:
+                  appDbConnString:
+                    description: .NET ConnectionString used when external=true.
+                    type: string
+                  appDbName:
+                    default: MicrosegmentationDB
+                    type: string
+                  external:
+                    default: false
+                    description: true → use external connection strings; false → deploy
+                      internal Postgres.
+                    type: boolean
+                  password:
+                    description: Empty → strong password generated on first install
+                      and reused on upgrades.
+                    type: string
+                  radarConnString:
+                    type: string
+                  radarDbName:
+                    default: AxeraRadarDB
+                    type: string
+                  runMigrations:
+                    default: true
+                    description: Run EF migration Jobs against both databases (idempotent).
+                    type: boolean
+                  storage:
+                    default: 20Gi
+                    type: string
+                  user:
+                    default: postgres
+                    type: string
+                type: object
+              resources:
+                description: |-
+                  ResourcesSpec holds requests/limits for the stateful workloads. Nil entries
+                  fall back to the chart's defaults (so the operator never clobbers them).
+                properties:
+                  kafka:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  ollama:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  postgres:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              routes:
+                description: RoutesSpec holds the browser-facing Routes.
+                properties:
+                  frontend:
+                    description: FrontendRoute is the browser-facing console Route.
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                      host:
+                        type: string
+                      timeout:
+                        default: 180s
+                        description: HAProxy per-request timeout. Keep >= the API's
+                          Ai timeoutSeconds.
+                        type: string
+                      tls:
+                        description: RouteTLS configures OpenShift Route TLS.
+                        properties:
+                          insecureEdgeTerminationPolicy:
+                            default: Redirect
+                            enum:
+                            - None
+                            - Allow
+                            - Redirect
+                            type: string
+                          termination:
+                            default: edge
+                            enum:
+                            - edge
+                            - passthrough
+                            - reencrypt
+                            type: string
+                        type: object
+                    type: object
+                  kafkaUi:
+                    description: KafkaUIRoute is the Kafka-UI Route (auto-disabled
+                      when kafka.external=true).
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                      host:
+                        type: string
+                      tls:
+                        description: RouteTLS configures OpenShift Route TLS.
+                        properties:
+                          insecureEdgeTerminationPolicy:
+                            default: Redirect
+                            enum:
+                            - None
+                            - Allow
+                            - Redirect
+                            type: string
+                          termination:
+                            default: edge
+                            enum:
+                            - edge
+                            - passthrough
+                            - reencrypt
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              secrets:
+                description: |-
+                  Secret management — set create=false and bring your own pre-created Secrets to
+                  keep all secret material (connection strings, encryption keys, admin password,
+                  Kafka SASL) out of the CR. See SecretsSpec for the required keys.
+                properties:
+                  create:
+                    default: true
+                    description: |-
+                      Create the axera-db-secrets, axera-app-secret and kafka-external-secret objects
+                      from spec/generated values (default true — zero-config install). Set false to bring
+                      your OWN pre-created Secrets so no plaintext secret material lives in the CR. When
+                      false you must pre-create, with these keys:
+                        axera-db-secrets:  POSTGRES_USER, POSTGRES_PASSWORD, APP_DB_NAME, RADAR_DB_NAME,
+                                           APP_DB_CONNSTR, RADAR_DB_CONNSTR
+                        axera-app-secret:  AccessTokenSecret, AdminCredentials__Username, AdminCredentials__Email,
+                                           AdminCredentials__Password, Encryption__Key, Encryption__IV, Internal__Token
+                        kafka-external-secret (external Kafka only): Kafka__BootstrapServers, Kafka__SecurityProtocol,
+                                           Kafka__SaslMechanism, Kafka__SaslUsername, Kafka__SaslPassword,
+                                           Kafka__SslCaLocation, ca.crt
+                    type: boolean
+                type: object
+              version:
+                default: v8.7.0
+                description: |-
+                  Version is informational in the certified build: the six Axera images are
+                  digest-pinned in the bundle's relatedImages, so the operand version moves by
+                  installing a new operator bundle, NOT by editing this field. status.version
+                  always reports the actual deployed platform version (the chart appVersion).
+                  It still fans out to the image tag for any image that has no pinned digest.
+                type: string
+            type: object
+          status:
+            description: AxeraStatus defines the observed state of the Axera platform.
+            properties:
+              components:
+                description: Per-workload health.
+                items:
+                  description: ComponentStatus is the observed health of one managed
+                    workload.
+                  properties:
+                    desiredReplicas:
+                      format: int32
+                      type: integer
+                    kind:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    ready:
+                      type: boolean
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              frontendURL:
+                description: Resolved frontend console URL once the Route is admitted.
+                type: string
+              lastBackupTime:
+                description: Timestamp of the last successful scheduled DB backup
+                  (when backup.enabled).
+                format: date-time
+                type: string
+              managedPolicies:
+                description: |-
+                  Number of NetworkPolicies the platform currently manages in this namespace
+                  (a coarse segmentation-coverage signal surfaced for humans + alerts).
+                format: int32
+                type: integer
+              observedGeneration:
+                description: Generation last reconciled, to detect spec drift.
+                format: int64
+                type: integer
+              phase:
+                description: 'Coarse lifecycle phase: Pending|Installing|Ready|Degraded|Upgrading|Failed.'
+                type: string
+              readyComponents:
+                description: Human-readable ready ratio, e.g. "7/8".
+                type: string
+              version:
+                description: Deployed Axera version (image tag) currently rolled out.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/axera-operator/0.7.4/metadata/annotations.yaml
+++ b/operators/axera-operator/0.7.4/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: axera-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Minimum OpenShift version — must match the replaced bundle (0.3.0 = v4.12).
+  com.redhat.openshift.versions: "v4.12"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/axera-operator/0.7.4/tests/scorecard/config.yaml
+++ b/operators/axera-operator/0.7.4/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
### New Operator Version Submission

**Operator:** axera-operator
**Version:** 0.7.4 (replaces 0.7.3)
**Package channel:** alpha

Patch release hardening the Backup & restore storage defaults for clusters without
(RWX) persistent storage:

- **`spec.backup.storage.createPvc` now defaults to `false`.** A cluster without a
  suitable StorageClass installs cleanly — no backup PVC is created and the API pod
  does **not** mount `/backups`, so it can't wedge on a missing claim. Backup stays
  available in the UI; set `createPvc: true` (auto-create the PVC), set
  `pvcClaimName` (bring your own pre-created PVC), or `type: nfs` to enable the
  shared backup volume.
- The API `/backups` volume + mount now render **only when storage will actually
  exist** (`createPvc`, or a `pvcClaimName`, or a fully-specified NFS target),
  preventing an un-mountable-volume install failure.

Operand images unchanged (**v9.17.0**, already certified). Only the operator's
embedded chart + CRD defaults changed.

- [x] Bundle passes `operator-sdk bundle validate`
- [x] All referenced images are certified
