### PR TITLE
operator ent-small-operator (0.1.0)

### DIFF
--- a/operators/ent-small-operator/0.1.0/manifests/ent-small-operator.clusterserviceversion.yaml
+++ b/operators/ent-small-operator/0.1.0/manifests/ent-small-operator.clusterserviceversion.yaml
@@ -1,0 +1,215 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: ent-small-operator.v0.1.0
+  namespace: placeholder
+  annotations:
+    # Operator Capability Level 4 (requirements FR-2, AC-2).
+    capabilities: Deep Insights
+    categories: "Application Runtime, Database"
+    description: >-
+      Installs and manages the Enterprise Small co-located single-pod Kalybr appliance
+      (ent-small-svc, ent-small-db, ent-public-web, ent-admin-web) with backup/restore,
+      migration-on-upgrade, and capacity scaling.
+    containerImage: ghcr.io/autonous-systems/ent-small-operator@sha256:d23397b9082159661ae5c7a63afec321c68bbda525e40e506670cf6418924e78
+    repository: https://github.com/autonous-systems/kalybr
+    support: Autonous
+    # Red Hat certified-operator infrastructure features. disconnected=true: every operand is a
+    # digest-pinned relatedImage resolved from RELATED_IMAGE_* env, so `oc mirror` installs air-gapped
+    # (the externalized TP embedder is optional/off by default and outside the certified bundle, CON-3).
+    # The rest are declared false (not yet validated) — honest declaration is what cert requires.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    createdAt: "2026-07-27T00:00:00Z"
+    olm.skipRange: "<0.1.0"
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kalybr.ai/v1alpha1",
+          "kind": "EnterpriseSmall",
+          "metadata": { "name": "acme", "namespace": "ent-small" },
+          "spec": {
+            "agentCapacity": 100,
+            "platform": "auto",
+            "semanticSearch": { "enabled": false },
+            "publicWeb": { "enabled": true },
+            "backup": { "enabled": false }
+          }
+        }
+      ]
+spec:
+  displayName: Enterprise Small Operator
+  description: |
+    The Enterprise Small operator packages the co-located single-pod Kalybr appliance as
+    a platform-aware Kubernetes operator. It targets OpenShift (Route, restricted-v2 SCC,
+    user-workload monitoring) and, from the same codebase, upstream Kubernetes.
+
+    ## Capabilities (Level 4 — Deep Insights)
+    - Install + seamless upgrades of the full stack via OLM.
+    - Lifecycle: DB-readiness-gated schema migration on upgrade; scheduled pg_dump backup.
+    - Vertical capacity steps (100 / 500 / 1000 agents) with no data loss on change.
+    - Optional semantic search with an externalized embedder (never baked into the image).
+    - Metrics/alerts/status via ServiceMonitor + PrometheusRule and CR .status conditions.
+  version: 0.1.0
+  maturity: alpha
+  minKubeVersion: 1.27.0
+  icon:
+    - mediatype: image/svg+xml
+      base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsPSJFbnRlcnByaXNlIFNtYWxsIj4KICA8cmVjdCB4PSI0IiB5PSI0IiB3aWR0aD0iNTYiIGhlaWdodD0iNTYiIHJ4PSIxMiIgZmlsbD0iIzFmMjkzMyIvPgogIDxyZWN0IHg9IjE2IiB5PSIxNSIgd2lkdGg9IjMyIiBoZWlnaHQ9IjEwIiByeD0iMyIgZmlsbD0iIzRmNDZlNSIvPgogIDxyZWN0IHg9IjE2IiB5PSIyNyIgd2lkdGg9IjMyIiBoZWlnaHQ9IjEwIiByeD0iMyIgZmlsbD0iIzYzNjZmMSIvPgogIDxyZWN0IHg9IjE2IiB5PSIzOSIgd2lkdGg9IjMyIiBoZWlnaHQ9IjEwIiByeD0iMyIgZmlsbD0iIzgxOGNmOCIvPgogIDxjaXJjbGUgY3g9IjIxIiBjeT0iMjAiIHI9IjEuOCIgZmlsbD0iI2U1ZTdlYiIvPgogIDxjaXJjbGUgY3g9IjIxIiBjeT0iMzIiIHI9IjEuOCIgZmlsbD0iI2U1ZTdlYiIvPgogIDxjaXJjbGUgY3g9IjIxIiBjeT0iNDQiIHI9IjEuOCIgZmlsbD0iI2U1ZTdlYiIvPgo8L3N2Zz4K
+  provider:
+    name: Autonous
+  maintainers:
+    - name: Autonous
+      email: support@autonous.ai
+  links:
+    - name: Source
+      url: https://github.com/autonous-systems/kalybr
+  keywords:
+    - kalybr
+    - ent-small
+    - agents
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+  customresourcedefinitions:
+    owned:
+      - name: enterprisesmalls.kalybr.ai
+        kind: EnterpriseSmall
+        version: v1alpha1
+        displayName: Enterprise Small
+        description: A co-located single-pod Kalybr appliance.
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: ent-small-operator
+          rules:
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, patch]
+            - apiGroups: [""]
+              resources: [namespaces]
+              verbs: [get, list, patch, watch]
+            - apiGroups: [""]
+              resources: [persistentvolumeclaims, services]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [apps]
+              resources: [deployments]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [batch]
+              resources: [jobs, cronjobs]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [kalybr.ai]
+              resources: [enterprisesmalls]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [kalybr.ai]
+              resources: [enterprisesmalls/finalizers]
+              verbs: [update]
+            - apiGroups: [kalybr.ai]
+              resources: [enterprisesmalls/status]
+              verbs: [get, patch, update]
+            - apiGroups: [monitoring.coreos.com]
+              resources: [prometheusrules, servicemonitors]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [networking.k8s.io]
+              resources: [ingresses]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [route.openshift.io]
+              resources: [routes]
+              verbs: [create, delete, get, list, patch, update, watch]
+      permissions:
+        - serviceAccountName: ent-small-operator
+          rules:
+            - apiGroups: [coordination.k8s.io]
+              resources: [leases]
+              verbs: [create, get, list, update, watch]
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, patch]
+      deployments:
+        - name: ent-small-operator
+          label:
+            app.kubernetes.io/name: ent-small-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: ent-small-operator
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: ent-small-operator
+              spec:
+                serviceAccountName: ent-small-operator
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: manager
+                    image: ghcr.io/autonous-systems/ent-small-operator@sha256:d23397b9082159661ae5c7a63afec321c68bbda525e40e506670cf6418924e78
+                    args:
+                      - --health-probe-bind-address=:8081
+                      - --metrics-bind-address=:8080
+                      - --leader-elect=true
+                    # Digest-pinned operand images (Red Hat disconnected/air-gap). The operator resolves
+                    # each operand from these RELATED_IMAGE_* vars; they mirror the relatedImages list below.
+                    # scripts/pin-bundle-digests.sh rewrites BOTH these values and relatedImages to @sha256
+                    # at certification time. No embedder here — it is externalized (CON-3).
+                    env:
+                      - name: RELATED_IMAGE_ENT_SMALL_SVC
+                        value: ghcr.io/autonous-systems/ent-small-svc@sha256:abab70d6f612995682cec213b6cc33ac3eed78749002c3d6c80b47221cfdffa8
+                      - name: RELATED_IMAGE_ENT_SMALL_DB
+                        value: ghcr.io/autonous-systems/ent-small-db@sha256:ff187308408de33f92e0deb7edd8885fd0c488953842aa50dd686cea8ef029cc
+                      - name: RELATED_IMAGE_ENT_PUBLIC_WEB
+                        value: ghcr.io/autonous-systems/ent-public-web@sha256:8f415f6a17d634c48a4c24cd9d43ace8cceef7cfd829acf88eebc170f0c314e4
+                      - name: RELATED_IMAGE_ENT_ADMIN_WEB
+                        value: ghcr.io/autonous-systems/ent-admin-web@sha256:a44d7489c49b1a18bc536e52061e418bc89d1eb744c147c6ad9f96598c4c3477
+                    ports:
+                      - name: metrics
+                        containerPort: 8080
+                      - name: probe
+                        containerPort: 8081
+                    livenessProbe:
+                      httpGet: { path: /healthz, port: probe }
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet: { path: /readyz, port: probe }
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                        drop: [ALL]
+                    resources:
+                      requests: { cpu: 50m, memory: 64Mi }
+                      limits: { cpu: 500m, memory: 256Mi }
+  # relatedImages keeps the bundle air-gap complete (CON-6.1) — every operand image the
+  # operator may render is enumerated so `oc mirror` pulls them. Digest-pin at cert time.
+  relatedImages:
+    - name: operator
+      image: ghcr.io/autonous-systems/ent-small-operator@sha256:d23397b9082159661ae5c7a63afec321c68bbda525e40e506670cf6418924e78
+    - name: ent-small-svc
+      image: ghcr.io/autonous-systems/ent-small-svc@sha256:abab70d6f612995682cec213b6cc33ac3eed78749002c3d6c80b47221cfdffa8
+    - name: ent-small-db
+      image: ghcr.io/autonous-systems/ent-small-db@sha256:ff187308408de33f92e0deb7edd8885fd0c488953842aa50dd686cea8ef029cc
+    - name: ent-public-web
+      image: ghcr.io/autonous-systems/ent-public-web@sha256:8f415f6a17d634c48a4c24cd9d43ace8cceef7cfd829acf88eebc170f0c314e4
+    - name: ent-admin-web
+      image: ghcr.io/autonous-systems/ent-admin-web@sha256:a44d7489c49b1a18bc536e52061e418bc89d1eb744c147c6ad9f96598c4c3477

--- a/operators/ent-small-operator/0.1.0/manifests/ent-small-operator.clusterserviceversion.yaml
+++ b/operators/ent-small-operator/0.1.0/manifests/ent-small-operator.clusterserviceversion.yaml
@@ -185,11 +185,11 @@ spec:
                       - name: probe
                         containerPort: 8081
                     livenessProbe:
-                      httpGet: { path: /healthz, port: probe }
+                      httpGet: {path: /healthz, port: probe}
                       initialDelaySeconds: 15
                       periodSeconds: 20
                     readinessProbe:
-                      httpGet: { path: /readyz, port: probe }
+                      httpGet: {path: /readyz, port: probe}
                       initialDelaySeconds: 5
                       periodSeconds: 10
                     securityContext:
@@ -198,8 +198,8 @@ spec:
                       capabilities:
                         drop: [ALL]
                     resources:
-                      requests: { cpu: 50m, memory: 64Mi }
-                      limits: { cpu: 500m, memory: 256Mi }
+                      requests: {cpu: 50m, memory: 64Mi}
+                      limits: {cpu: 500m, memory: 256Mi}
   # relatedImages keeps the bundle air-gap complete (CON-6.1) — every operand image the
   # operator may render is enumerated so `oc mirror` pulls them. Digest-pin at cert time.
   relatedImages:

--- a/operators/ent-small-operator/0.1.0/manifests/kalybr.ai_enterprisesmalls.yaml
+++ b/operators/ent-small-operator/0.1.0/manifests/kalybr.ai_enterprisesmalls.yaml
@@ -1,0 +1,327 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: enterprisesmalls.kalybr.ai
+spec:
+  group: kalybr.ai
+  names:
+    categories:
+    - kalybr
+    kind: EnterpriseSmall
+    listKind: EnterpriseSmallList
+    plural: enterprisesmalls
+    shortNames:
+    - ensm
+    singular: enterprisesmall
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.agentCapacity
+      name: Capacity
+      type: integer
+    - jsonPath: .spec.semanticSearch.enabled
+      name: Semantic
+      type: boolean
+    - jsonPath: .status.platform
+      name: Platform
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EnterpriseSmall is the Schema for the co-located single-pod Enterprise
+          Small stack.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnterpriseSmallSpec is the desired state of an Enterprise
+              Small appliance.
+            properties:
+              access:
+                description: Access configures external exposure (CON-2.1, §8). Default
+                  auto (Route/Ingress).
+                properties:
+                  adminWebNodePort:
+                    default: 31301
+                    description: AdminWebNodePort exposes ent-admin-web (nodePort
+                      mode).
+                    format: int32
+                    type: integer
+                  gatewayNodePort:
+                    default: 31080
+                    description: GatewayNodePort exposes the api-gateway (nodePort
+                      mode).
+                    format: int32
+                    type: integer
+                  mode:
+                    default: auto
+                    description: Mode is "auto" (default), "ingress", "nodePort",
+                      or "route".
+                    enum:
+                    - auto
+                    - ingress
+                    - nodePort
+                    - route
+                    type: string
+                  nodeIP:
+                    description: |-
+                      NodeIP is the externally-reachable node address (nodePort mode) used to build the
+                      consoles' NEXT_PUBLIC_API_URL and the OAuth redirect allowlist.
+                    type: string
+                  publicWebNodePort:
+                    default: 31300
+                    description: PublicWebNodePort exposes ent-public-web (nodePort
+                      mode).
+                    format: int32
+                    type: integer
+                type: object
+              agentCapacity:
+                default: 100
+                description: AgentCapacity is the capacity step that sizes the co-located
+                  pod + DB (FR-4).
+                enum:
+                - 100
+                - 500
+                - 1000
+                format: int32
+                type: integer
+              backup:
+                description: Backup configures scheduled DB backups (FR-2.2). Default
+                  off.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled turns on scheduled pg_dump backups.
+                    type: boolean
+                  retention:
+                    default: 7
+                    description: Retention is how many successful backups to keep
+                      (CronJob history limit).
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  schedule:
+                    default: 0 2 * * *
+                    description: Schedule is the cron expression for the backup CronJob.
+                      Default nightly 02:00.
+                    type: string
+                type: object
+              globalDiscovery:
+                description: GlobalDiscovery is the sole optional external dependency
+                  (CON-6), default bundled.
+                properties:
+                  url:
+                    description: URL of an external discovery-svc. Empty means use
+                      the bundled snapshot.
+                    type: string
+                type: object
+              hardened:
+                default: true
+                description: |-
+                  Hardened applies rootless/arbitrary-UID SecurityContexts + PSA "restricted" namespace
+                  enforcement (the certified posture, CON-2). Default true. Set false for the current
+                  Debian/Node operand images (s6-overlay + postgres start as root) until the UBI
+                  conversion lands — the requirements doc's CON-2 image gap.
+                type: boolean
+              imageTag:
+                description: |-
+                  ImageTag pins the ent-small image tag for all workloads. Empty uses the
+                  operator's default. Digest-pinning is applied at bundle build time (CON-2).
+                type: string
+              migration:
+                description: Migration toggles operator-driven schema migration on
+                  upgrade (FR-2.2). Default on.
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled runs the ledger-tracked migration Job when the image tag changes. Set false
+                      when an external step owns schema convergence (e.g. deploy-ent runs migrate.sh as the
+                      postgres superuser over the DB pod's unix socket — a privilege a separate Job lacks).
+                    type: boolean
+                type: object
+              platform:
+                default: auto
+                description: Platform selects the render target (FR-8). Default "auto"
+                  detects at reconcile.
+                enum:
+                - openshift
+                - kubernetes
+                - auto
+                type: string
+              publicWeb:
+                description: PublicWeb controls the optional public console (FR-5.1).
+                properties:
+                  enabled:
+                    default: true
+                    description: Enabled deploys ent-public-web. Default true. Set
+                      false for admin-only installs.
+                    type: boolean
+                type: object
+              semanticSearch:
+                description: SemanticSearch is optional at every capacity (FR-3),
+                  default off.
+                properties:
+                  embedderUrl:
+                    description: |-
+                      EmbedderURL points at a customer-supplied external embedder endpoint (FR-3.1a).
+                      When empty and Enabled is true, the operator sources the embedder per the
+                      operator-deployed Technology Preview path (FR-3.1b). Never an in-image model.
+                    type: string
+                  enabled:
+                    default: false
+                    description: |-
+                      Enabled turns on semantic/vector search. Default false — the certified default
+                      is lexical (tsvector/BM25) + reputation rerank.
+                    type: boolean
+                type: object
+              storage:
+                description: Storage configures the DB data volume (CON-2.1). Default
+                  PVC.
+                properties:
+                  hostPath:
+                    default: /var/lib/ent-small-db
+                    description: HostPath is the node-local PGDATA directory when
+                      Mode is "hostPath".
+                    type: string
+                  mode:
+                    default: pvc
+                    description: Mode is "pvc" (default, certified) or "hostPath"
+                      (single-node, no StorageClass).
+                    enum:
+                    - pvc
+                    - hostPath
+                    type: string
+                type: object
+              svcImageTag:
+                description: |-
+                  SvcImageTag overrides just the ent-small-svc image tag, so a fast svc-only iteration
+                  can roll the multi-process pod without re-tagging the DB/UI images (which stay at
+                  ImageTag). Empty falls back to ImageTag.
+                type: string
+            type: object
+          status:
+            description: EnterpriseSmallStatus is the observed state of the appliance
+              (NFR-7.3).
+            properties:
+              activeAgentCapacity:
+                description: ActiveAgentCapacity is the capacity step currently reconciled
+                  (NFR-7.3).
+                enum:
+                - 100
+                - 500
+                - 1000
+                format: int32
+                type: integer
+              conditions:
+                description: |-
+                  Conditions follow the standard metav1.Condition contract
+                  (Ready / DatabaseReady / Degraded).
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              migratedTag:
+                description: |-
+                  MigratedTag is the image tag whose DB migrations have been applied (FR-2.2).
+                  Empty until the first migration Job succeeds.
+                type: string
+              observedAgentCount:
+                description: |-
+                  ObservedAgentCount is the live agent count reported by the appliance (NFR-7.3).
+                  Zero until the appliance reports; populated by a later phase.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the .metadata.generation last reconciled.
+                format: int64
+                type: integer
+              platform:
+                description: |-
+                  Platform is the platform resolved for this appliance ("openshift"/"kubernetes"),
+                  after applying spec.platform + detection (FR-8).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/ent-small-operator/0.1.0/metadata/annotations.yaml
+++ b/operators/ent-small-operator/0.1.0/metadata/annotations.yaml
@@ -1,0 +1,9 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ent-small-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  # Certified-operator hint: minimum OpenShift version.
+  com.redhat.openshift.versions: "v4.14"

--- a/operators/ent-small-operator/ci.yaml
+++ b/operators/ent-small-operator/ci.yaml
@@ -1,0 +1,3 @@
+---
+# Links this operator submission to the Red Hat Partner Connect operator-bundle component.
+cert_project_id: 6a6a165610bf16d89c325efb


### PR DESCRIPTION
New certified operator: **ent-small-operator** v0.1.0 (Kalybr Enterprise Small).

- Bundle references all operands by immutable @sha256 digest.
- `ci.yaml` linked to Partner Connect operator component `6a6a165610bf16d89c325efb`.
- Operand + operator images are UBI-based, non-root, and submitted for container certification.