### PR TITLE
Catalog update [stackable-listener-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-listener-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-listener-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-listener-operator
 schema: olm.channel
 ---
 entries:
+- name: listener-operator.v26.7.0
+name: "26.7"
+package: stackable-listener-operator
+schema: olm.channel
+---
+entries:
 - name: listener-operator.v25.3.0
 - name: listener-operator.v25.7.0
   replaces: listener-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: listener-operator.v25.7.0
 - name: listener-operator.v26.3.0
   replaces: listener-operator.v25.11.0
+- name: listener-operator.v26.7.0
+  replaces: listener-operator.v26.3.0
 name: stable
 package: stackable-listener-operator
 schema: olm.channel
@@ -425,5 +433,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
+name: listener-operator.v26.7.0
+package: stackable-listener-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-listener-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Listener Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/listener-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is an operator for Kubernetes that provisions network listeners according to the cluster policy, and injects connection parameters into Pods. The Stackable Listener Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/listener-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Listener Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - listener
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/listener-operator@sha256:405dcb901212f9a74236a088c210f6e91e1ff69ffc800e27f5b60ece63a4562d
+  name: listener-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-listener-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-listener-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-listener-operator
 schema: olm.channel
 ---
 entries:
+- name: listener-operator.v26.7.0
+name: "26.7"
+package: stackable-listener-operator
+schema: olm.channel
+---
+entries:
 - name: listener-operator.v25.3.0
 - name: listener-operator.v25.7.0
   replaces: listener-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: listener-operator.v25.7.0
 - name: listener-operator.v26.3.0
   replaces: listener-operator.v25.11.0
+- name: listener-operator.v26.7.0
+  replaces: listener-operator.v26.3.0
 name: stable
 package: stackable-listener-operator
 schema: olm.channel
@@ -425,5 +433,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
+name: listener-operator.v26.7.0
+package: stackable-listener-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-listener-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Listener Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/listener-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is an operator for Kubernetes that provisions network listeners according to the cluster policy, and injects connection parameters into Pods. The Stackable Listener Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/listener-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Listener Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - listener
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/listener-operator@sha256:405dcb901212f9a74236a088c210f6e91e1ff69ffc800e27f5b60ece63a4562d
+  name: listener-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-listener-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-listener-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-listener-operator
 schema: olm.channel
 ---
 entries:
+- name: listener-operator.v26.7.0
+name: "26.7"
+package: stackable-listener-operator
+schema: olm.channel
+---
+entries:
 - name: listener-operator.v25.11.0
 - name: listener-operator.v26.3.0
   replaces: listener-operator.v25.11.0
+- name: listener-operator.v26.7.0
+  replaces: listener-operator.v26.3.0
 name: stable
 package: stackable-listener-operator
 schema: olm.channel
@@ -199,5 +207,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
+name: listener-operator.v26.7.0
+package: stackable-listener-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-listener-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Listener Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/listener-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is an operator for Kubernetes that provisions network listeners according to the cluster policy, and injects connection parameters into Pods. The Stackable Listener Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/listener-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Listener Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - listener
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/listener-operator@sha256:405dcb901212f9a74236a088c210f6e91e1ff69ffc800e27f5b60ece63a4562d
+  name: listener-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-listener-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-listener-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-listener-operator
 schema: olm.channel
 ---
 entries:
+- name: listener-operator.v26.7.0
+name: "26.7"
+package: stackable-listener-operator
+schema: olm.channel
+---
+entries:
 - name: listener-operator.v25.11.0
 - name: listener-operator.v26.3.0
   replaces: listener-operator.v25.11.0
+- name: listener-operator.v26.7.0
+  replaces: listener-operator.v26.3.0
 name: stable
 package: stackable-listener-operator
 schema: olm.channel
@@ -199,5 +207,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
+name: listener-operator.v26.7.0
+package: stackable-listener-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-listener-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Listener Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/listener-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is an operator for Kubernetes that provisions network listeners according to the cluster policy, and injects connection parameters into Pods. The Stackable Listener Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/listener-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Listener Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - listener
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/listener-operator@sha256:405dcb901212f9a74236a088c210f6e91e1ff69ffc800e27f5b60ece63a4562d
+  name: listener-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-listener-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-listener-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-listener-operator
 schema: olm.channel
 ---
 entries:
+- name: listener-operator.v26.7.0
+name: "26.7"
+package: stackable-listener-operator
+schema: olm.channel
+---
+entries:
 - name: listener-operator.v25.11.0
 - name: listener-operator.v26.3.0
   replaces: listener-operator.v25.11.0
+- name: listener-operator.v26.7.0
+  replaces: listener-operator.v26.3.0
 name: stable
 package: stackable-listener-operator
 schema: olm.channel
@@ -199,5 +207,77 @@ relatedImages:
 - image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
   name: csi-provisioner
 - image: registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
+name: listener-operator.v26.7.0
+package: stackable-listener-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-listener-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      com.redhat.openshift.versions: v4.18-v4.22
+      description: Stackable Listener Operator
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/listener-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |-
+      This is an operator for Kubernetes that provisions network listeners according to the cluster policy, and injects connection parameters into Pods. The Stackable Listener Operator is part of the Stackable Data Platform, a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere - on prem or in the cloud.
+
+      You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/listener-operator/installation.html).
+
+      NOTE:
+      Make sure you install this operator in a namespace called "stackable-operators". Failing to do so will result in a broken installation.
+    displayName: Stackable Listener Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - listener
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.31.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/listener-operator@sha256:405dcb901212f9a74236a088c210f6e91e1ff69ffc800e27f5b60ece63a4562d
+  name: listener-operator
+- image: quay.io/stackable/sig-storage/csi-node-driver-registrar@sha256:ab4a3289015f7de39c4dc987fa6183bcb157294a841c88fa842332ce66b068d8
+  name: csi-node-driver-registrar
+- image: quay.io/stackable/sig-storage/csi-provisioner@sha256:142e0b069dcc100671c91d66d8c973d56ea330b4e11ab79e5eb4fea5c79c6ecb
+  name: csi-provisioner
+- image: registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec
   name: ""
 schema: olm.bundle

--- a/operators/stackable-listener-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-listener-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: listener-operator.v25.7.0
   - name: listener-operator.v26.3.0
     replaces: listener-operator.v25.11.0
+  - name: listener-operator.v26.7.0
+    replaces: listener-operator.v26.3.0
   name: stable
   package: stackable-listener-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:2d184d2d61aca2b5c17e471f02b732069dd58518d3a3f675da5ecb695cefde0b # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: listener-operator.v26.7.0
+  name: '26.7'
+  package: stackable-listener-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:f775b29c3ea2c4d0d8f1a140e3827400c1eeeb9874cd0e0dbf50987fb41cc5c1 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-listener-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-listener-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: listener-operator.v25.7.0
   - name: listener-operator.v26.3.0
     replaces: listener-operator.v25.11.0
+  - name: listener-operator.v26.7.0
+    replaces: listener-operator.v26.3.0
   name: stable
   package: stackable-listener-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:2d184d2d61aca2b5c17e471f02b732069dd58518d3a3f675da5ecb695cefde0b # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: listener-operator.v26.7.0
+  name: '26.7'
+  package: stackable-listener-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:f775b29c3ea2c4d0d8f1a140e3827400c1eeeb9874cd0e0dbf50987fb41cc5c1 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-listener-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-listener-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: listener-operator.v25.11.0
   - name: listener-operator.v26.3.0
     replaces: listener-operator.v25.11.0
+  - name: listener-operator.v26.7.0
+    replaces: listener-operator.v26.3.0
   name: stable
+  package: stackable-listener-operator
+  schema: olm.channel
+- entries:
+  - name: listener-operator.v26.7.0
+  name: '26.7'
   package: stackable-listener-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/listener-operator@sha256:d51ea750e8b299daed14388cee3ebdeb159304207be15241e7a3a21e1224c2ed # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/listener-operator@sha256:7046fc31a18f03aa6fb3c92fd1e5b9f356613fd1d67b1ac0188d3a1bc750c9ec # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-listener-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `listener-operator.v26.7.0`
- `stable` extended with `listener-operator.v26.7.0` replacing `listener-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.