### PR TITLE
Catalog update [stackable-commons-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-commons-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-commons-operator/catalog.yaml
@@ -25,6 +25,12 @@ package: stackable-commons-operator
 schema: olm.channel
 ---
 entries:
+- name: commons-operator.v26.7.0
+name: "26.7"
+package: stackable-commons-operator
+schema: olm.channel
+---
+entries:
 - name: commons-operator.v25.3.0
 - name: commons-operator.v25.7.0
   replaces: commons-operator.v25.3.0
@@ -32,6 +38,8 @@ entries:
   replaces: commons-operator.v25.7.0
 - name: commons-operator.v26.3.0
   replaces: commons-operator.v25.11.0
+- name: commons-operator.v26.7.0
+  replaces: commons-operator.v26.3.0
 name: stable
 package: stackable-commons-operator
 schema: olm.channel
@@ -417,5 +425,70 @@ relatedImages:
 - image: quay.io/stackable/commons-operator@sha256:5325df6b0ed2c8eddae3f4df007e17e0e5e21db56ca752a1e8e53b19c37fa40c
   name: commons-operator
 - image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
+name: commons-operator.v26.7.0
+package: stackable-commons-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-commons-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+      description: Stackable Commons Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/commons-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Commons Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - commons
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+  name: commons-operator
+- image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-commons-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-commons-operator/catalog.yaml
@@ -25,6 +25,12 @@ package: stackable-commons-operator
 schema: olm.channel
 ---
 entries:
+- name: commons-operator.v26.7.0
+name: "26.7"
+package: stackable-commons-operator
+schema: olm.channel
+---
+entries:
 - name: commons-operator.v25.3.0
 - name: commons-operator.v25.7.0
   replaces: commons-operator.v25.3.0
@@ -32,6 +38,8 @@ entries:
   replaces: commons-operator.v25.7.0
 - name: commons-operator.v26.3.0
   replaces: commons-operator.v25.11.0
+- name: commons-operator.v26.7.0
+  replaces: commons-operator.v26.3.0
 name: stable
 package: stackable-commons-operator
 schema: olm.channel
@@ -417,5 +425,70 @@ relatedImages:
 - image: quay.io/stackable/commons-operator@sha256:5325df6b0ed2c8eddae3f4df007e17e0e5e21db56ca752a1e8e53b19c37fa40c
   name: commons-operator
 - image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
+name: commons-operator.v26.7.0
+package: stackable-commons-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-commons-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+      description: Stackable Commons Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/commons-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Commons Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - commons
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+  name: commons-operator
+- image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-commons-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-commons-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-commons-operator
 schema: olm.channel
 ---
 entries:
+- name: commons-operator.v26.7.0
+name: "26.7"
+package: stackable-commons-operator
+schema: olm.channel
+---
+entries:
 - name: commons-operator.v25.11.0
 - name: commons-operator.v26.3.0
   replaces: commons-operator.v25.11.0
+- name: commons-operator.v26.7.0
+  replaces: commons-operator.v26.3.0
 name: stable
 package: stackable-commons-operator
 schema: olm.channel
@@ -215,5 +223,70 @@ relatedImages:
 - image: quay.io/stackable/commons-operator@sha256:5325df6b0ed2c8eddae3f4df007e17e0e5e21db56ca752a1e8e53b19c37fa40c
   name: commons-operator
 - image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
+name: commons-operator.v26.7.0
+package: stackable-commons-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-commons-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+      description: Stackable Commons Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/commons-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Commons Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - commons
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+  name: commons-operator
+- image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-commons-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-commons-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-commons-operator
 schema: olm.channel
 ---
 entries:
+- name: commons-operator.v26.7.0
+name: "26.7"
+package: stackable-commons-operator
+schema: olm.channel
+---
+entries:
 - name: commons-operator.v25.11.0
 - name: commons-operator.v26.3.0
   replaces: commons-operator.v25.11.0
+- name: commons-operator.v26.7.0
+  replaces: commons-operator.v26.3.0
 name: stable
 package: stackable-commons-operator
 schema: olm.channel
@@ -215,5 +223,70 @@ relatedImages:
 - image: quay.io/stackable/commons-operator@sha256:5325df6b0ed2c8eddae3f4df007e17e0e5e21db56ca752a1e8e53b19c37fa40c
   name: commons-operator
 - image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
+name: commons-operator.v26.7.0
+package: stackable-commons-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-commons-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+      description: Stackable Commons Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/commons-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Commons Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - commons
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+  name: commons-operator
+- image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-commons-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-commons-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-commons-operator
 schema: olm.channel
 ---
 entries:
+- name: commons-operator.v26.7.0
+name: "26.7"
+package: stackable-commons-operator
+schema: olm.channel
+---
+entries:
 - name: commons-operator.v25.11.0
 - name: commons-operator.v26.3.0
   replaces: commons-operator.v25.11.0
+- name: commons-operator.v26.7.0
+  replaces: commons-operator.v26.3.0
 name: stable
 package: stackable-commons-operator
 schema: olm.channel
@@ -215,5 +223,70 @@ relatedImages:
 - image: quay.io/stackable/commons-operator@sha256:5325df6b0ed2c8eddae3f4df007e17e0e5e21db56ca752a1e8e53b19c37fa40c
   name: commons-operator
 - image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
+name: commons-operator.v26.7.0
+package: stackable-commons-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-commons-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+      description: Stackable Commons Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/commons-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Commons Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - commons
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/commons-operator@sha256:7959fa31fbeea0ed9859123d3d0b699ffcb4dbddd365390421dd227097808ade
+  name: commons-operator
+- image: registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f
   name: ""
 schema: olm.bundle

--- a/operators/stackable-commons-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-commons-operator/catalog-templates/v4.18.yaml
@@ -30,6 +30,8 @@ entries:
     replaces: commons-operator.v25.7.0
   - name: commons-operator.v26.3.0
     replaces: commons-operator.v25.11.0
+  - name: commons-operator.v26.7.0
+    replaces: commons-operator.v26.3.0
   name: stable
   package: stackable-commons-operator
   schema: olm.channel
@@ -39,6 +41,11 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:ca2d0ea011ee4d02a8043df932890291bcf7f6ab15edac5e8b1e74bc2b29ff85 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: commons-operator.v26.7.0
+  name: '26.7'
+  package: stackable-commons-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:2a9de3ee2f44c74604a516a2f4ad7525315ea37b3b7193505c68e065821a9b06 # 25.11.0
@@ -46,4 +53,7 @@ entries:
   image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981 # 26.3.0
 
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-commons-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-commons-operator/catalog-templates/v4.19.yaml
@@ -30,6 +30,8 @@ entries:
     replaces: commons-operator.v25.7.0
   - name: commons-operator.v26.3.0
     replaces: commons-operator.v25.11.0
+  - name: commons-operator.v26.7.0
+    replaces: commons-operator.v26.3.0
   name: stable
   package: stackable-commons-operator
   schema: olm.channel
@@ -39,10 +41,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:ca2d0ea011ee4d02a8043df932890291bcf7f6ab15edac5e8b1e74bc2b29ff85 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: commons-operator.v26.7.0
+  name: '26.7'
+  package: stackable-commons-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:2a9de3ee2f44c74604a516a2f4ad7525315ea37b3b7193505c68e065821a9b06 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-commons-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-commons-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: commons-operator.v25.11.0
   - name: commons-operator.v26.3.0
     replaces: commons-operator.v25.11.0
+  - name: commons-operator.v26.7.0
+    replaces: commons-operator.v26.3.0
   name: stable
+  package: stackable-commons-operator
+  schema: olm.channel
+- entries:
+  - name: commons-operator.v26.7.0
+  name: '26.7'
   package: stackable-commons-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:0db7b71b830d94a914d15be1c4b0ae2163f9501efb71ebade8fabfdeb55cb981 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-commons-operator@sha256:4bf1d05cc76f7195a69e2ea8c1a8e93105eb56468fb6fd684bbfacff25c9262f # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-commons-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `commons-operator.v26.7.0`
- `stable` extended with `commons-operator.v26.7.0` replacing `commons-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.