### PR TITLE
fix: nvidia-network-operator invalid reference format

### DIFF
--- a/operators/nvidia-network-operator/24.1.0/manifests/nvidia-network-operator.clusterserviceversion.yaml
+++ b/operators/nvidia-network-operator/24.1.0/manifests/nvidia-network-operator.clusterserviceversion.yaml
@@ -663,17 +663,17 @@ spec:
     name: NVIDIA
     url: https://github.com/Mellanox/network-operator/
   relatedImages:
-  - image: nvcr.io/nvidia/mellanox/doca-driver:24.01-0.3.3.1.3-rhcos4.14-amd64@sha256:002864103e188074656510dc4c5ec1d84b6b0fcea    ddea4323999aeb051cf88a9
+  - image: nvcr.io/nvidia/mellanox/doca-driver:24.01-0.3.3.1.3-rhcos4.14-amd64@sha256:002864103e188074656510dc4c5ec1d84b6b0fceaddea4323999aeb051cf88a9
     name: mofed
-  - image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin@sha256:f717f9778f48665b7c592f2225df51b755a1fe048125e034a286    c564ee10fd37
+  - image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin@sha256:f717f9778f48665b7c592f2225df51b755a1fe048125e034a286c564ee10fd37
     name: sriov-network-device-plugin
-  - image: nvcr.io/nvidia/cloud-native/k8s-rdma-shared-dev-plugin@sha256:941ad9ff5013e9e7ad5abeb0ea9f79d45379cfae88a628d923f87d    2259bdd132
+  - image: nvcr.io/nvidia/cloud-native/k8s-rdma-shared-dev-plugin@sha256:941ad9ff5013e9e7ad5abeb0ea9f79d45379cfae88a628d923f87d2259bdd132
     name: rdma-shared-device-plugin
   - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c
     name: kube-rbac-proxy
   - image: nvcr.io/nvidia/cloud-native/network-operator@sha256:eab20c1439fc0ff438ef84db9f289bf344db5584f4238cf7384e1d8f1b4982c8
     name: network-operator
-  - image: ghcr.io/mellanox/network-operator-init-container@sha256:eab20c1439fc0ff438ef84db9f289bf344db5584f4238cf7384e1d8f1b49    82c8
+  - image: ghcr.io/mellanox/network-operator-init-container@sha256:eab20c1439fc0ff438ef84db9f289bf344db5584f4238cf7384e1d8f1b4982c8
     name: network-operator-init-container
   version: 24.1.0
   webhookdefinitions:


### PR DESCRIPTION
Additional white-spaces are captured by new OPM version as invalid. Catalog files already fixed in https://github.com/redhat-openshift-ecosystem/certified-operators/pull/9144 