### PR TITLE
Catalog update [stackable-hive-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-hive-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-hive-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-hive-operator
 schema: olm.channel
 ---
 entries:
+- name: hive-operator.v26.7.0
+name: "26.7"
+package: stackable-hive-operator
+schema: olm.channel
+---
+entries:
 - name: hive-operator.v25.3.0
 - name: hive-operator.v25.7.0
   replaces: hive-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: hive-operator.v25.7.0
 - name: hive-operator.v26.3.0
   replaces: hive-operator.v25.11.0
+- name: hive-operator.v26.7.0
+  replaces: hive-operator.v26.3.0
 name: stable
 package: stackable-hive-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/hive-operator@sha256:2c084dea46073e01800656b581d75160c56577ddf62786097c28c9610dd88e0c
   name: hive-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
+name: hive-operator.v26.7.0
+package: stackable-hive-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hive-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+      description: Stackable Operator for Apache Hive
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hive-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hive
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hive
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+  name: hive-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-hive-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-hive-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-hive-operator
 schema: olm.channel
 ---
 entries:
+- name: hive-operator.v26.7.0
+name: "26.7"
+package: stackable-hive-operator
+schema: olm.channel
+---
+entries:
 - name: hive-operator.v25.3.0
 - name: hive-operator.v25.7.0
   replaces: hive-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: hive-operator.v25.7.0
 - name: hive-operator.v26.3.0
   replaces: hive-operator.v25.11.0
+- name: hive-operator.v26.7.0
+  replaces: hive-operator.v26.3.0
 name: stable
 package: stackable-hive-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/hive-operator@sha256:2c084dea46073e01800656b581d75160c56577ddf62786097c28c9610dd88e0c
   name: hive-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
+name: hive-operator.v26.7.0
+package: stackable-hive-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hive-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+      description: Stackable Operator for Apache Hive
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hive-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hive
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hive
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+  name: hive-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-hive-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-hive-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hive-operator
 schema: olm.channel
 ---
 entries:
+- name: hive-operator.v26.7.0
+name: "26.7"
+package: stackable-hive-operator
+schema: olm.channel
+---
+entries:
 - name: hive-operator.v25.11.0
 - name: hive-operator.v26.3.0
   replaces: hive-operator.v25.11.0
+- name: hive-operator.v26.7.0
+  replaces: hive-operator.v26.3.0
 name: stable
 package: stackable-hive-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hive-operator@sha256:2c084dea46073e01800656b581d75160c56577ddf62786097c28c9610dd88e0c
   name: hive-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
+name: hive-operator.v26.7.0
+package: stackable-hive-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hive-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+      description: Stackable Operator for Apache Hive
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hive-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hive
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hive
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+  name: hive-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-hive-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-hive-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hive-operator
 schema: olm.channel
 ---
 entries:
+- name: hive-operator.v26.7.0
+name: "26.7"
+package: stackable-hive-operator
+schema: olm.channel
+---
+entries:
 - name: hive-operator.v25.11.0
 - name: hive-operator.v26.3.0
   replaces: hive-operator.v25.11.0
+- name: hive-operator.v26.7.0
+  replaces: hive-operator.v26.3.0
 name: stable
 package: stackable-hive-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hive-operator@sha256:2c084dea46073e01800656b581d75160c56577ddf62786097c28c9610dd88e0c
   name: hive-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
+name: hive-operator.v26.7.0
+package: stackable-hive-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hive-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+      description: Stackable Operator for Apache Hive
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hive-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hive
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hive
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+  name: hive-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-hive-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-hive-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hive-operator
 schema: olm.channel
 ---
 entries:
+- name: hive-operator.v26.7.0
+name: "26.7"
+package: stackable-hive-operator
+schema: olm.channel
+---
+entries:
 - name: hive-operator.v25.11.0
 - name: hive-operator.v26.3.0
   replaces: hive-operator.v25.11.0
+- name: hive-operator.v26.7.0
+  replaces: hive-operator.v26.3.0
 name: stable
 package: stackable-hive-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hive-operator@sha256:2c084dea46073e01800656b581d75160c56577ddf62786097c28c9610dd88e0c
   name: hive-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
+name: hive-operator.v26.7.0
+package: stackable-hive-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hive-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+      description: Stackable Operator for Apache Hive
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hive-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Hive
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hive
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hive-operator@sha256:826cce877243759b477881e96576ca6fddce607b690eb6c10a2d5b692963342c
+  name: hive-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29
   name: ""
 schema: olm.bundle

--- a/operators/stackable-hive-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-hive-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: hive-operator.v25.7.0
   - name: hive-operator.v26.3.0
     replaces: hive-operator.v25.11.0
+  - name: hive-operator.v26.7.0
+    replaces: hive-operator.v26.3.0
   name: stable
   package: stackable-hive-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:49575f91d7c39ccbbecf2d66ea5a2e6a0ab40267aefb489330b7806ab6c9fb50 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: hive-operator.v26.7.0
+  name: '26.7'
+  package: stackable-hive-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:e5e7f52e18a640ea5a7b11897b9609352c9e7dd1c44ff26d387dae0a2ac4146e # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-hive-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-hive-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: hive-operator.v25.7.0
   - name: hive-operator.v26.3.0
     replaces: hive-operator.v25.11.0
+  - name: hive-operator.v26.7.0
+    replaces: hive-operator.v26.3.0
   name: stable
   package: stackable-hive-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:49575f91d7c39ccbbecf2d66ea5a2e6a0ab40267aefb489330b7806ab6c9fb50 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: hive-operator.v26.7.0
+  name: '26.7'
+  package: stackable-hive-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:e5e7f52e18a640ea5a7b11897b9609352c9e7dd1c44ff26d387dae0a2ac4146e # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-hive-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-hive-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: hive-operator.v25.11.0
   - name: hive-operator.v26.3.0
     replaces: hive-operator.v25.11.0
+  - name: hive-operator.v26.7.0
+    replaces: hive-operator.v26.3.0
   name: stable
+  package: stackable-hive-operator
+  schema: olm.channel
+- entries:
+  - name: hive-operator.v26.7.0
+  name: '26.7'
   package: stackable-hive-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:0ab1d9ca8b88b744115ec1bf6c1367e45b7d49b650a9621af94cfac90f894074 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-hive-operator@sha256:c3aeb9260a77554e42855e2406ed739880f74c2033bb8bc2085bcbb8654cbf29 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-hive-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `hive-operator.v26.7.0`
- `stable` extended with `hive-operator.v26.7.0` replacing `hive-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.