### PR TITLE
Catalog update [stackable-hdfs-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-hdfs-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-hdfs-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-hdfs-operator
 schema: olm.channel
 ---
 entries:
+- name: hdfs-operator.v26.7.0
+name: "26.7"
+package: stackable-hdfs-operator
+schema: olm.channel
+---
+entries:
 - name: hdfs-operator.v25.3.0
 - name: hdfs-operator.v25.7.0
   replaces: hdfs-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: hdfs-operator.v25.7.0
 - name: hdfs-operator.v26.3.0
   replaces: hdfs-operator.v25.11.0
+- name: hdfs-operator.v26.7.0
+  replaces: hdfs-operator.v26.3.0
 name: stable
 package: stackable-hdfs-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/hdfs-operator@sha256:2076f8e81b2f495a4ee783497a96067953db37b6f061ef58e69834566df474a5
   name: hdfs-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
+name: hdfs-operator.v26.7.0
+package: stackable-hdfs-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hdfs-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+      description: Stackable Operator for Apache Hadoop HDFS
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hdfs-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hadoop HDFS
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hdfs
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+  name: hdfs-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-hdfs-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-hdfs-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-hdfs-operator
 schema: olm.channel
 ---
 entries:
+- name: hdfs-operator.v26.7.0
+name: "26.7"
+package: stackable-hdfs-operator
+schema: olm.channel
+---
+entries:
 - name: hdfs-operator.v25.3.0
 - name: hdfs-operator.v25.7.0
   replaces: hdfs-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: hdfs-operator.v25.7.0
 - name: hdfs-operator.v26.3.0
   replaces: hdfs-operator.v25.11.0
+- name: hdfs-operator.v26.7.0
+  replaces: hdfs-operator.v26.3.0
 name: stable
 package: stackable-hdfs-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/hdfs-operator@sha256:2076f8e81b2f495a4ee783497a96067953db37b6f061ef58e69834566df474a5
   name: hdfs-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
+name: hdfs-operator.v26.7.0
+package: stackable-hdfs-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hdfs-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+      description: Stackable Operator for Apache Hadoop HDFS
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hdfs-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hadoop HDFS
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hdfs
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+  name: hdfs-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-hdfs-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-hdfs-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hdfs-operator
 schema: olm.channel
 ---
 entries:
+- name: hdfs-operator.v26.7.0
+name: "26.7"
+package: stackable-hdfs-operator
+schema: olm.channel
+---
+entries:
 - name: hdfs-operator.v25.11.0
 - name: hdfs-operator.v26.3.0
   replaces: hdfs-operator.v25.11.0
+- name: hdfs-operator.v26.7.0
+  replaces: hdfs-operator.v26.3.0
 name: stable
 package: stackable-hdfs-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hdfs-operator@sha256:2076f8e81b2f495a4ee783497a96067953db37b6f061ef58e69834566df474a5
   name: hdfs-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
+name: hdfs-operator.v26.7.0
+package: stackable-hdfs-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hdfs-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+      description: Stackable Operator for Apache Hadoop HDFS
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hdfs-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hadoop HDFS
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hdfs
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+  name: hdfs-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-hdfs-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-hdfs-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hdfs-operator
 schema: olm.channel
 ---
 entries:
+- name: hdfs-operator.v26.7.0
+name: "26.7"
+package: stackable-hdfs-operator
+schema: olm.channel
+---
+entries:
 - name: hdfs-operator.v25.11.0
 - name: hdfs-operator.v26.3.0
   replaces: hdfs-operator.v25.11.0
+- name: hdfs-operator.v26.7.0
+  replaces: hdfs-operator.v26.3.0
 name: stable
 package: stackable-hdfs-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hdfs-operator@sha256:2076f8e81b2f495a4ee783497a96067953db37b6f061ef58e69834566df474a5
   name: hdfs-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
+name: hdfs-operator.v26.7.0
+package: stackable-hdfs-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hdfs-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+      description: Stackable Operator for Apache Hadoop HDFS
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hdfs-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hadoop HDFS
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hdfs
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+  name: hdfs-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-hdfs-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-hdfs-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hdfs-operator
 schema: olm.channel
 ---
 entries:
+- name: hdfs-operator.v26.7.0
+name: "26.7"
+package: stackable-hdfs-operator
+schema: olm.channel
+---
+entries:
 - name: hdfs-operator.v25.11.0
 - name: hdfs-operator.v26.3.0
   replaces: hdfs-operator.v25.11.0
+- name: hdfs-operator.v26.7.0
+  replaces: hdfs-operator.v26.3.0
 name: stable
 package: stackable-hdfs-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hdfs-operator@sha256:2076f8e81b2f495a4ee783497a96067953db37b6f061ef58e69834566df474a5
   name: hdfs-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
+name: hdfs-operator.v26.7.0
+package: stackable-hdfs-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hdfs-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+      description: Stackable Operator for Apache Hadoop HDFS
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hdfs-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hadoop HDFS
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hdfs
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hdfs-operator@sha256:221e2ae7077f98a148b677a51d04bd956a61e5745a5cc8c8a1cd1239a9cca1e8
+  name: hdfs-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338
   name: ""
 schema: olm.bundle

--- a/operators/stackable-hdfs-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-hdfs-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: hdfs-operator.v25.7.0
   - name: hdfs-operator.v26.3.0
     replaces: hdfs-operator.v25.11.0
+  - name: hdfs-operator.v26.7.0
+    replaces: hdfs-operator.v26.3.0
   name: stable
   package: stackable-hdfs-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:225c5e8029cb7a131e30dd108a4c0dd3800372d4964163a7b1043cfcae4213e8 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: hdfs-operator.v26.7.0
+  name: '26.7'
+  package: stackable-hdfs-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:393a2f034c0dc1ebf71b87caf58108c974d310fd4bb4526d3114271967465f77 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-hdfs-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-hdfs-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: hdfs-operator.v25.7.0
   - name: hdfs-operator.v26.3.0
     replaces: hdfs-operator.v25.11.0
+  - name: hdfs-operator.v26.7.0
+    replaces: hdfs-operator.v26.3.0
   name: stable
   package: stackable-hdfs-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:225c5e8029cb7a131e30dd108a4c0dd3800372d4964163a7b1043cfcae4213e8 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: hdfs-operator.v26.7.0
+  name: '26.7'
+  package: stackable-hdfs-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:393a2f034c0dc1ebf71b87caf58108c974d310fd4bb4526d3114271967465f77 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-hdfs-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-hdfs-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: hdfs-operator.v25.11.0
   - name: hdfs-operator.v26.3.0
     replaces: hdfs-operator.v25.11.0
+  - name: hdfs-operator.v26.7.0
+    replaces: hdfs-operator.v26.3.0
   name: stable
+  package: stackable-hdfs-operator
+  schema: olm.channel
+- entries:
+  - name: hdfs-operator.v26.7.0
+  name: '26.7'
   package: stackable-hdfs-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:4d88d8416576d80118e04c86e7aef0f5ec9e5db99c139ab7ef6903364f823347 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-hdfs-operator@sha256:561a952ea3aa9bb7df0547d0fdb6502774525f1b7a3760af46187bbe12ea8338 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-hdfs-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `hdfs-operator.v26.7.0`
- `stable` extended with `hdfs-operator.v26.7.0` replacing `hdfs-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.