### PR TITLE
Catalog update [stackable-zookeeper-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-zookeeper-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-zookeeper-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-zookeeper-operator
 schema: olm.channel
 ---
 entries:
+- name: zookeeper-operator.v26.7.0
+name: "26.7"
+package: stackable-zookeeper-operator
+schema: olm.channel
+---
+entries:
 - name: zookeeper-operator.v25.3.0
 - name: zookeeper-operator.v25.7.0
   replaces: zookeeper-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: zookeeper-operator.v25.7.0
 - name: zookeeper-operator.v26.3.0
   replaces: zookeeper-operator.v25.11.0
+- name: zookeeper-operator.v26.7.0
+  replaces: zookeeper-operator.v26.3.0
 name: stable
 package: stackable-zookeeper-operator
 schema: olm.channel
@@ -362,5 +370,70 @@ relatedImages:
 - image: quay.io/stackable/zookeeper-operator@sha256:9241b7298eb69582206adb513e32b45d074ec9b8da2d31c37b32a6eb740df491
   name: zookeeper-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
+name: zookeeper-operator.v26.7.0
+package: stackable-zookeeper-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-zookeeper-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+      description: Stackable Operator for Apache ZooKeeper
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/zookeeper-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache ZooKeeper
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zookeeper
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+  name: zookeeper-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-zookeeper-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-zookeeper-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-zookeeper-operator
 schema: olm.channel
 ---
 entries:
+- name: zookeeper-operator.v26.7.0
+name: "26.7"
+package: stackable-zookeeper-operator
+schema: olm.channel
+---
+entries:
 - name: zookeeper-operator.v25.3.0
 - name: zookeeper-operator.v25.7.0
   replaces: zookeeper-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: zookeeper-operator.v25.7.0
 - name: zookeeper-operator.v26.3.0
   replaces: zookeeper-operator.v25.11.0
+- name: zookeeper-operator.v26.7.0
+  replaces: zookeeper-operator.v26.3.0
 name: stable
 package: stackable-zookeeper-operator
 schema: olm.channel
@@ -362,5 +370,70 @@ relatedImages:
 - image: quay.io/stackable/zookeeper-operator@sha256:9241b7298eb69582206adb513e32b45d074ec9b8da2d31c37b32a6eb740df491
   name: zookeeper-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
+name: zookeeper-operator.v26.7.0
+package: stackable-zookeeper-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-zookeeper-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+      description: Stackable Operator for Apache ZooKeeper
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/zookeeper-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache ZooKeeper
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zookeeper
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+  name: zookeeper-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-zookeeper-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-zookeeper-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-zookeeper-operator
 schema: olm.channel
 ---
 entries:
+- name: zookeeper-operator.v26.7.0
+name: "26.7"
+package: stackable-zookeeper-operator
+schema: olm.channel
+---
+entries:
 - name: zookeeper-operator.v25.11.0
 - name: zookeeper-operator.v26.3.0
   replaces: zookeeper-operator.v25.11.0
+- name: zookeeper-operator.v26.7.0
+  replaces: zookeeper-operator.v26.3.0
 name: stable
 package: stackable-zookeeper-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/zookeeper-operator@sha256:9241b7298eb69582206adb513e32b45d074ec9b8da2d31c37b32a6eb740df491
   name: zookeeper-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
+name: zookeeper-operator.v26.7.0
+package: stackable-zookeeper-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-zookeeper-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+      description: Stackable Operator for Apache ZooKeeper
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/zookeeper-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache ZooKeeper
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zookeeper
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+  name: zookeeper-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-zookeeper-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-zookeeper-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-zookeeper-operator
 schema: olm.channel
 ---
 entries:
+- name: zookeeper-operator.v26.7.0
+name: "26.7"
+package: stackable-zookeeper-operator
+schema: olm.channel
+---
+entries:
 - name: zookeeper-operator.v25.11.0
 - name: zookeeper-operator.v26.3.0
   replaces: zookeeper-operator.v25.11.0
+- name: zookeeper-operator.v26.7.0
+  replaces: zookeeper-operator.v26.3.0
 name: stable
 package: stackable-zookeeper-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/zookeeper-operator@sha256:9241b7298eb69582206adb513e32b45d074ec9b8da2d31c37b32a6eb740df491
   name: zookeeper-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
+name: zookeeper-operator.v26.7.0
+package: stackable-zookeeper-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-zookeeper-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+      description: Stackable Operator for Apache ZooKeeper
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/zookeeper-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache ZooKeeper
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zookeeper
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+  name: zookeeper-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-zookeeper-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-zookeeper-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-zookeeper-operator
 schema: olm.channel
 ---
 entries:
+- name: zookeeper-operator.v26.7.0
+name: "26.7"
+package: stackable-zookeeper-operator
+schema: olm.channel
+---
+entries:
 - name: zookeeper-operator.v25.11.0
 - name: zookeeper-operator.v26.3.0
   replaces: zookeeper-operator.v25.11.0
+- name: zookeeper-operator.v26.7.0
+  replaces: zookeeper-operator.v26.3.0
 name: stable
 package: stackable-zookeeper-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/zookeeper-operator@sha256:9241b7298eb69582206adb513e32b45d074ec9b8da2d31c37b32a6eb740df491
   name: zookeeper-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
+name: zookeeper-operator.v26.7.0
+package: stackable-zookeeper-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-zookeeper-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+      description: Stackable Operator for Apache ZooKeeper
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/zookeeper-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache ZooKeeper
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - zookeeper
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/zookeeper-operator@sha256:51d2b4f64be6cb3dbdc1a63147c0691bc6a868a02aee78fa33bc6f40e2b4de58
+  name: zookeeper-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1
   name: ""
 schema: olm.bundle

--- a/operators/stackable-zookeeper-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-zookeeper-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: zookeeper-operator.v25.7.0
   - name: zookeeper-operator.v26.3.0
     replaces: zookeeper-operator.v25.11.0
+  - name: zookeeper-operator.v26.7.0
+    replaces: zookeeper-operator.v26.3.0
   name: stable
   package: stackable-zookeeper-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:b4183289cc6d66e36aab6b956d932d1e6537a8975da5b5fa534ff3293e02e83f # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: zookeeper-operator.v26.7.0
+  name: '26.7'
+  package: stackable-zookeeper-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:a2d289bf7c2c8efec5ce5afc79a0a2971fe9a525e0b0b68c2cd2b44e7852d8db # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-zookeeper-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-zookeeper-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: zookeeper-operator.v25.7.0
   - name: zookeeper-operator.v26.3.0
     replaces: zookeeper-operator.v25.11.0
+  - name: zookeeper-operator.v26.7.0
+    replaces: zookeeper-operator.v26.3.0
   name: stable
   package: stackable-zookeeper-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:b4183289cc6d66e36aab6b956d932d1e6537a8975da5b5fa534ff3293e02e83f # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: zookeeper-operator.v26.7.0
+  name: '26.7'
+  package: stackable-zookeeper-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:a2d289bf7c2c8efec5ce5afc79a0a2971fe9a525e0b0b68c2cd2b44e7852d8db # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-zookeeper-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-zookeeper-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: zookeeper-operator.v25.11.0
   - name: zookeeper-operator.v26.3.0
     replaces: zookeeper-operator.v25.11.0
+  - name: zookeeper-operator.v26.7.0
+    replaces: zookeeper-operator.v26.3.0
   name: stable
+  package: stackable-zookeeper-operator
+  schema: olm.channel
+- entries:
+  - name: zookeeper-operator.v26.7.0
+  name: '26.7'
   package: stackable-zookeeper-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:4ddd8ee30382e022df468e6f58c40b5b62a220a87b07a3cae60649b8cb7a8a90 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-zookeeper-operator@sha256:ffe47d5ab295cc323b601acbaa012745d3d084d62218a9a1c7a62b102698f5d1 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-zookeeper-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `zookeeper-operator.v26.7.0`
- `stable` extended with `zookeeper-operator.v26.7.0` replacing `zookeeper-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.