### PR TITLE
Catalog update [stackable-secret-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-secret-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-secret-operator/catalog.yaml
@@ -25,6 +25,12 @@ package: stackable-secret-operator
 schema: olm.channel
 ---
 entries:
+- name: secret-operator.v26.7.0
+name: "26.7"
+package: stackable-secret-operator
+schema: olm.channel
+---
+entries:
 - name: secret-operator.v25.3.0
 - name: secret-operator.v25.7.0
   replaces: secret-operator.v25.3.0
@@ -32,6 +38,8 @@ entries:
   replaces: secret-operator.v25.7.0
 - name: secret-operator.v26.3.0
   replaces: secret-operator.v25.11.0
+- name: secret-operator.v26.7.0
+  replaces: secret-operator.v26.3.0
 name: stable
 package: stackable-secret-operator
 schema: olm.channel
@@ -355,5 +363,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
+name: secret-operator.v26.7.0
+package: stackable-secret-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-secret-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Secret Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/secret-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is a Kubernetes operator to provide secret functionality to other Stackable operators. The Stackable Secret Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/secret-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Secret Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - secret
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/secret-operator@sha256:ccdad5309978a1c890badf85313f398ae35dccef02a7ff5aa4fc6211246df8a9
+  name: secret-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-secret-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-secret-operator/catalog.yaml
@@ -25,6 +25,12 @@ package: stackable-secret-operator
 schema: olm.channel
 ---
 entries:
+- name: secret-operator.v26.7.0
+name: "26.7"
+package: stackable-secret-operator
+schema: olm.channel
+---
+entries:
 - name: secret-operator.v25.3.0
 - name: secret-operator.v25.7.0
   replaces: secret-operator.v25.3.0
@@ -32,6 +38,8 @@ entries:
   replaces: secret-operator.v25.7.0
 - name: secret-operator.v26.3.0
   replaces: secret-operator.v25.11.0
+- name: secret-operator.v26.7.0
+  replaces: secret-operator.v26.3.0
 name: stable
 package: stackable-secret-operator
 schema: olm.channel
@@ -355,5 +363,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
+name: secret-operator.v26.7.0
+package: stackable-secret-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-secret-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Secret Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/secret-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is a Kubernetes operator to provide secret functionality to other Stackable operators. The Stackable Secret Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/secret-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Secret Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - secret
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/secret-operator@sha256:ccdad5309978a1c890badf85313f398ae35dccef02a7ff5aa4fc6211246df8a9
+  name: secret-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-secret-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-secret-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-secret-operator
 schema: olm.channel
 ---
 entries:
+- name: secret-operator.v26.7.0
+name: "26.7"
+package: stackable-secret-operator
+schema: olm.channel
+---
+entries:
 - name: secret-operator.v25.11.0
 - name: secret-operator.v26.3.0
   replaces: secret-operator.v25.11.0
+- name: secret-operator.v26.7.0
+  replaces: secret-operator.v26.3.0
 name: stable
 package: stackable-secret-operator
 schema: olm.channel
@@ -167,5 +175,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
+name: secret-operator.v26.7.0
+package: stackable-secret-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-secret-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Secret Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/secret-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is a Kubernetes operator to provide secret functionality to other Stackable operators. The Stackable Secret Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/secret-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Secret Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - secret
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/secret-operator@sha256:ccdad5309978a1c890badf85313f398ae35dccef02a7ff5aa4fc6211246df8a9
+  name: secret-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-secret-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-secret-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-secret-operator
 schema: olm.channel
 ---
 entries:
+- name: secret-operator.v26.7.0
+name: "26.7"
+package: stackable-secret-operator
+schema: olm.channel
+---
+entries:
 - name: secret-operator.v25.11.0
 - name: secret-operator.v26.3.0
   replaces: secret-operator.v25.11.0
+- name: secret-operator.v26.7.0
+  replaces: secret-operator.v26.3.0
 name: stable
 package: stackable-secret-operator
 schema: olm.channel
@@ -167,5 +175,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
+name: secret-operator.v26.7.0
+package: stackable-secret-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-secret-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Secret Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/secret-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is a Kubernetes operator to provide secret functionality to other Stackable operators. The Stackable Secret Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/secret-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Secret Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - secret
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/secret-operator@sha256:ccdad5309978a1c890badf85313f398ae35dccef02a7ff5aa4fc6211246df8a9
+  name: secret-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-secret-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-secret-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-secret-operator
 schema: olm.channel
 ---
 entries:
+- name: secret-operator.v26.7.0
+name: "26.7"
+package: stackable-secret-operator
+schema: olm.channel
+---
+entries:
 - name: secret-operator.v25.11.0
 - name: secret-operator.v26.3.0
   replaces: secret-operator.v25.11.0
+- name: secret-operator.v26.7.0
+  replaces: secret-operator.v26.3.0
 name: stable
 package: stackable-secret-operator
 schema: olm.channel
@@ -167,5 +175,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
+name: secret-operator.v26.7.0
+package: stackable-secret-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-secret-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Secret Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/secret-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is a Kubernetes operator to provide secret functionality to other Stackable operators. The Stackable Secret Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/secret-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Secret Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - secret
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/secret-operator@sha256:ccdad5309978a1c890badf85313f398ae35dccef02a7ff5aa4fc6211246df8a9
+  name: secret-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a
   name: ""
 schema: olm.bundle

--- a/operators/stackable-secret-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-secret-operator/catalog-templates/v4.18.yaml
@@ -30,6 +30,8 @@ entries:
     replaces: secret-operator.v25.7.0
   - name: secret-operator.v26.3.0
     replaces: secret-operator.v25.11.0
+  - name: secret-operator.v26.7.0
+    replaces: secret-operator.v26.3.0
   name: stable
   package: stackable-secret-operator
   schema: olm.channel
@@ -39,10 +41,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:ac78409c6d7a2510f7381a6cd75e4538a31ec9e99612190e9f123978bce74b5a # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: secret-operator.v26.7.0
+  name: '26.7'
+  package: stackable-secret-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:9e7955fccd149247741beb9eb6d30f519f262a847a8ba8310c8863a334cd4fee # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-secret-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-secret-operator/catalog-templates/v4.19.yaml
@@ -30,6 +30,8 @@ entries:
     replaces: secret-operator.v25.7.0
   - name: secret-operator.v26.3.0
     replaces: secret-operator.v25.11.0
+  - name: secret-operator.v26.7.0
+    replaces: secret-operator.v26.3.0
   name: stable
   package: stackable-secret-operator
   schema: olm.channel
@@ -39,10 +41,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:ac78409c6d7a2510f7381a6cd75e4538a31ec9e99612190e9f123978bce74b5a # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: secret-operator.v26.7.0
+  name: '26.7'
+  package: stackable-secret-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:9e7955fccd149247741beb9eb6d30f519f262a847a8ba8310c8863a334cd4fee # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-secret-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-secret-operator/catalog-templates/v4.20.yaml
@@ -20,7 +20,14 @@ entries:
   - name: secret-operator.v25.11.0
   - name: secret-operator.v26.3.0
     replaces: secret-operator.v25.11.0
+  - name: secret-operator.v26.7.0
+    replaces: secret-operator.v26.3.0
   name: stable
+  package: stackable-secret-operator
+  schema: olm.channel
+- entries:
+  - name: secret-operator.v26.7.0
+  name: '26.7'
   package: stackable-secret-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/secret-operator@sha256:49157ad3cf2431a1806bc485f06d098a20c0b5231f2ac480db5818ea45c1ba0b # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/secret-operator@sha256:05a97641998db9a039ba56a5ead23b68fdc997cb240893c1821a5fcd98d9456a # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-secret-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `secret-operator.v26.7.0`
- `stable` extended with `secret-operator.v26.7.0` replacing `secret-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.