### PR TITLE
operator amd-gpu-operator (1.5.2)

### DIFF
--- a/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator-manager-config_v1_configmap.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator-manager-config_v1_configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    healthProbeBindAddress: :8081
+    metricsBindAddress: 127.0.0.1:8080
+    leaderElection:
+      enabled: true
+      resourceID: gpu.amd.com
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: amd-gpu-operator-manager-config

--- a/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: amd-gpu-operator-prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: amd-gpu-operator-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: amd-gpu-operator-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -1,0 +1,1793 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "amd.com/v1alpha1",
+          "kind": "DeviceConfig",
+          "metadata": {
+            "name": "test-deviceconfig",
+            "namespace": "kube-amd-gpu"
+          },
+          "spec": {
+            "devicePlugin": {
+              "devicePluginImage": "rocm/k8s-device-plugin:latest",
+              "enableDevicePlugin": true,
+              "nodeLabellerImage": "rocm/k8s-device-plugin:labeller-latest"
+            },
+            "draDriver": {
+              "enable": false
+            },
+            "driver": {
+              "image": "my.registry.io/myUserName/myRepo",
+              "imageRegistrySecret": {
+                "name": "docker-auth"
+              },
+              "version": "30.20.1"
+            },
+            "selector": {
+              "feature.node.kubernetes.io/amd-gpu": "true"
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: AI/Machine Learning,Monitoring
+    containerImage: docker.io/rocm/gpu-operator@sha256:572243df68701bd9f239820966ac333b75bf02182cb930ab7ef4bcc9232948e8
+    utilsContainerImage: docker.io/rocm/gpu-operator-utils@sha256:7412c4492be5bc5ed0d9925813a1f244377155a52f72376e1aeab9c4dc0380e0
+    testRunnerImage: docker.io/rocm/test-runner@sha256:12b38eed808b76e06314e9b24aa657f38a7d4bd6268bfb37f358cdbe6139fb83
+    metricsExporterImage: docker.io/rocm/device-metrics-exporter@sha256:cbef5772c435d648ebd6de705517c4978efdb4b5650952c6797cc2bf15af747a
+    devicePluginImage: docker.io/rocm/k8s-device-plugin@sha256:f51bfdade693a7b2a909a5759e2d9fc11b23000e0f6c65870be0736273dd208f
+    nodelabellerImage: docker.io/rocm/k8s-node-labeller@sha256:ed60266d8a0e45824a09b3cb9db54a8eafe257eb5b89a8dae060c41880100b95
+    deviceConfigManagerImage: docker.io/rocm/device-config-manager@sha256:757531c8fc43804a5ed551b6396655beaf0a08bd46e9bf65e59c59256d257f54
+    draImage: docker.io/rocm/k8s-gpu-dra-driver@sha256:f173c8e78bc819e2b8adc15192afefaf69a11307d49fca5382bda82885975830
+    createdAt: "2026-07-21T04:34:47Z"
+    description: |-
+      Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+      For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-amd-gpu
+    operators.openshift.io/valid-subscription: '[]'
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/ROCm/gpu-operator
+    support: Advanced Micro Devices, Inc.
+  name: amd-gpu-operator.v1.5.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: DeviceConfig describes how to enable AMD GPU device
+      displayName: DeviceConfig
+      kind: DeviceConfig
+      name: deviceconfigs.amd.com
+      resources:
+      - kind: Daemonset
+        name: apps
+        version: v1
+      - kind: Pod
+        name: core
+        version: v1
+      - kind: services
+        name: core
+        version: v1
+      - kind: Module
+        name: modules.kmm.sigs.x-k8s.io
+        version: v1beta1
+      specDescriptors:
+      - description: common config
+        displayName: CommonConfig
+        path: commonConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:commonConfig
+      - description: ImageRegistrySecrets are global secrets used for pull/push images
+          from/to private registries. These secrets will be applied to all component
+          pods (device plugin, metrics exporter, test runner, config manager, DRA
+          driver, node labeller) in addition to component-specific secrets.
+        displayName: ImageRegistrySecrets
+        path: commonConfig.imageRegistrySecrets
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecrets
+      - description: InitContainerImage is being used for the operands pods, i.e.
+          metrics exporter, test runner, device plugin, device config manager and
+          node labeller
+        displayName: InitContainerImage
+        path: commonConfig.initContainerImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:initContainerImage
+      - description: UtilsContainer contains parameters to configure operator's utils
+          container
+        displayName: UtilsContainer
+        path: commonConfig.utilsContainer
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:utilsContainer
+      - description: Image is the image of utils container
+        displayName: Image
+        path: commonConfig.utilsContainer.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: image pull policy for utils container
+        displayName: ImagePullPolicy
+        path: commonConfig.utilsContainer.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+      - description: secret used for pull utils container image
+        displayName: ImageRegistrySecret
+        path: commonConfig.utilsContainer.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: config manager
+        displayName: ConfigManager
+        path: configManager
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:configManager
+      - description: ConfigMap holding DCM config.json. When set, the operator mounts
+          this ConfigMap and does not create it. When omitted or name is empty, the
+          operator mounts ConfigMap "default-dcm-config" and creates it in the DeviceConfig
+          namespace if it does not already exist (same default payload as chart defaultDCMConfigMap).
+        displayName: Config
+        path: configManager.config
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+      - description: tolerations for the device config manager DaemonSet
+        displayName: ConfigManagerTolerations
+        path: configManager.configManagerTolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:configManagerTolerations
+      - description: enable config manager, disabled by default
+        displayName: Enable
+        path: configManager.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: config manager image
+        displayName: Image
+        path: configManager.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: image pull policy for config manager
+        displayName: ImagePullPolicy
+        path: configManager.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+      - description: config manager image registry secret used to pull/push images
+        displayName: ImageRegistrySecret
+        path: configManager.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: Selector describes on which nodes to enable config manager
+        displayName: Selector
+        path: configManager.selector
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:selector
+      - description: upgrade policy for config manager daemonset
+        displayName: UpgradePolicy
+        path: configManager.upgradePolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+      - description: MaxUnavailable specifies the maximum number of Pods that can
+          be unavailable during the update process. Applicable for RollingUpdate only.
+          Default value is 1.
+        displayName: MaxUnavailable
+        path: configManager.upgradePolicy.maxUnavailable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+      - description: UpgradeStrategy specifies the type of the DaemonSet update. Valid
+          values are "RollingUpdate" (default) or "OnDelete".
+        displayName: UpgradeStrategy
+        path: configManager.upgradePolicy.upgradeStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+      - description: device plugin
+        displayName: DevicePlugin
+        path: devicePlugin
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:devicePlugin
+      - description: 'device plugin arguments is used to pass supported flags and
+          their values while starting device plugin daemonset supported flag values:
+          {"resource_naming_strategy": {"single", "mixed"}}'
+        displayName: DevicePluginArguments
+        path: devicePlugin.devicePluginArguments
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginArguments
+      - description: device plugin image
+        displayName: DevicePluginImage
+        path: devicePlugin.devicePluginImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginImage
+      - description: image pull policy for device plugin
+        displayName: DevicePluginImagePullPolicy
+        path: devicePlugin.devicePluginImagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:DevicePluginImagePullPolicy
+      - description: tolerations for the device plugin DaemonSet
+        displayName: DevicePluginTolerations
+        path: devicePlugin.devicePluginTolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:devicePluginTolerations
+      - description: enable Device Plugin, enabled by default
+        displayName: EnableDevicePlugin
+        path: devicePlugin.enableDevicePlugin
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enableDevicePlugin
+      - description: enable or disable the node labeller
+        displayName: EnableNodeLabeller
+        path: devicePlugin.enableNodeLabeller
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enableNodeLabeller
+      - description: HostNetwork specifies whether to use host network namespace for
+          the device plugin DaemonSet pods.
+        displayName: HostNetwork
+        path: devicePlugin.hostNetwork
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:hostNetwork
+      - description: node labeller image registry secret used to pull/push images
+        displayName: ImageRegistrySecret
+        path: devicePlugin.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: KubeletSocketPath specifies the kubelet device plugins directory
+          path. Useful for Kubernetes distributions like microk8s, k3s where the path
+          differs from the standard.
+        displayName: KubeletSocketPath
+        path: devicePlugin.kubeletSocketPath
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:kubeletSocketPath
+      - description: 'node labeller arguments is used to pass supported labels while
+          starting node labeller daemonset some flags are enabled by default as they
+          are applicable and bare minimum for all setups and are supported in all
+          versions of node labeller default flags: {"vram", "cu-count", "simd-count",
+          "device-id", "family", "product-name", "driver-version"} supported flags:
+          {"compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"}'
+        displayName: NodeLabellerArguments
+        path: devicePlugin.nodeLabellerArguments
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerArguments
+      - description: node labeller image
+        displayName: NodeLabellerImage
+        path: devicePlugin.nodeLabellerImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerImage
+      - description: image pull policy for node labeller
+        displayName: NodeLabellerImagePullPolicy
+        path: devicePlugin.nodeLabellerImagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:NodeLabellerImagePullPolicy
+      - description: tolerations for the node labeller DaemonSet
+        displayName: NodeLabellerTolerations
+        path: devicePlugin.nodeLabellerTolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeLabellerTolerations
+      - description: upgrade policy for device plugin and node labeller daemons
+        displayName: UpgradePolicy
+        path: devicePlugin.upgradePolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+      - description: MaxUnavailable specifies the maximum number of Pods that can
+          be unavailable during the update process. Applicable for RollingUpdate only.
+          Default value is 1.
+        displayName: MaxUnavailable
+        path: devicePlugin.upgradePolicy.maxUnavailable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+      - description: UpgradeStrategy specifies the type of the DaemonSet update. Valid
+          values are "RollingUpdate" (default) or "OnDelete".
+        displayName: UpgradeStrategy
+        path: devicePlugin.upgradePolicy.upgradeStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+      - description: dra driver
+        displayName: DRADriver
+        path: draDriver
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:draDriver
+      - description: arguments is used to pass supported flags and their values while
+          starting DRA driver daemonset
+        displayName: DRADriverArguments
+        path: draDriver.cmdLineArguments
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:cmdLineArguments
+      - description: enable DRA driver, disabled by default
+        displayName: Enable
+        path: draDriver.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: DRA driver image
+        displayName: Image
+        path: draDriver.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: image pull policy for DRA driver
+        displayName: ImagePullPolicy
+        path: draDriver.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+      - description: DRA driver image registry secret used to pull/push images
+        displayName: ImageRegistrySecret
+        path: draDriver.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: Selector describes on which nodes to enable DRA driver
+        displayName: Selector
+        path: draDriver.selector
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:selector
+      - description: tolerations for the DRA driver DaemonSet
+        displayName: Tolerations
+        path: draDriver.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+      - description: upgrade policy for DRA driver daemon
+        displayName: UpgradePolicy
+        path: draDriver.upgradePolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+      - description: MaxUnavailable specifies the maximum number of Pods that can
+          be unavailable during the update process. Applicable for RollingUpdate only.
+          Default value is 1.
+        displayName: MaxUnavailable
+        path: draDriver.upgradePolicy.maxUnavailable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+      - description: UpgradeStrategy specifies the type of the DaemonSet update. Valid
+          values are "RollingUpdate" (default) or "OnDelete".
+        displayName: UpgradeStrategy
+        path: draDriver.upgradePolicy.upgradeStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+      - description: driver
+        displayName: Driver
+        path: driver
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:driver
+      - description: 'radeon repo URL for fetching amdgpu installer if building driver
+          image on the fly installer URL is https://repo.radeon.com/amdgpu-install
+          by default Security note: this URL is a trusted driver-build input. It determines
+          where the amdgpu packages and (by default) the GPG trust root are fetched
+          from for a ring-0 kernel module installed on every node. Treat write access
+          to DeviceConfig as equivalent to choosing the driver''s package source;
+          only grant it to trusted admins.'
+        displayName: AMDGPUInstallerRepoURL
+        path: driver.amdgpuInstallerRepoURL
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
+      - description: blacklist amdgpu drivers on the host. Node reboot is required
+          to apply the baclklist on the worker nodes. Not working for OpenShift cluster.
+          OpenShift users please use the Machine Config Operator (MCO) resource to
+          configure amdgpu blacklist. Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+        displayName: BlacklistDrivers
+        path: driver.blacklist
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers
+      - description: 'specify the type of driver (container/vf-passthrough/pf-passthrough)
+          to install on the worker node. default value is container. container: normal
+          amdgpu-dkms driver for Bare Metal GPU nodes or guest VM. vf-passthrough:
+          MxGPU GIM driver on the host machine to generate VF, then mount VF to vfio-pci
+          pf-passthrough: directly mount PF device to vfio-pci'
+        displayName: DriverType
+        path: driver.driverType
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:driverType
+      - description: enable driver install. default value is true. disable is for
+          skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel
+          module
+        displayName: Enable
+        path: driver.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: 'defines image that includes drivers and firmware blobs, don''t
+          include tag since it will be fully managed by operator for vanilla k8s the
+          default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod for OpenShift
+          the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+          image tag will be in the format of <linux distro>-<release version>-<kernel
+          version>-<driver version> example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2
+          and ubuntu-22.04-5.15.0-94-generic-6.1.3 NOTE: Updating the driver image
+          repository is not supported. Please delete the existing DeviceConfig and
+          create a new one with the updated image repository'
+        displayName: Image
+        path: driver.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: image build configs
+        displayName: ImageBuild
+        path: driver.imageBuild
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageBuild
+      - description: 'image registry to fetch base image for building driver image,
+          default value is docker.io, the builder will search for corresponding OS
+          base image from given registry e.g. if your worker node is using Ubuntu
+          22.04, by default the base image would be docker.io/ubuntu:22.04 Use spec.driver.imageRegistrySecret
+          for authentication with private registries. NOTE: this field won''t apply
+          for OpenShift since OpenShift is using its own DriverToolKit image to build
+          driver image'
+        displayName: BaseImageRegistry
+        path: driver.imageBuild.baseImageRegistry
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:baseImageRegistry
+      - description: TLS settings for fetching base image this field will be applied
+          to SourceImageRepo as well
+        displayName: BaseImageRegistryTLS
+        path: driver.imageBuild.baseImageRegistryTLS
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:baseImageRegistryTLS
+      - description: If true, check if the container image already exists using plain
+          HTTP.
+        displayName: Insecure
+        path: driver.imageBuild.baseImageRegistryTLS.insecure
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+      - description: If true, skip any TLS server certificate validation
+        displayName: InsecureSkipTLSVerify
+        path: driver.imageBuild.baseImageRegistryTLS.insecureSkipTLSVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+      - description: 'GPGKeyURL specifies the full URL to the GPG key used to verify
+          packages during driver image build. When specified, this URL completely
+          overrides the default GPG key URL. This is useful when using a custom package
+          repository that has its own GPG key, or when the GPG key location does not
+          follow the standard repo.radeon.com scheme. Examples: - "https://custom-mirror.example.com/keys/amdgpu.gpg.key"
+          - "https://repo.example.com/rocm/rocm.gpg.key" When empty (default), the
+          URL is constructed as: ${amdgpuInstallerRepoURL}/rocm/rocm.gpg.key Security
+          note: this key is the GPG trust root used to verify the amdgpu packages
+          that build a ring-0 kernel module for every node, so this URL is a highly
+          trusted driver-build input. It is fetched at build time (as is the default
+          key), so serve it over https:// from a source you control and treat DeviceConfig
+          write access as equivalent to controlling the driver''s trust root; only
+          grant it to trusted admins.'
+        displayName: GPGKeyURL
+        path: driver.imageBuild.gpgKeyURL
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:gpgKeyURL
+      - description: 'PackageRepoURL specifies the full URL to the package repository
+          used during driver image build. When specified, this URL completely overrides
+          the default URL constructed from spec.driver.amdgpuInstallerRepoURL. This
+          is useful when the package repository does not follow the standard repo.radeon.com
+          URL scheme, or when using a custom mirror/proxy that requires a different
+          URL structure. The URL should point directly to the repository base (without
+          trailing slash). Examples: - For Ubuntu: "https://custom-mirror.example.com/repos/amdgpu/6.1.3/ubuntu
+          jammy main" This will be used as: "deb [arch=amd64 ...] ${PACKAGE_REPO_URL}"
+          - For CoreOS/RHEL: "https://custom-mirror.example.com/repos/amdgpu/6.2.2/el/9.4/main/x86_64"
+          This will be used as: "baseurl=${PACKAGE_REPO_URL}" When empty (default),
+          the URL is constructed as: ${amdgpuInstallerRepoURL}/amdgpu/${DRIVERS_VERSION}/${os}/${distro}
+          Security note: this URL is a trusted driver-build input that selects the
+          package source for a ring-0 kernel module installed on every node. Treat
+          write access to DeviceConfig as equivalent to choosing the driver''s package
+          source; only grant it to trusted admins, and prefer an https:// URL you
+          control.'
+        displayName: PackageRepoURL
+        path: driver.imageBuild.packageRepoURL
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:packageRepoURL
+      - description: 'SourceImageRepo specifies the image repository for the driver
+          source code (OpenShift only). Used when spec.driver.useSourceImage is true.
+          The operator automatically determines the image tag based on cluster RHEL
+          version and spec.driver.version (format: coreos-<rhel>-<driver version>).
+          Default: docker.io/rocm/amdgpu-driver Use spec.driver.imageRegistrySecret
+          for authentication with private registries.'
+        displayName: SourceImageRepo
+        path: driver.imageBuild.sourceImageRepo
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:sourceImageRepo
+      - description: secrets used for pull/push images from/to private registry specified
+          in driversImage
+        displayName: ImageRegistrySecret
+        path: driver.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: driver image registry TLS setting for the container image
+        displayName: ImageRegistryTLS
+        path: driver.imageRegistryTLS
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistryTLS
+      - description: If true, check if the container image already exists using plain
+          HTTP.
+        displayName: Insecure
+        path: driver.imageRegistryTLS.insecure
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:insecure
+      - description: If true, skip any TLS server certificate validation
+        displayName: InsecureSkipTLSVerify
+        path: driver.imageRegistryTLS.insecureSkipTLSVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:insecureSkipTLSVerify
+      - description: image signing config to sign the driver image when building driver
+          image on the fly image signing is required for installing driver on secure
+          boot enabled system
+        displayName: ImageSign
+        path: driver.imageSign
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageSign
+      - description: ImageSignCertSecret the public key used to sign kernel modules
+          within image necessary for secure boot enabled system
+        displayName: ImageSignCertSecret
+        path: driver.imageSign.certSecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageSignCertSecret
+      - description: ImageSignKeySecret the private key used to sign kernel modules
+          within image necessary for secure boot enabled system
+        displayName: ImageSignKeySecret
+        path: driver.imageSign.keySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageSignKeySecret
+      - description: advanced arguments, parameters and more configs to manage tne
+          driver
+        displayName: KernelModuleConfig
+        path: driver.kernelModuleConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:kernelModuleConfig
+      - description: LoadArg are the arguments when modprobe is executed to load the
+          kernel module. The command will be `modprobe ${Args} module_name`.
+        displayName: LoadArg
+        path: driver.kernelModuleConfig.loadArgs
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:loadArg
+      - description: Parameters is being used for modprobe commands. The command will
+          be `modprobe ${Args} module_name ${Parameters}`.
+        displayName: Parameters
+        path: driver.kernelModuleConfig.parameters
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:parameters
+      - description: UnloadArg are the arguments when modprobe is executed to unload
+          the kernel module. The command will be `modprobe -r ${Args} module_name`.
+        displayName: UnloadArg
+        path: driver.kernelModuleConfig.unloadArgs
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:unloadArg
+      - description: tolerations for kmm module object
+        displayName: Tolerations
+        path: driver.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+      - description: policy to upgrade the drivers
+        displayName: UpgradePolicy
+        path: driver.upgradePolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+      - description: enable upgrade policy, disabled by default If disabled, user
+          has to manually upgrade all the nodes.
+        displayName: Enable
+        path: driver.upgradePolicy.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: MaxParallelUpgrades indicates how many nodes can be upgraded
+          in parallel 0 means no limit, all nodes will be upgraded in parallel
+        displayName: MaxParallelUpgrades
+        path: driver.upgradePolicy.maxParallelUpgrades
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelUpgrades
+      - description: 'MaxUnavailableNodes indicates maximum number of nodes that can
+          be in a failed upgrade state beyond which upgrades will stop to keep cluster
+          at a minimal healthy state Value can be an integer (ex: 2) which would mean
+          atmost 2 nodes can be in failed state after which new upgrades will not
+          start. Or it can be a percentage string(ex: "50%") from which absolute number
+          will be calculated and round up'
+        displayName: MaxUnavailableNodes
+        path: driver.upgradePolicy.maxUnavailableNodes
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailableNodes
+      - description: Node draining policy
+        displayName: NodeDrainPolicy
+        path: driver.upgradePolicy.nodeDrainPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+      - description: Pod Deletion policy. If both NodeDrainPolicy and PodDeletionPolicy
+          config is available, NodeDrainPolicy(if enabled) will take precedence.
+        displayName: PodDeletionPolicy
+        path: driver.upgradePolicy.podDeletionPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:podDeletionPolicy
+      - description: reboot between driver upgrades, enabled by default, if enabled
+          spec.commonConfig.utilsContainer will be used to perform reboot on worker
+          nodes
+        displayName: RebootRequired
+        path: driver.upgradePolicy.rebootRequired
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:rebootRequired
+      - description: 'NOTE: currently only for OpenShift cluster set to true to use
+          source image to build driver image on the fly otherwise use installer debian/rpm
+          packages from radeon repo to build driver image'
+        displayName: UseSourceImage
+        path: driver.useSourceImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:useSourceImage
+      - description: 'version of the drivers source code, can be used as part of image
+          of dockerfile source image default value for different OS is: ubuntu: 6.1.3,
+          coreOS: 6.2.2'
+        displayName: Version
+        path: driver.version
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:version
+      - description: vfio config specify the specific configs for binding PCI devices
+          to vfio-pci kernel module, applies for driver type vf-passthrough and pf-passthrough
+        displayName: VFIOConfig
+        path: driver.vfioConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:vfioConfig
+      - description: metrics exporter
+        displayName: MetricsExporter
+        path: metricsExporter
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:metricsExporter
+      - description: optional configuration for metrics
+        displayName: Config
+        path: metricsExporter.config
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:config
+      - description: Name of the configMap that defines the list of metrics default
+          list:[]
+        displayName: Name
+        path: metricsExporter.config.name
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:name
+      - description: enable metrics exporter, disabled by default
+        displayName: Enable
+        path: metricsExporter.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: HostNetwork specifies whether to use host network namespace for
+          the metrics exporter DaemonSet pods.
+        displayName: HostNetwork
+        path: metricsExporter.hostNetwork
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:hostNetwork
+      - description: metrics exporter image
+        displayName: Image
+        path: metricsExporter.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: image pull policy for metrics exporter
+        displayName: ImagePullPolicy
+        path: metricsExporter.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+      - description: metrics exporter image registry secret used to pull/push images
+        displayName: ImageRegistrySecret
+        path: metricsExporter.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: NodePort is the external port for pulling metrics from outside
+          the cluster, in the range 30000-32767 (assigned automatically by default)
+        displayName: NodePort
+        path: metricsExporter.nodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodePort
+      - description: Set PodAnnotations for metrics exporter
+        displayName: PodAnnotations
+        path: metricsExporter.podAnnotations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:podAnnotations
+      - description: Set the host path for pod-resource kubelet.socket, vanila kubernetes
+          path is /var/lib/kubelet/pod-resources microk8s path is /var/snap/microk8s/common/var/lib/kubelet/pod-resources/
+          path is an absolute unix path that allows a trailing slash
+        displayName: PodResourceAPISocketPath
+        path: metricsExporter.podResourceAPISocketPath
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:podResourceAPISocketPath
+      - description: Port is the internal port used for in-cluster and node access
+          to pull metrics from the metrics-exporter (default 5000).
+        displayName: Port
+        path: metricsExporter.port
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:port
+      - description: Prometheus configuration for metrics exporter
+        displayName: Prometheus
+        path: metricsExporter.prometheus
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:prometheus
+      - description: ServiceMonitor configuration for Prometheus integration
+        displayName: ServiceMonitor
+        path: metricsExporter.prometheus.serviceMonitor
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:serviceMonitor
+      - description: AttachMetadata defines if Prometheus should attach node metadata
+          to the target
+        displayName: AttachMetadata
+        path: metricsExporter.prometheus.serviceMonitor.attachMetadata
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:attachMetadata
+      - description: Optional Prometheus authorization configuration for accessing
+          the endpoint
+        displayName: Authorization
+        path: metricsExporter.prometheus.serviceMonitor.authorization
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:authorization
+      - description: 'Path to bearer token file to be used by Prometheus (e.g., service
+          account token path) Deprecated: Use Authorization instead. This field is
+          kept for backward compatibility.'
+        displayName: BearerTokenFile
+        path: metricsExporter.prometheus.serviceMonitor.bearerTokenFile
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:bearerTokenFile
+      - description: Enable or disable ServiceMonitor creation (default false)
+        displayName: Enable
+        path: metricsExporter.prometheus.serviceMonitor.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: HonorLabels chooses the metric's labels on collisions with target
+          labels (default true)
+        displayName: HonorLabels
+        path: metricsExporter.prometheus.serviceMonitor.honorLabels
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:honorLabels
+      - description: HonorTimestamps controls whether the scrape endpoints honor timestamps
+          (default false)
+        displayName: HonorTimestamps
+        path: metricsExporter.prometheus.serviceMonitor.honorTimestamps
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:honorTimestamps
+      - description: 'How frequently to scrape metrics. Accepts values with time unit
+          suffix: "30s", "1m", "2h", "500ms"'
+        displayName: Interval
+        path: metricsExporter.prometheus.serviceMonitor.interval
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:interval
+      - description: 'Additional labels to add to the ServiceMonitor (default release:
+          prometheus)'
+        displayName: Labels
+        path: metricsExporter.prometheus.serviceMonitor.labels
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:labels
+      - description: Relabeling rules applied to individual scraped metrics
+        displayName: MetricRelabelings
+        path: metricsExporter.prometheus.serviceMonitor.metricRelabelings
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:metricRelabelings
+      - description: RelabelConfigs to apply to samples before ingestion
+        displayName: Relabelings
+        path: metricsExporter.prometheus.serviceMonitor.relabelings
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:relabelings
+      - description: TLS settings used by Prometheus to connect to the metrics endpoint
+        displayName: TLSConfig
+        path: metricsExporter.prometheus.serviceMonitor.tlsConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:tlsConfig
+      - description: optional kube-rbac-proxy config to provide rbac services
+        displayName: RbacConfig
+        path: metricsExporter.rbacConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:rbacConfig
+      - description: 'Reference to a configmap containing the client CA (key: ca.crt)
+          for mTLS client validation'
+        displayName: ClientCAConfigMap
+        path: metricsExporter.rbacConfig.clientCAConfigMap
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:clientCAConfigMap
+      - description: disable https protecting the proxy endpoint
+        displayName: DisableHttps
+        path: metricsExporter.rbacConfig.disableHttps
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:disableHttps
+      - description: enable kube-rbac-proxy, disabled by default
+        displayName: Enable
+        path: metricsExporter.rbacConfig.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: kube-rbac-proxy image
+        displayName: Image
+        path: metricsExporter.rbacConfig.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: certificate secret to mount in kube-rbac container for TLS, self
+          signed certificates will be generated by default
+        displayName: Secret
+        path: metricsExporter.rbacConfig.secret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:secret
+      - description: Optional static RBAC rules based on client certificate Common
+          Name (CN)
+        displayName: StaticAuthorization
+        path: metricsExporter.rbacConfig.staticAuthorization
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:staticAuthorization
+      - description: Expected CN (Common Name) from client cert (e.g., Prometheus
+          SA identity)
+        displayName: ClientName
+        path: metricsExporter.rbacConfig.staticAuthorization.clientName
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:clientName
+      - description: Enables static authorization using client certificate CN
+        displayName: Enable
+        path: metricsExporter.rbacConfig.staticAuthorization.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: Set resource config for metrics exporter
+        displayName: Resource
+        path: metricsExporter.resource
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:resource
+      - description: Selector describes on which nodes to enable metrics exporter
+        displayName: Selector
+        path: metricsExporter.selector
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:selector
+      - description: Set ServiceAnnotations for metrics exporter
+        displayName: ServiceAnnotations
+        path: metricsExporter.serviceAnnotations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:serviceAnnotations
+      - description: ServiceType service type for metrics, clusterIP/NodePort, clusterIP
+          by default
+        displayName: ServiceType
+        path: metricsExporter.serviceType
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:serviceType
+      - description: tolerations for metrics exporter
+        displayName: Tolerations
+        path: metricsExporter.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+      - description: upgrade policy for metrics exporter daemons
+        displayName: UpgradePolicy
+        path: metricsExporter.upgradePolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+      - description: MaxUnavailable specifies the maximum number of Pods that can
+          be unavailable during the update process. Applicable for RollingUpdate only.
+          Default value is 1.
+        displayName: MaxUnavailable
+        path: metricsExporter.upgradePolicy.maxUnavailable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+      - description: UpgradeStrategy specifies the type of the DaemonSet update. Valid
+          values are "RollingUpdate" (default) or "OnDelete".
+        displayName: UpgradeStrategy
+        path: metricsExporter.upgradePolicy.upgradeStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+      - description: remediation workflow
+        displayName: RemediationWorkflow
+        path: remediationWorkflow
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:remediationWorkflow
+      - description: AutoStartWorkflow specifies the behavior of the remediation workflow.
+          Default value is true. If true, remediation workflow will be automatically
+          started when the node condition matches. If false, remediation workflow
+          will be in suspended state when the node condition matches and needs to
+          be manually started by the user. This field gives users more control and
+          flexibility on when to start the remediation workflow. Default value is
+          set to true if not specified and the remediation workflow automatically
+          starts when the node condition matches.
+        displayName: AutoStartWorkflow
+        path: remediationWorkflow.autoStartWorkflow
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:autoStartWorkflow
+      - description: Name of the ConfigMap that holds condition-to-workflow mappings.
+        displayName: Config
+        path: remediationWorkflow.config
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:config
+      - description: ConfigMapImage specifies a container image that contains the
+          remediation ConfigMap. When set, the operator runs a Job from this image
+          to apply the ConfigMap to the cluster before the remediation workflow proceeds.
+        displayName: ConfigMapImage
+        path: remediationWorkflow.configMapImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:configMapImage
+      - description: enable remediation workflows. disabled by default enable if operator
+          should automatically handle remediation of node incase of gpu issues
+        displayName: Enable
+        path: remediationWorkflow.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: MaxParallelWorkflows specifies limit on how many remediation
+          workflows can be executed in parallel. 0 is the default value and it means
+          no limit.
+        displayName: MaxParallelWorkflows
+        path: remediationWorkflow.maxParallelWorkflows
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxParallelWorkflows
+      - description: Node drain policy during remediation workflow execution
+        displayName: NodeDrainPolicy
+        path: remediationWorkflow.nodeDrainPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeDrainPolicy
+      - description: Node Remediation labels are custom labels that we can apply on
+          the node to specify that the node is undergoing remediation or needs attention
+          by the administrator.
+        displayName: NodeRemediationLabels
+        path: remediationWorkflow.nodeRemediationLabels
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeRemediationLabels
+      - description: Node Remediation taints are custom taints that we can apply on
+          the node to specify that the node is undergoing remediation or needs attention
+          by the administrator. If user does not specify any taints, the operator
+          will apply a taint with key "amd-gpu-unhealthy" and effect "NoSchedule"
+          to the node under remediation.
+        displayName: NodeRemediationTaints
+        path: remediationWorkflow.nodeRemediationTaints
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeRemediationTaints
+      - description: RebootTimeout specifies the duration to wait for the node to
+          reboot. Accepts duration strings like "30s", "4h", "24h". By default, it
+          is set to 15m.
+        displayName: RebootTimeout
+        path: remediationWorkflow.rebootTimeout
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:rebootTimeout
+      - description: Tester image used to run tests and verify if remediation fixed
+          the reported problem.
+        displayName: TesterImage
+        path: remediationWorkflow.testerImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:testerImage
+      - description: Time to live for argo workflow object and its pods for a failed
+          workflow. Accepts duration strings like "30s", "4h", "24h". By default,
+          it is set to 24h
+        displayName: TtlForFailedWorkflows
+        path: remediationWorkflow.ttlForFailedWorkflows
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:ttlForFailedWorkflows
+      - description: Selector describes on which nodes the GPU Operator should enable
+          the GPU device.
+        displayName: Selector
+        path: selector
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:selector
+      - description: test runner
+        displayName: TestRunner
+        path: testRunner
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:testRunner
+      - description: config map to customize the config for test runner, if not specified
+          default test config will be applied
+        displayName: Secret
+        path: testRunner.config
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:configmap
+      - description: enable test runner, disabled by default
+        displayName: Enable
+        path: testRunner.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: test runner image
+        displayName: Image
+        path: testRunner.image
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:image
+      - description: image pull policy for test runner
+        displayName: ImagePullPolicy
+        path: testRunner.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imagePullPolicy
+      - description: test runner image registry secret used to pull/push images
+        displayName: ImageRegistrySecret
+        path: testRunner.imageRegistrySecret
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:imageRegistrySecret
+      - description: captures logs location and export config for test runner logs
+        displayName: LogsLocation
+        path: testRunner.logsLocation
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:logsLocation
+      - description: host path to store test runner internal status db in order to
+          persist test running status
+        displayName: HostPath
+        path: testRunner.logsLocation.hostPath
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:hostPath
+      - description: LogsExportSecrets is a list of secrets that contain connectivity
+          info to multiple cloud providers
+        displayName: LogsExportSecrets
+        path: testRunner.logsLocation.logsExportSecrets
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:logsExportSecrets
+      - description: volume mount destination within test runner container
+        displayName: MountPath
+        path: testRunner.logsLocation.mountPath
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:mountPath
+      - description: Selector describes on which nodes to enable test runner
+        displayName: Selector
+        path: testRunner.selector
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:selector
+      - description: tolerations for test runner
+        displayName: Tolerations
+        path: testRunner.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:tolerations
+      - description: upgrade policy for test runner daemonset
+        displayName: UpgradePolicy
+        path: testRunner.upgradePolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradePolicy
+      - description: MaxUnavailable specifies the maximum number of Pods that can
+          be unavailable during the update process. Applicable for RollingUpdate only.
+          Default value is 1.
+        displayName: MaxUnavailable
+        path: testRunner.upgradePolicy.maxUnavailable
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:maxUnavailable
+      - description: UpgradeStrategy specifies the type of the DaemonSet update. Valid
+          values are "RollingUpdate" (default) or "OnDelete".
+        displayName: UpgradeStrategy
+        path: testRunner.upgradePolicy.upgradeStrategy
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:upgradeStrategy
+      statusDescriptors:
+      - description: number of the actually deployed and running pods
+        displayName: AvailableNumber
+        path: configManager.availableNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+      - description: number of the pods that should be deployed for daemonset
+        displayName: DesiredNumber
+        path: configManager.desiredNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+      - description: number of nodes that are targeted by the DeviceConfig selector
+        displayName: NodesMatchingSelectorNumber
+        path: configManager.nodesMatchingSelectorNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+      - description: number of the actually deployed and running pods
+        displayName: AvailableNumber
+        path: devicePlugin.availableNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+      - description: number of the pods that should be deployed for daemonset
+        displayName: DesiredNumber
+        path: devicePlugin.desiredNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+      - description: number of nodes that are targeted by the DeviceConfig selector
+        displayName: NodesMatchingSelectorNumber
+        path: devicePlugin.nodesMatchingSelectorNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+      - description: number of the actually deployed and running pods
+        displayName: AvailableNumber
+        path: driver.availableNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+      - description: number of the pods that should be deployed for daemonset
+        displayName: DesiredNumber
+        path: driver.desiredNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+      - description: number of nodes that are targeted by the DeviceConfig selector
+        displayName: NodesMatchingSelectorNumber
+        path: driver.nodesMatchingSelectorNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+      - description: number of the actually deployed and running pods
+        displayName: AvailableNumber
+        path: metricsExporter.availableNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+      - description: number of the pods that should be deployed for daemonset
+        displayName: DesiredNumber
+        path: metricsExporter.desiredNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+      - description: number of nodes that are targeted by the DeviceConfig selector
+        displayName: NodesMatchingSelectorNumber
+        path: metricsExporter.nodesMatchingSelectorNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+      - description: NodeModuleStatus contains per node status of driver module installation
+        displayName: NodeModuleStatus
+        path: nodeModuleStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodeModuleStatus
+      - description: number of the actually deployed and running pods
+        displayName: AvailableNumber
+        path: remediationWorkflow.availableNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:availableNumber
+      - description: number of the pods that should be deployed for daemonset
+        displayName: DesiredNumber
+        path: remediationWorkflow.desiredNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:desiredNumber
+      - description: number of nodes that are targeted by the DeviceConfig selector
+        displayName: NodesMatchingSelectorNumber
+        path: remediationWorkflow.nodesMatchingSelectorNumber
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:nodesMatchingSelectorNumber
+      version: v1alpha1
+    - kind: RemediationWorkflowStatus
+      name: remediationworkflowstatuses.amd.com
+      version: v1alpha1
+  description: |-
+    Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
+    For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
+  displayName: amd-gpu-operator
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MDAiIGhlaWdodD0iMTkwLjgwMyIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIj48cGF0aCBkPSJNMTg3Ljg4OCAxNzguMTIySDE0My41MmwtMTMuNTczLTMyLjczOEg1Ni4wMDNsLTEyLjM2NiAzMi43MzhIMEw2Ni42NjcgMTIuNzc2aDQ3Ljc2MXpNOTEuMTU1IDUyLjI4Nkw2Ni45MTIgMTE2LjUzaDUwLjkxM3ptMjU3LjkwMS0zOS41MWgzNS44OHYxNjUuMzQ2aC00MS4yMTlWNzQuODQybC00NC42MDggNTEuODc3aC02LjMwMWwtNDQuNjA1LTUxLjg3N1YxNzguMTJoLTQxLjIxOVYxMi43NzZoMzUuODhsNTMuMDkyIDYxLjMzNnptMTQwLjMxOSAwYzYwLjM2NCAwIDkxLjM5MSAzNy41NzMgOTEuMzkxIDgyLjkwOSAwIDQ3LjUxNy0zMC4wNTggODIuNDM3LTk2IDgyLjQzN2gtNjguMzY5VjEyLjc3NnptLTMxLjc2MiAxMzUuMDQxaDI2LjkwNmM0MS40NTcgMCA1My44MjMtMjguMTI5IDUzLjgyMy01Mi4zNzcgMC0yOC4zNjgtMTUuMjc2LTUyLjM2My01NC4zMDgtNTIuMzYzaC0yNi40MjJ2MTA0Ljc0em0yMDUuMTU2LTk1LjgzNkw2MTAuNzk3IDBIODAwdjE4OS4yMWwtNTEuOTcyLTUxLjk3NVY1MS45ODF6bS0uMDYxIDEwLjQxNkw2MDkuMiAxMTUuOTAzdjc0Ljg5OWg3NC44ODlsNTMuNTA1LTUzLjUwNmgtNzQuODg2eiIvPjwvc3ZnPg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
+          - nodemodulesconfigs
+          - nodemodulesconfigs/status
+          verbs:
+          - get
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-config-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/finalizers
+          - nodes/status
+          verbs:
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods/finalizers
+          - pods/status
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services/finalizers
+          verbs:
+          - create
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - amd.com
+          resources:
+          - deviceconfigs
+          - remediationworkflowstatuses
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - amd.com
+          resources:
+          - deviceconfigs/finalizers
+          - remediationworkflowstatuses/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - amd.com
+          resources:
+          - deviceconfigs/status
+          - remediationworkflowstatuses/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - daemonsets/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets/finalizers
+          verbs:
+          - create
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
+          - modules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
+          - modules/finalizers
+          - nodemodulesconfigs/finalizers
+          verbs:
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
+          - modules/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
+          - nodemodulesconfigs
+          - nodemodulesconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - nfd.openshift.io
+          resources:
+          - nodefeaturediscoveries
+          verbs:
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - nfd.openshift.io
+          resources:
+          - nodefeaturediscoveries/finalizers
+          - nodefeaturediscoveries/status
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - resource.k8s.io
+          resources:
+          - deviceclasses
+          verbs:
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - workflows
+          - workflowtemplates
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - workflowtaskresults
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - workflows/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: amd-gpu-operator-controller-manager
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - resource.k8s.io
+          resources:
+          - resourceslices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - resource.k8s.io
+          resources:
+          - resourceclaims
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+        serviceAccountName: amd-gpu-operator-dra-driver
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-metrics-exporter
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - watch
+          - get
+          - list
+          - update
+        serviceAccountName: amd-gpu-operator-metrics-exporter-rbac-proxy
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - watch
+          - get
+          - list
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-node-labeller
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+          - get
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - patch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-test-runner
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-utils-container
+      deployments:
+      - label:
+          app.kubernetes.io/component: amd-gpu
+          app.kubernetes.io/name: amd-gpu
+          app.kubernetes.io/part-of: amd-gpu
+          control-plane: controller-manager
+        name: amd-gpu-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: amd-gpu
+              app.kubernetes.io/name: amd-gpu
+              app.kubernetes.io/part-of: amd-gpu
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/component: amd-gpu
+                app.kubernetes.io/name: amd-gpu
+                app.kubernetes.io/part-of: amd-gpu
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - preference:
+                      matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                    weight: 1
+                  - preference:
+                      matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+                    weight: 1
+              containers:
+              - args:
+                - --config=controller_manager_config.yaml
+                env:
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: RELATED_IMAGE_MANAGER
+                  value: docker.io/rocm/gpu-operator@sha256:572243df68701bd9f239820966ac333b75bf02182cb930ab7ef4bcc9232948e8
+                image: docker.io/rocm/gpu-operator@sha256:572243df68701bd9f239820966ac333b75bf02182cb930ab7ef4bcc9232948e8
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                volumeMounts:
+                - mountPath: /controller_manager_config.yaml
+                  name: manager-config
+                  subPath: controller_manager_config.yaml
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: amd-gpu-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Equal
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
+                operator: Equal
+              volumes:
+              - configMap:
+                  name: amd-gpu-operator-manager-config
+                name: manager-config
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: amd-gpu-operator-controller-manager
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-kmm-device-plugin
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-kmm-module-loader
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - AMD
+  - GPU
+  - AI
+  - Deep Learning
+  - Hardware
+  - Driver
+  - Monitoring
+  links:
+  - name: AMD GPU Operator
+    url: https://github.com/ROCm/gpu-operator
+  maintainers:
+  - email: Yan.Sun3@amd.com
+    name: Yan Sun
+  - email: Praveenkumar.Shanmugam@amd.com
+    name: Praveenkumar Shanmugam
+  - email: shrey.ajmera@amd.com
+    name: Shrey Ajmera
+  maturity: stable
+  provider:
+    name: Advanced Micro Devices, Inc.
+  relatedImages:
+    - image: docker.io/rocm/device-metrics-exporter@sha256:cbef5772c435d648ebd6de705517c4978efdb4b5650952c6797cc2bf15af747a
+      name: device-metrics-exporter-cbef5772c435d648ebd6de705517c4978efdb4b5650952c6797cc2bf15af747a-annotation
+    - image: docker.io/rocm/gpu-operator@sha256:572243df68701bd9f239820966ac333b75bf02182cb930ab7ef4bcc9232948e8
+      name: manager
+    - image: docker.io/rocm/gpu-operator@sha256:572243df68701bd9f239820966ac333b75bf02182cb930ab7ef4bcc9232948e8
+      name: gpu-operator-572243df68701bd9f239820966ac333b75bf02182cb930ab7ef4bcc9232948e8-annotation
+    - image: docker.io/rocm/k8s-device-plugin@sha256:f51bfdade693a7b2a909a5759e2d9fc11b23000e0f6c65870be0736273dd208f
+      name: k8s-device-plugin-f51bfdade693a7b2a909a5759e2d9fc11b23000e0f6c65870be0736273dd208f-annotation
+    - image: docker.io/rocm/k8s-node-labeller@sha256:ed60266d8a0e45824a09b3cb9db54a8eafe257eb5b89a8dae060c41880100b95
+      name: k8s-node-labeller-ed60266d8a0e45824a09b3cb9db54a8eafe257eb5b89a8dae060c41880100b95-annotation
+    - image: docker.io/rocm/gpu-operator-utils@sha256:7412c4492be5bc5ed0d9925813a1f244377155a52f72376e1aeab9c4dc0380e0
+      name: gpu-operator-utils-7412c4492be5bc5ed0d9925813a1f244377155a52f72376e1aeab9c4dc0380e0-annotation
+    - image: docker.io/rocm/test-runner@sha256:12b38eed808b76e06314e9b24aa657f38a7d4bd6268bfb37f358cdbe6139fb83
+      name: device-test-runner-12b38eed808b76e06314e9b24aa657f38a7d4bd6268bfb37f358cdbe6139fb83-annotation
+    - image: docker.io/rocm/device-config-manager@sha256:757531c8fc43804a5ed551b6396655beaf0a08bd46e9bf65e59c59256d257f54
+      name: device-config-manager-757531c8fc43804a5ed551b6396655beaf0a08bd46e9bf65e59c59256d257f54-annotation
+    - image: docker.io/rocm/k8s-gpu-dra-driver@sha256:f173c8e78bc819e2b8adc15192afefaf69a11307d49fca5382bda82885975830
+      name: k8s-gpu-dra-driver-f173c8e78bc819e2b8adc15192afefaf69a11307d49fca5382bda82885975830-annotation
+  version: 1.5.2

--- a/operators/amd-gpu-operator/1.5.2/manifests/amd.com_deviceconfigs.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amd.com_deviceconfigs.yaml
@@ -1,0 +1,2057 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: deviceconfigs.amd.com
+spec:
+  group: amd.com
+  names:
+    kind: DeviceConfig
+    listKind: DeviceConfigList
+    plural: deviceconfigs
+    shortNames:
+    - gpue
+    singular: deviceconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DeviceConfig describes how to enable AMD GPU device
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DeviceConfigSpec describes how the AMD GPU operator should
+              enable AMD GPU device for customer's use.
+            properties:
+              commonConfig:
+                description: common config
+                properties:
+                  imageRegistrySecrets:
+                    description: |-
+                      ImageRegistrySecrets are global secrets used for pull/push images from/to private registries.
+                      These secrets will be applied to all component pods (device plugin, metrics exporter,
+                      test runner, config manager, DRA driver, node labeller) in addition to component-specific secrets.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  initContainerImage:
+                    description: InitContainerImage is being used for the operands
+                      pods, i.e. metrics exporter, test runner, device plugin, device
+                      config manager and node labeller
+                    type: string
+                  utilsContainer:
+                    description: UtilsContainer contains parameters to configure operator's
+                      utils container
+                    properties:
+                      image:
+                        description: Image is the image of utils container
+                        pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                        type: string
+                      imagePullPolicy:
+                        description: image pull policy for utils container
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imageRegistrySecret:
+                        description: secret used for pull utils container image
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
+              configManager:
+                description: config manager
+                properties:
+                  config:
+                    description: |-
+                      ConfigMap holding DCM config.json. When set, the operator mounts this ConfigMap and does not create it.
+                      When omitted or name is empty, the operator mounts ConfigMap "default-dcm-config" and creates it in the
+                      DeviceConfig namespace if it does not already exist (same default payload as chart defaultDCMConfigMap).
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  configManagerTolerations:
+                    description: tolerations for the device config manager DaemonSet
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  enable:
+                    description: enable config manager, disabled by default
+                    type: boolean
+                  image:
+                    description: config manager image
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  imagePullPolicy:
+                    description: image pull policy for config manager
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imageRegistrySecret:
+                    description: config manager image registry secret used to pull/push
+                      images
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: Selector describes on which nodes to enable config
+                      manager
+                    type: object
+                  upgradePolicy:
+                    description: upgrade policy for config manager daemonset
+                    properties:
+                      maxUnavailable:
+                        default: 1
+                        description: MaxUnavailable specifies the maximum number of
+                          Pods that can be unavailable during the update process.
+                          Applicable for RollingUpdate only. Default value is 1.
+                        format: int32
+                        type: integer
+                      upgradeStrategy:
+                        description: UpgradeStrategy specifies the type of the DaemonSet
+                          update. Valid values are "RollingUpdate" (default) or "OnDelete".
+                        enum:
+                        - RollingUpdate
+                        - OnDelete
+                        type: string
+                    type: object
+                type: object
+              devicePlugin:
+                description: device plugin
+                properties:
+                  devicePluginArguments:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      device plugin arguments is used to pass supported flags and their values while starting device plugin daemonset
+                      supported flag values: {"resource_naming_strategy": {"single", "mixed"}}
+                    type: object
+                  devicePluginImage:
+                    description: device plugin image
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  devicePluginImagePullPolicy:
+                    description: image pull policy for device plugin
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  devicePluginTolerations:
+                    description: tolerations for the device plugin DaemonSet
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  enableDevicePlugin:
+                    default: true
+                    description: enable Device Plugin, enabled by default
+                    type: boolean
+                  enableNodeLabeller:
+                    default: true
+                    description: enable or disable the node labeller
+                    type: boolean
+                  hostNetwork:
+                    description: HostNetwork specifies whether to use host network
+                      namespace for the device plugin DaemonSet pods.
+                    type: boolean
+                  imageRegistrySecret:
+                    description: node labeller image registry secret used to pull/push
+                      images
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  kubeletSocketPath:
+                    default: /var/lib/kubelet/device-plugins
+                    description: |-
+                      KubeletSocketPath specifies the kubelet device plugins directory path.
+                      Useful for Kubernetes distributions like microk8s, k3s where the path differs from the standard.
+                    pattern: ^(/[^/\0]+)*(/)?$
+                    type: string
+                  nodeLabellerArguments:
+                    description: |-
+                      node labeller arguments is used to pass supported labels while starting node labeller daemonset
+                      some flags are enabled by default as they are applicable and bare minimum for all setups and are supported in all versions of node labeller
+                      default flags: {"vram", "cu-count", "simd-count", "device-id", "family", "product-name", "driver-version"}
+                      supported flags: {"compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"}
+                    items:
+                      type: string
+                    type: array
+                  nodeLabellerImage:
+                    description: node labeller image
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  nodeLabellerImagePullPolicy:
+                    description: image pull policy for node labeller
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  nodeLabellerTolerations:
+                    description: tolerations for the node labeller DaemonSet
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  upgradePolicy:
+                    description: upgrade policy for device plugin and node labeller
+                      daemons
+                    properties:
+                      maxUnavailable:
+                        default: 1
+                        description: MaxUnavailable specifies the maximum number of
+                          Pods that can be unavailable during the update process.
+                          Applicable for RollingUpdate only. Default value is 1.
+                        format: int32
+                        type: integer
+                      upgradeStrategy:
+                        description: UpgradeStrategy specifies the type of the DaemonSet
+                          update. Valid values are "RollingUpdate" (default) or "OnDelete".
+                        enum:
+                        - RollingUpdate
+                        - OnDelete
+                        type: string
+                    type: object
+                type: object
+              draDriver:
+                description: dra driver
+                properties:
+                  cmdLineArguments:
+                    additionalProperties:
+                      type: string
+                    description: arguments is used to pass supported flags and their
+                      values while starting DRA driver daemonset
+                    type: object
+                  enable:
+                    default: false
+                    description: enable DRA driver, disabled by default
+                    type: boolean
+                  image:
+                    description: DRA driver image
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  imagePullPolicy:
+                    description: image pull policy for DRA driver
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imageRegistrySecret:
+                    description: DRA driver image registry secret used to pull/push
+                      images
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: Selector describes on which nodes to enable DRA driver
+                    type: object
+                  tolerations:
+                    description: tolerations for the DRA driver DaemonSet
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  upgradePolicy:
+                    description: upgrade policy for DRA driver daemon
+                    properties:
+                      maxUnavailable:
+                        default: 1
+                        description: MaxUnavailable specifies the maximum number of
+                          Pods that can be unavailable during the update process.
+                          Applicable for RollingUpdate only. Default value is 1.
+                        format: int32
+                        type: integer
+                      upgradeStrategy:
+                        description: UpgradeStrategy specifies the type of the DaemonSet
+                          update. Valid values are "RollingUpdate" (default) or "OnDelete".
+                        enum:
+                        - RollingUpdate
+                        - OnDelete
+                        type: string
+                    type: object
+                type: object
+              driver:
+                description: driver
+                properties:
+                  amdgpuInstallerRepoURL:
+                    description: |-
+                      radeon repo URL for fetching amdgpu installer if building driver image on the fly
+                      installer URL is https://repo.radeon.com/amdgpu-install by default
+                      Security note: this URL is a trusted driver-build input. It determines where the
+                      amdgpu packages and (by default) the GPG trust root are fetched from for a ring-0
+                      kernel module installed on every node. Treat write access to DeviceConfig as
+                      equivalent to choosing the driver's package source; only grant it to trusted admins.
+                    type: string
+                  blacklist:
+                    description: |-
+                      blacklist amdgpu drivers on the host. Node reboot is required to apply the baclklist on the worker nodes.
+                      Not working for OpenShift cluster. OpenShift users please use the Machine Config Operator (MCO) resource to configure amdgpu blacklist.
+                      Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
+                    type: boolean
+                  driverType:
+                    default: container
+                    description: |-
+                      specify the type of driver (container/vf-passthrough/pf-passthrough) to install on the worker node. default value is container.
+                      container: normal amdgpu-dkms driver for Bare Metal GPU nodes or guest VM.
+                      vf-passthrough: MxGPU GIM driver on the host machine to generate VF, then mount VF to vfio-pci
+                      pf-passthrough: directly mount PF device to vfio-pci
+                    enum:
+                    - container
+                    - vf-passthrough
+                    - pf-passthrough
+                    type: string
+                  enable:
+                    default: true
+                    description: |-
+                      enable driver install. default value is true.
+                      disable is for skipping driver install/uninstall for dryrun or using in-tree amdgpu kernel module
+                    type: boolean
+                  image:
+                    description: |-
+                      defines image that includes drivers and firmware blobs, don't include tag since it will be fully managed by operator
+                      for vanilla k8s the default value is image-registry:5000/$MOD_NAMESPACE/amdgpu_kmod
+                      for OpenShift the default value is image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
+                      image tag will be in the format of <linux distro>-<release version>-<kernel version>-<driver version>
+                      example tag is coreos-416.94-5.14.0-427.28.1.el9_4.x86_64-6.2.2 and ubuntu-22.04-5.15.0-94-generic-6.1.3
+                      NOTE: Updating the driver image repository is not supported. Please delete the existing DeviceConfig and create a new one with the updated image repository
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[$a-zA-Z0-9_]+(?:[._-][$a-zA-Z0-9_]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  imageBuild:
+                    description: image build configs
+                    properties:
+                      baseImageRegistry:
+                        default: docker.io
+                        description: |-
+                          image registry to fetch base image for building driver image, default value is docker.io, the builder will search for corresponding OS base image from given registry
+                          e.g. if your worker node is using Ubuntu 22.04, by default the base image would be docker.io/ubuntu:22.04
+                          Use spec.driver.imageRegistrySecret for authentication with private registries.
+                          NOTE: this field won't apply for OpenShift since OpenShift is using its own DriverToolKit image to build driver image
+                        type: string
+                      baseImageRegistryTLS:
+                        description: |-
+                          TLS settings for fetching base image
+                          this field will be applied to SourceImageRepo as well
+                        properties:
+                          insecure:
+                            description: If true, check if the container image already
+                              exists using plain HTTP.
+                            type: boolean
+                          insecureSkipTLSVerify:
+                            description: If true, skip any TLS server certificate
+                              validation
+                            type: boolean
+                        type: object
+                      gpgKeyURL:
+                        description: |-
+                          GPGKeyURL specifies the full URL to the GPG key used to verify packages during driver image build.
+                          When specified, this URL completely overrides the default GPG key URL.
+                          This is useful when using a custom package repository that has its own GPG key,
+                          or when the GPG key location does not follow the standard repo.radeon.com scheme.
+                          Examples:
+                            - "https://custom-mirror.example.com/keys/amdgpu.gpg.key"
+                            - "https://repo.example.com/rocm/rocm.gpg.key"
+                          When empty (default), the URL is constructed as: ${amdgpuInstallerRepoURL}/rocm/rocm.gpg.key
+                          Security note: this key is the GPG trust root used to verify the amdgpu packages
+                          that build a ring-0 kernel module for every node, so this URL is a highly trusted
+                          driver-build input. It is fetched at build time (as is the default key), so serve
+                          it over https:// from a source you control and treat DeviceConfig write access as
+                          equivalent to controlling the driver's trust root; only grant it to trusted admins.
+                        type: string
+                      packageRepoURL:
+                        description: |-
+                          PackageRepoURL specifies the full URL to the package repository used during driver image build.
+                          When specified, this URL completely overrides the default URL constructed from spec.driver.amdgpuInstallerRepoURL.
+                          This is useful when the package repository does not follow the standard repo.radeon.com URL scheme,
+                          or when using a custom mirror/proxy that requires a different URL structure.
+                          The URL should point directly to the repository base (without trailing slash).
+                          Examples:
+                            - For Ubuntu: "https://custom-mirror.example.com/repos/amdgpu/6.1.3/ubuntu jammy main"
+                              This will be used as: "deb [arch=amd64 ...] ${PACKAGE_REPO_URL}"
+                            - For CoreOS/RHEL: "https://custom-mirror.example.com/repos/amdgpu/6.2.2/el/9.4/main/x86_64"
+                              This will be used as: "baseurl=${PACKAGE_REPO_URL}"
+                          When empty (default), the URL is constructed as: ${amdgpuInstallerRepoURL}/amdgpu/${DRIVERS_VERSION}/${os}/${distro}
+                          Security note: this URL is a trusted driver-build input that selects the package
+                          source for a ring-0 kernel module installed on every node. Treat write access to
+                          DeviceConfig as equivalent to choosing the driver's package source; only grant it
+                          to trusted admins, and prefer an https:// URL you control.
+                        type: string
+                      sourceImageRepo:
+                        description: |-
+                          SourceImageRepo specifies the image repository for the driver source code (OpenShift only).
+                          Used when spec.driver.useSourceImage is true. The operator automatically determines the image tag
+                          based on cluster RHEL version and spec.driver.version (format: coreos-<rhel>-<driver version>).
+                          Default: docker.io/rocm/amdgpu-driver
+                          Use spec.driver.imageRegistrySecret for authentication with private registries.
+                        type: string
+                    type: object
+                  imageRegistrySecret:
+                    description: secrets used for pull/push images from/to private
+                      registry specified in driversImage
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  imageRegistryTLS:
+                    description: driver image registry TLS setting for the container
+                      image
+                    properties:
+                      insecure:
+                        description: If true, check if the container image already
+                          exists using plain HTTP.
+                        type: boolean
+                      insecureSkipTLSVerify:
+                        description: If true, skip any TLS server certificate validation
+                        type: boolean
+                    type: object
+                  imageSign:
+                    description: |-
+                      image signing config to sign the driver image when building driver image on the fly
+                      image signing is required for installing driver on secure boot enabled system
+                    properties:
+                      certSecret:
+                        description: |-
+                          ImageSignCertSecret the public key used to sign kernel modules within image
+                          necessary for secure boot enabled system
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      keySecret:
+                        description: |-
+                          ImageSignKeySecret the private key used to sign kernel modules within image
+                          necessary for secure boot enabled system
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  kernelModuleConfig:
+                    description: advanced arguments, parameters and more configs to
+                      manage tne driver
+                    properties:
+                      loadArgs:
+                        description: LoadArg are the arguments when modprobe is executed
+                          to load the kernel module. The command will be `modprobe
+                          ${Args} module_name`.
+                        items:
+                          type: string
+                        type: array
+                      parameters:
+                        description: Parameters is being used for modprobe commands.
+                          The command will be `modprobe ${Args} module_name ${Parameters}`.
+                        items:
+                          type: string
+                        type: array
+                      unloadArgs:
+                        description: UnloadArg are the arguments when modprobe is
+                          executed to unload the kernel module. The command will be
+                          `modprobe -r ${Args} module_name`.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  tolerations:
+                    description: tolerations for kmm module object
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  upgradePolicy:
+                    description: policy to upgrade the drivers
+                    properties:
+                      enable:
+                        description: |-
+                          enable upgrade policy, disabled by default
+                          If disabled, user has to manually upgrade all the nodes.
+                        type: boolean
+                      maxParallelUpgrades:
+                        default: 1
+                        description: |-
+                          MaxParallelUpgrades indicates how many nodes can be upgraded in parallel
+                          0 means no limit, all nodes will be upgraded in parallel
+                        minimum: 0
+                        type: integer
+                      maxUnavailableNodes:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 25%
+                        description: |-
+                          MaxUnavailableNodes indicates maximum number of nodes that can be in a failed upgrade state beyond which upgrades will stop to keep cluster at a minimal healthy state
+                          Value can be an integer (ex: 2) which would mean atmost 2 nodes can be in failed state after which new upgrades will not start. Or it can be a percentage string(ex: "50%") from which absolute number will be calculated and round up
+                        x-kubernetes-int-or-string: true
+                      nodeDrainPolicy:
+                        description: Node draining policy
+                        properties:
+                          force:
+                            default: false
+                            description: Force indicates if force draining is allowed
+                            type: boolean
+                          gracePeriodSeconds:
+                            default: -1
+                            description: GracePeriodSeconds indicates the time kubernetes
+                              waits for a pod to shut down gracefully after receiving
+                              a termination signal
+                            type: integer
+                          ignoreDaemonSets:
+                            default: true
+                            description: IgnoreDaemonSets indicates whether to ignore
+                              DaemonSet-managed pods
+                            type: boolean
+                          ignoreNamespaces:
+                            description: |-
+                              IgnoreNamespaces is the list of namespaces to ignore during node drain operation.
+                              This is useful to avoid draining pods from critical namespaces like 'kube-system', etc.
+                            items:
+                              type: string
+                            type: array
+                          timeoutSeconds:
+                            default: 300
+                            description: TimeoutSecond specifies the length of time
+                              in seconds to wait before giving up drain, zero means
+                              infinite
+                            minimum: 0
+                            type: integer
+                        type: object
+                      podDeletionPolicy:
+                        description: Pod Deletion policy. If both NodeDrainPolicy
+                          and PodDeletionPolicy config is available, NodeDrainPolicy(if
+                          enabled) will take precedence.
+                        properties:
+                          force:
+                            default: false
+                            description: Force indicates if force deletion is allowed
+                            type: boolean
+                          gracePeriodSeconds:
+                            default: -1
+                            description: GracePeriodSeconds indicates the time kubernetes
+                              waits for a pod to shut down gracefully after receiving
+                              a termination signal
+                            type: integer
+                          timeoutSeconds:
+                            default: 300
+                            description: TimeoutSecond specifies the length of time
+                              in seconds to wait before giving up on pod deletion,
+                              zero means infinite
+                            minimum: 0
+                            type: integer
+                        type: object
+                      rebootRequired:
+                        default: true
+                        description: reboot between driver upgrades, enabled by default,
+                          if enabled spec.commonConfig.utilsContainer will be used
+                          to perform reboot on worker nodes
+                        type: boolean
+                    type: object
+                  useSourceImage:
+                    description: |-
+                      NOTE: currently only for OpenShift cluster
+                      set to true to use source image to build driver image on the fly
+                      otherwise use installer debian/rpm packages from radeon repo to build driver image
+                    type: boolean
+                  version:
+                    description: |-
+                      version of the drivers source code, can be used as part of image of dockerfile source image
+                      default value for different OS is: ubuntu: 6.1.3, coreOS: 6.2.2
+                    type: string
+                  vfioConfig:
+                    description: |-
+                      vfio config
+                      specify the specific configs for binding PCI devices to vfio-pci kernel module, applies for driver type vf-passthrough and pf-passthrough
+                    properties:
+                      deviceIDs:
+                        description: list of PCI device IDs to load into vfio-pci
+                          driver. default is the list of AMD GPU PF/VF PCI device
+                          IDs based on driver type vf-passthrough/pf-passthrough.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              metricsExporter:
+                description: metrics exporter
+                properties:
+                  config:
+                    description: optional configuration for metrics
+                    properties:
+                      name:
+                        description: |-
+                          Name of the configMap that defines the list of metrics
+                          default list:[]
+                        type: string
+                    type: object
+                  enable:
+                    description: enable metrics exporter, disabled by default
+                    type: boolean
+                  hostNetwork:
+                    description: HostNetwork specifies whether to use host network
+                      namespace for the metrics exporter DaemonSet pods.
+                    type: boolean
+                  image:
+                    description: metrics exporter image
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  imagePullPolicy:
+                    description: image pull policy for metrics exporter
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imageRegistrySecret:
+                    description: metrics exporter image registry secret used to pull/push
+                      images
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  nodePort:
+                    description: NodePort is the external port for pulling metrics
+                      from outside the cluster, in the range 30000-32767 (assigned
+                      automatically by default)
+                    format: int32
+                    maximum: 32767
+                    minimum: 30000
+                    type: integer
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Set PodAnnotations for metrics exporter
+                    type: object
+                  podResourceAPISocketPath:
+                    default: /var/lib/kubelet/pod-resources
+                    description: |-
+                      Set the host path for pod-resource kubelet.socket,
+                      vanila kubernetes path is /var/lib/kubelet/pod-resources
+                      microk8s path is /var/snap/microk8s/common/var/lib/kubelet/pod-resources/
+                      path is an absolute unix path that allows a trailing slash
+                    pattern: ^(/[^/\0]+)*(/)?$
+                    type: string
+                  port:
+                    default: 5000
+                    description: Port is the internal port used for in-cluster and
+                      node access to pull metrics from the metrics-exporter (default
+                      5000).
+                    format: int32
+                    type: integer
+                  prometheus:
+                    description: Prometheus configuration for metrics exporter
+                    properties:
+                      serviceMonitor:
+                        description: ServiceMonitor configuration for Prometheus integration
+                        properties:
+                          attachMetadata:
+                            description: AttachMetadata defines if Prometheus should
+                              attach node metadata to the target
+                            properties:
+                              node:
+                                description: |-
+                                  When set to true, Prometheus attaches node metadata to the discovered
+                                  targets.
+
+                                  The Prometheus service account must have the `list` and `watch`
+                                  permissions on the `Nodes` objects.
+                                type: boolean
+                            type: object
+                          authorization:
+                            description: Optional Prometheus authorization configuration
+                              for accessing the endpoint
+                            properties:
+                              credentials:
+                                description: Selects a key of a Secret in the namespace
+                                  that contains the credentials for authentication.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type:
+                                description: |-
+                                  Defines the authentication type. The value is case-insensitive.
+
+                                  "Basic" is not a supported value.
+
+                                  Default: "Bearer"
+                                type: string
+                            type: object
+                          bearerTokenFile:
+                            description: |-
+                              Path to bearer token file to be used by Prometheus (e.g., service account token path)
+                              Deprecated: Use Authorization instead. This field is kept for backward compatibility.
+                            type: string
+                          enable:
+                            description: Enable or disable ServiceMonitor creation
+                              (default false)
+                            type: boolean
+                          honorLabels:
+                            default: true
+                            description: HonorLabels chooses the metric's labels on
+                              collisions with target labels (default true)
+                            type: boolean
+                          honorTimestamps:
+                            description: HonorTimestamps controls whether the scrape
+                              endpoints honor timestamps (default false)
+                            type: boolean
+                          interval:
+                            description: 'How frequently to scrape metrics. Accepts
+                              values with time unit suffix: "30s", "1m", "2h", "500ms"'
+                            pattern: ^([0-9]+)(ms|s|m|h)$
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Additional labels to add to the ServiceMonitor
+                              (default release: prometheus)'
+                            type: object
+                          metricRelabelings:
+                            description: Relabeling rules applied to individual scraped
+                              metrics
+                            items:
+                              description: |-
+                                RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                                scraped samples and remote write samples.
+
+                                More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                              properties:
+                                action:
+                                  default: replace
+                                  description: |-
+                                    Action to perform based on the regex matching.
+
+                                    `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                    `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                    Default: "Replace"
+                                  enum:
+                                  - replace
+                                  - Replace
+                                  - keep
+                                  - Keep
+                                  - drop
+                                  - Drop
+                                  - hashmod
+                                  - HashMod
+                                  - labelmap
+                                  - LabelMap
+                                  - labeldrop
+                                  - LabelDrop
+                                  - labelkeep
+                                  - LabelKeep
+                                  - lowercase
+                                  - Lowercase
+                                  - uppercase
+                                  - Uppercase
+                                  - keepequal
+                                  - KeepEqual
+                                  - dropequal
+                                  - DropEqual
+                                  type: string
+                                modulus:
+                                  description: |-
+                                    Modulus to take of the hash of the source label values.
+
+                                    Only applicable when the action is `HashMod`.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched.
+                                  type: string
+                                replacement:
+                                  description: |-
+                                    Replacement value against which a Replace action is performed if the
+                                    regular expression matches.
+
+                                    Regex capture groups are available.
+                                  type: string
+                                separator:
+                                  description: Separator is the string between concatenated
+                                    SourceLabels.
+                                  type: string
+                                sourceLabels:
+                                  description: |-
+                                    The source labels select values from existing labels. Their content is
+                                    concatenated using the configured Separator and matched against the
+                                    configured regular expression.
+                                  items:
+                                    description: |-
+                                      LabelName is a valid Prometheus label name which may only contain ASCII
+                                      letters, numbers, as well as underscores.
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  description: |-
+                                    Label to which the resulting string is written in a replacement.
+
+                                    It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                    `KeepEqual` and `DropEqual` actions.
+
+                                    Regex capture groups are available.
+                                  type: string
+                              type: object
+                            type: array
+                          relabelings:
+                            description: RelabelConfigs to apply to samples before
+                              ingestion
+                            items:
+                              description: |-
+                                RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                                scraped samples and remote write samples.
+
+                                More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                              properties:
+                                action:
+                                  default: replace
+                                  description: |-
+                                    Action to perform based on the regex matching.
+
+                                    `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                    `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                    Default: "Replace"
+                                  enum:
+                                  - replace
+                                  - Replace
+                                  - keep
+                                  - Keep
+                                  - drop
+                                  - Drop
+                                  - hashmod
+                                  - HashMod
+                                  - labelmap
+                                  - LabelMap
+                                  - labeldrop
+                                  - LabelDrop
+                                  - labelkeep
+                                  - LabelKeep
+                                  - lowercase
+                                  - Lowercase
+                                  - uppercase
+                                  - Uppercase
+                                  - keepequal
+                                  - KeepEqual
+                                  - dropequal
+                                  - DropEqual
+                                  type: string
+                                modulus:
+                                  description: |-
+                                    Modulus to take of the hash of the source label values.
+
+                                    Only applicable when the action is `HashMod`.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched.
+                                  type: string
+                                replacement:
+                                  description: |-
+                                    Replacement value against which a Replace action is performed if the
+                                    regular expression matches.
+
+                                    Regex capture groups are available.
+                                  type: string
+                                separator:
+                                  description: Separator is the string between concatenated
+                                    SourceLabels.
+                                  type: string
+                                sourceLabels:
+                                  description: |-
+                                    The source labels select values from existing labels. Their content is
+                                    concatenated using the configured Separator and matched against the
+                                    configured regular expression.
+                                  items:
+                                    description: |-
+                                      LabelName is a valid Prometheus label name which may only contain ASCII
+                                      letters, numbers, as well as underscores.
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  description: |-
+                                    Label to which the resulting string is written in a replacement.
+
+                                    It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                    `KeepEqual` and `DropEqual` actions.
+
+                                    Regex capture groups are available.
+                                  type: string
+                              type: object
+                            type: array
+                          tlsConfig:
+                            description: TLS settings used by Prometheus to connect
+                              to the metrics endpoint
+                            properties:
+                              ca:
+                                description: Certificate authority used when verifying
+                                  server certificates.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              caFile:
+                                description: Path to the CA cert in the Prometheus
+                                  container to use for the targets.
+                                type: string
+                              cert:
+                                description: Client certificate to present when doing
+                                  client-authentication.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              certFile:
+                                description: Path to the client cert file in the Prometheus
+                                  container for the targets.
+                                type: string
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keyFile:
+                                description: Path to the client key file in the Prometheus
+                                  container for the targets.
+                                type: string
+                              keySecret:
+                                description: Secret containing the client key file
+                                  for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              maxVersion:
+                                description: |-
+                                  Maximum acceptable TLS version.
+
+                                  It requires Prometheus >= v2.41.0.
+                                enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                                type: string
+                              minVersion:
+                                description: |-
+                                  Minimum acceptable TLS version.
+
+                                  It requires Prometheus >= v2.35.0.
+                                enum:
+                                - TLS10
+                                - TLS11
+                                - TLS12
+                                - TLS13
+                                type: string
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  rbacConfig:
+                    description: optional kube-rbac-proxy config to provide rbac services
+                    properties:
+                      clientCAConfigMap:
+                        description: 'Reference to a configmap containing the client
+                          CA (key: ca.crt) for mTLS client validation'
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      disableHttps:
+                        description: disable https protecting the proxy endpoint
+                        type: boolean
+                      enable:
+                        description: enable kube-rbac-proxy, disabled by default
+                        type: boolean
+                      image:
+                        description: kube-rbac-proxy image
+                        pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                        type: string
+                      secret:
+                        description: certificate secret to mount in kube-rbac container
+                          for TLS, self signed certificates will be generated by default
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      staticAuthorization:
+                        description: Optional static RBAC rules based on client certificate
+                          Common Name (CN)
+                        properties:
+                          clientName:
+                            description: Expected CN (Common Name) from client cert
+                              (e.g., Prometheus SA identity)
+                            type: string
+                          enable:
+                            description: Enables static authorization using client
+                              certificate CN
+                            type: boolean
+                        type: object
+                    type: object
+                  resource:
+                    default:
+                      limits:
+                        cpu: "2"
+                        memory: 4G
+                      requests:
+                        cpu: 500m
+                        memory: 512M
+                    description: Set resource config for metrics exporter
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: Selector describes on which nodes to enable metrics
+                      exporter
+                    type: object
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Set ServiceAnnotations for metrics exporter
+                    type: object
+                  serviceType:
+                    default: ClusterIP
+                    description: ServiceType service type for metrics, clusterIP/NodePort,
+                      clusterIP by default
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    type: string
+                  tolerations:
+                    description: tolerations for metrics exporter
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  upgradePolicy:
+                    description: upgrade policy for metrics exporter daemons
+                    properties:
+                      maxUnavailable:
+                        default: 1
+                        description: MaxUnavailable specifies the maximum number of
+                          Pods that can be unavailable during the update process.
+                          Applicable for RollingUpdate only. Default value is 1.
+                        format: int32
+                        type: integer
+                      upgradeStrategy:
+                        description: UpgradeStrategy specifies the type of the DaemonSet
+                          update. Valid values are "RollingUpdate" (default) or "OnDelete".
+                        enum:
+                        - RollingUpdate
+                        - OnDelete
+                        type: string
+                    type: object
+                type: object
+              remediationWorkflow:
+                description: remediation workflow
+                properties:
+                  autoStartWorkflow:
+                    default: true
+                    description: |-
+                      AutoStartWorkflow specifies the behavior of the remediation workflow. Default value is true.
+                      If true, remediation workflow will be automatically started when the node condition matches.
+                      If false, remediation workflow will be in suspended state when the node condition matches and needs to be manually started by the user.
+                      This field gives users more control and flexibility on when to start the remediation workflow.
+                      Default value is set to true if not specified and the remediation workflow automatically starts when the node condition matches.
+                    type: boolean
+                  config:
+                    description: Name of the ConfigMap that holds condition-to-workflow
+                      mappings.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  configMapImage:
+                    description: |-
+                      ConfigMapImage specifies a container image that contains the remediation
+                      ConfigMap. When set, the operator runs a Job from this image to apply
+                      the ConfigMap to the cluster before the remediation workflow proceeds.
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  enable:
+                    description: |-
+                      enable remediation workflows. disabled by default
+                      enable if operator should automatically handle remediation of node incase of gpu issues
+                    type: boolean
+                  maxParallelWorkflows:
+                    default: 0
+                    description: MaxParallelWorkflows specifies limit on how many
+                      remediation workflows can be executed in parallel. 0 is the
+                      default value and it means no limit.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  nodeDrainPolicy:
+                    description: Node drain policy during remediation workflow execution
+                    properties:
+                      force:
+                        default: false
+                        description: Force indicates if force draining is allowed
+                        type: boolean
+                      gracePeriodSeconds:
+                        default: -1
+                        description: GracePeriodSeconds indicates the time kubernetes
+                          waits for a pod to shut down gracefully after receiving
+                          a termination signal
+                        type: integer
+                      ignoreDaemonSets:
+                        default: true
+                        description: IgnoreDaemonSets indicates whether to ignore
+                          DaemonSet-managed pods
+                        type: boolean
+                      ignoreNamespaces:
+                        description: |-
+                          IgnoreNamespaces is the list of namespaces to ignore during node drain operation.
+                          This is useful to avoid draining pods from critical namespaces like 'kube-system', etc.
+                        items:
+                          type: string
+                        type: array
+                      timeoutSeconds:
+                        default: 300
+                        description: TimeoutSecond specifies the length of time in
+                          seconds to wait before giving up drain, zero means infinite
+                        minimum: 0
+                        type: integer
+                    type: object
+                  nodeRemediationLabels:
+                    additionalProperties:
+                      type: string
+                    description: Node Remediation labels are custom labels that we
+                      can apply on the node to specify that the node is undergoing
+                      remediation or needs attention by the administrator.
+                    type: object
+                  nodeRemediationTaints:
+                    description: |-
+                      Node Remediation taints are custom taints that we can apply on the node to specify that the node is undergoing remediation or needs attention by the administrator.
+                      If user does not specify any taints, the operator will apply a taint with key "amd-gpu-unhealthy" and effect "NoSchedule" to the node under remediation.
+                    items:
+                      description: |-
+                        The node this Taint is attached to has the "effect" on
+                        any pod that does not tolerate the Taint.
+                      properties:
+                        effect:
+                          description: |-
+                            Required. The effect of the taint on pods
+                            that do not tolerate the taint.
+                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Required. The taint key to be applied to a
+                            node.
+                          type: string
+                        timeAdded:
+                          description: TimeAdded represents the time at which the
+                            taint was added.
+                          format: date-time
+                          type: string
+                        value:
+                          description: The taint value corresponding to the taint
+                            key.
+                          type: string
+                      required:
+                      - effect
+                      - key
+                      type: object
+                    type: array
+                  rebootTimeout:
+                    default: 15m
+                    description: RebootTimeout specifies the duration to wait for
+                      the node to reboot. Accepts duration strings like "30s", "4h",
+                      "24h". By default, it is set to 15m.
+                    pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))+$
+                    type: string
+                  testerImage:
+                    description: Tester image used to run tests and verify if remediation
+                      fixed the reported problem.
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  ttlForFailedWorkflows:
+                    default: 24h
+                    description: Time to live for argo workflow object and its pods
+                      for a failed workflow. Accepts duration strings like "30s",
+                      "4h", "24h". By default, it is set to 24h
+                    pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                type: object
+              selector:
+                additionalProperties:
+                  type: string
+                description: Selector describes on which nodes the GPU Operator should
+                  enable the GPU device.
+                type: object
+              testRunner:
+                description: test runner
+                properties:
+                  config:
+                    description: config map to customize the config for test runner,
+                      if not specified default test config will be applied
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  enable:
+                    description: enable test runner, disabled by default
+                    type: boolean
+                  image:
+                    description: test runner image
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
+                  imagePullPolicy:
+                    description: image pull policy for test runner
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imageRegistrySecret:
+                    description: test runner image registry secret used to pull/push
+                      images
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  logsLocation:
+                    description: captures logs location and export config for test
+                      runner logs
+                    properties:
+                      hostPath:
+                        default: /var/log/amd-test-runner
+                        description: host path to store test runner internal status
+                          db in order to persist test running status
+                        type: string
+                      logsExportSecrets:
+                        description: LogsExportSecrets is a list of secrets that contain
+                          connectivity info to multiple cloud providers
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      mountPath:
+                        default: /var/log/amd-test-runner
+                        description: volume mount destination within test runner container
+                        type: string
+                    type: object
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: Selector describes on which nodes to enable test
+                      runner
+                    type: object
+                  tolerations:
+                    description: tolerations for test runner
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  upgradePolicy:
+                    description: upgrade policy for test runner daemonset
+                    properties:
+                      maxUnavailable:
+                        default: 1
+                        description: MaxUnavailable specifies the maximum number of
+                          Pods that can be unavailable during the update process.
+                          Applicable for RollingUpdate only. Default value is 1.
+                        format: int32
+                        type: integer
+                      upgradeStrategy:
+                        description: UpgradeStrategy specifies the type of the DaemonSet
+                          update. Valid values are "RollingUpdate" (default) or "OnDelete".
+                        enum:
+                        - RollingUpdate
+                        - OnDelete
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: DeviceConfigStatus defines the observed state of Module.
+            properties:
+              conditions:
+                description: Conditions list the current status of the DeviceConfig
+                  object
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              configManager:
+                description: ConfigManager contains the status of the ConfigManager
+                  deployment
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the DeviceConfig
+                      selector
+                    format: int32
+                    type: integer
+                type: object
+              devicePlugin:
+                description: DevicePlugin contains the status of the Device Plugin
+                  deployment
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the DeviceConfig
+                      selector
+                    format: int32
+                    type: integer
+                type: object
+              driver:
+                description: Driver contains the status of the Drivers deployment
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the DeviceConfig
+                      selector
+                    format: int32
+                    type: integer
+                type: object
+              metricsExporter:
+                description: MetricsExporter contains the status of the MetricsExporter
+                  deployment
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the DeviceConfig
+                      selector
+                    format: int32
+                    type: integer
+                type: object
+              nodeModuleStatus:
+                additionalProperties:
+                  description: ModuleStatus contains the status of driver module installed
+                    by operator on the node
+                  properties:
+                    bootId:
+                      type: string
+                    containerImage:
+                      type: string
+                    kernelVersion:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    status:
+                      description: UpgradeState captures the state of the upgrade
+                        process on a node
+                      type: string
+                    upgradeStartTime:
+                      type: string
+                  type: object
+                description: NodeModuleStatus contains per node status of driver module
+                  installation
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest spec generation successfully
+                  processed by the controller
+                format: int64
+                type: integer
+              remediationWorkflow:
+                description: RemediationWorkflow contains the status of the RemediationWorkflow
+                  deployment
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the DeviceConfig
+                      selector
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/amd-gpu-operator/1.5.2/manifests/amd.com_remediationworkflowstatuses.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amd.com_remediationworkflowstatuses.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: remediationworkflowstatuses.amd.com
+spec:
+  group: amd.com
+  names:
+    kind: RemediationWorkflowStatus
+    listKind: RemediationWorkflowStatusList
+    plural: remediationworkflowstatuses
+    shortNames:
+    - rwfstatus
+    singular: remediationworkflowstatus
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          RemediationWorkflowStatus keeps a record of recent remediation workflow runs.
+          We maintain this information to avoid re-running remediation workflows on nodes where a pre-defined threshold is crossed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            additionalProperties:
+              additionalProperties:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    startTime:
+                      type: string
+                  type: object
+                type: array
+              type: object
+            description: |-
+              Status field holds remediation workflow run history for each node and node condition
+              Key is node name. Value is a map with key as node condition and value as list of workflow metadata(workflow name and it's start time)
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/amd-gpu-operator/1.5.2/manifests/amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/operators/amd-gpu-operator/1.5.2/manifests/amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: amdgpu-accelerator-rule
+  labels:
+    app: amdgpu-metrics-exporter
+spec:
+  groups:
+  - name: amdgpu.accelerator.metrics
+    interval: 30s
+    rules:
+    - record: accelerator_gpu_utilization
+      expr: label_replace({__name__=~".*gpu_gfx_activity$"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_used_bytes
+      expr: label_replace({__name__=~".*gpu_used_vram$"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_total_bytes
+      expr: label_replace({__name__=~".*gpu_total_vram$"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_power_usage_watts
+      expr: label_replace({__name__=~".*gpu_power_usage$"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_temperature_celsius
+      expr: label_replace({__name__=~".*gpu_junction_temperature$"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_sm_clock_hertz
+      expr: label_replace({__name__=~".*gpu_clock$", clock_type=~"GPU_CLOCK_TYPE_SYSTEM|system"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_clock_hertz
+      expr: label_replace({__name__=~".*gpu_clock$", clock_type=~"GPU_CLOCK_TYPE_MEMORY|memory"}, "accelerator_id", "$1", "gpu_id", "(.*)")
+      labels:
+        vendor: "amd"

--- a/operators/amd-gpu-operator/1.5.2/metadata/annotations.yaml
+++ b/operators/amd-gpu-operator/1.5.2/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+---
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: amd-gpu-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+    #
+  # OpenShift annotations.
+  com.redhat.openshift.versions: "v4.16-v4.22"

--- a/operators/amd-gpu-operator/1.5.2/release-config.yaml
+++ b/operators/amd-gpu-operator/1.5.2/release-config.yaml
@@ -1,0 +1,23 @@
+---
+catalog_templates:
+  - template_name: v4.16.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1
+  - template_name: v4.17.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1
+  - template_name: v4.18.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1
+  - template_name: v4.19.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1
+  - template_name: v4.20.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1
+  - template_name: v4.21.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1
+  - template_name: v4.22.yaml
+    channels: [alpha]
+    replaces: amd-gpu-operator.v1.5.1

--- a/operators/amd-gpu-operator/1.5.2/tests/scorecard/config.yaml
+++ b/operators/amd-gpu-operator/1.5.2/tests/scorecard/config.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.32.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
This pull request introduces several new configuration and manifest files for the `amd-gpu-operator` version 1.5.2, enhancing monitoring, RBAC, custom resources, and release management. The main focus is on enabling Prometheus monitoring, defining RBAC roles and bindings for Prometheus, adding a new CRD for remediation workflow status, and updating bundle metadata and release configuration.

**Monitoring and Metrics Integration:**

* Added a `PrometheusRule` (`amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml`) to define recording rules for AMD GPU metrics, enabling Prometheus to collect and aggregate GPU utilization, memory, power, temperature, and clock metrics.

**RBAC for Monitoring:**

* Introduced a `Role` and `RoleBinding` (`amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml` and `amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml`) to grant the `prometheus-k8s` service account permissions to access services, endpoints, and pods for metrics scraping. [[1]](diffhunk://#diff-30b94f010ecd38ddd3e1ca57fabe02c9d43118549c518e252984ee8ee7b9db86R1-R21) [[2]](diffhunk://#diff-47cca33e5237b2933f0098920c7d0e4a5018aa5b9cecbc6b0a22340ac767d10bR1-R18)

**Custom Resource Definition:**

* Added a new CRD (`amd.com_remediationworkflowstatuses.yaml`) for `RemediationWorkflowStatus`, which tracks remediation workflow runs per node and condition, helping avoid redundant remediation actions.

**Operator and Release Configuration:**

* Added a manager config `ConfigMap` (`amd-gpu-operator-manager-config_v1_configmap.yaml`) to configure health probes, metrics binding, and leader election for the operator manager.
* Updated bundle metadata (`metadata/annotations.yaml`) and release configuration (`release-config.yaml`) to support OpenShift versions 4.16–4.22 and manage alpha channel releases. [[1]](diffhunk://#diff-ebc60fbed1ac32f5380049c91887678d1ad62527d3e2bbfe3ebf648d70102cfaR1-R18) [[2]](diffhunk://#diff-3a648e25220b88d6bfb36537fff6bd963f4919f3e82ead40434f3139512a1aa2R1-R23)

**Testing Configuration:**

* Added a scorecard test configuration (`tests/scorecard/config.yaml`) to validate operator bundle and CRDs using standard Operator Framework tests.Patch release fixing incorrect nodelabellerImage SHA in v1.5.1. Updates k8s-node-labeller digest to ed60266d (rhubi-latest) which resolves correctly in the registry.