### PR TITLE
Catalog update [stackable-hbase-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-hbase-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-hbase-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-hbase-operator
 schema: olm.channel
 ---
 entries:
+- name: hbase-operator.v26.7.0
+name: "26.7"
+package: stackable-hbase-operator
+schema: olm.channel
+---
+entries:
 - name: hbase-operator.v25.3.0
 - name: hbase-operator.v25.7.0
   replaces: hbase-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: hbase-operator.v25.7.0
 - name: hbase-operator.v26.3.0
   replaces: hbase-operator.v25.11.0
+- name: hbase-operator.v26.7.0
+  replaces: hbase-operator.v26.3.0
 name: stable
 package: stackable-hbase-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/hbase-operator@sha256:34782d12906338988f09e51e5167c1d775aa1318597862371931de5d856d4032
   name: hbase-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
+name: hbase-operator.v26.7.0
+package: stackable-hbase-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hbase-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+      description: Stackable Operator for Apache HBase
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hbase-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache HBase
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hbase
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+  name: hbase-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-hbase-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-hbase-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-hbase-operator
 schema: olm.channel
 ---
 entries:
+- name: hbase-operator.v26.7.0
+name: "26.7"
+package: stackable-hbase-operator
+schema: olm.channel
+---
+entries:
 - name: hbase-operator.v25.3.0
 - name: hbase-operator.v25.7.0
   replaces: hbase-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: hbase-operator.v25.7.0
 - name: hbase-operator.v26.3.0
   replaces: hbase-operator.v25.11.0
+- name: hbase-operator.v26.7.0
+  replaces: hbase-operator.v26.3.0
 name: stable
 package: stackable-hbase-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/hbase-operator@sha256:34782d12906338988f09e51e5167c1d775aa1318597862371931de5d856d4032
   name: hbase-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
+name: hbase-operator.v26.7.0
+package: stackable-hbase-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hbase-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+      description: Stackable Operator for Apache HBase
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hbase-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache HBase
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hbase
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+  name: hbase-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-hbase-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-hbase-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hbase-operator
 schema: olm.channel
 ---
 entries:
+- name: hbase-operator.v26.7.0
+name: "26.7"
+package: stackable-hbase-operator
+schema: olm.channel
+---
+entries:
 - name: hbase-operator.v25.11.0
 - name: hbase-operator.v26.3.0
   replaces: hbase-operator.v25.11.0
+- name: hbase-operator.v26.7.0
+  replaces: hbase-operator.v26.3.0
 name: stable
 package: stackable-hbase-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hbase-operator@sha256:34782d12906338988f09e51e5167c1d775aa1318597862371931de5d856d4032
   name: hbase-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
+name: hbase-operator.v26.7.0
+package: stackable-hbase-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hbase-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+      description: Stackable Operator for Apache HBase
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hbase-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache HBase
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hbase
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+  name: hbase-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-hbase-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-hbase-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hbase-operator
 schema: olm.channel
 ---
 entries:
+- name: hbase-operator.v26.7.0
+name: "26.7"
+package: stackable-hbase-operator
+schema: olm.channel
+---
+entries:
 - name: hbase-operator.v25.11.0
 - name: hbase-operator.v26.3.0
   replaces: hbase-operator.v25.11.0
+- name: hbase-operator.v26.7.0
+  replaces: hbase-operator.v26.3.0
 name: stable
 package: stackable-hbase-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hbase-operator@sha256:34782d12906338988f09e51e5167c1d775aa1318597862371931de5d856d4032
   name: hbase-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
+name: hbase-operator.v26.7.0
+package: stackable-hbase-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hbase-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+      description: Stackable Operator for Apache HBase
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hbase-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache HBase
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hbase
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+  name: hbase-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-hbase-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-hbase-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-hbase-operator
 schema: olm.channel
 ---
 entries:
+- name: hbase-operator.v26.7.0
+name: "26.7"
+package: stackable-hbase-operator
+schema: olm.channel
+---
+entries:
 - name: hbase-operator.v25.11.0
 - name: hbase-operator.v26.3.0
   replaces: hbase-operator.v25.11.0
+- name: hbase-operator.v26.7.0
+  replaces: hbase-operator.v26.3.0
 name: stable
 package: stackable-hbase-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/hbase-operator@sha256:34782d12906338988f09e51e5167c1d775aa1318597862371931de5d856d4032
   name: hbase-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
+name: hbase-operator.v26.7.0
+package: stackable-hbase-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-hbase-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+      description: Stackable Operator for Apache HBase
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/hbase-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache HBase
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - hbase
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/hbase-operator@sha256:f74d2f5b08d20db6c1c2f9db6286e911222296c8ff00503721e37d78b81a905c
+  name: hbase-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691
   name: ""
 schema: olm.bundle

--- a/operators/stackable-hbase-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-hbase-operator/catalog-templates/v4.18.yaml
@@ -34,7 +34,14 @@ entries:
     replaces: hbase-operator.v25.7.0
   - name: hbase-operator.v26.3.0
     replaces: hbase-operator.v25.11.0
+  - name: hbase-operator.v26.7.0
+    replaces: hbase-operator.v26.3.0
   name: stable
+  package: stackable-hbase-operator
+  schema: olm.channel
+- entries:
+  - name: hbase-operator.v26.7.0
+  name: '26.7'
   package: stackable-hbase-operator
   schema: olm.channel
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:f6c7b51a74ea8b6a11e26192fc4268df07b855a8423dcd23f199a3d956bc2844 # 25.3.0
@@ -44,5 +51,7 @@ entries:
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:8f95cdb5e48ab98b10a7d5c8e50dbc6d14967b589bf15d94a44701168af69752 # 25.11.0
   schema: olm.bundle
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827 # 26.3.0
+  schema: olm.bundle
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691 # 26.7.0
   schema: olm.bundle
 schema: olm.template.basic

--- a/operators/stackable-hbase-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-hbase-operator/catalog-templates/v4.19.yaml
@@ -34,7 +34,14 @@ entries:
     replaces: hbase-operator.v25.7.0
   - name: hbase-operator.v26.3.0
     replaces: hbase-operator.v25.11.0
+  - name: hbase-operator.v26.7.0
+    replaces: hbase-operator.v26.3.0
   name: stable
+  package: stackable-hbase-operator
+  schema: olm.channel
+- entries:
+  - name: hbase-operator.v26.7.0
+  name: '26.7'
   package: stackable-hbase-operator
   schema: olm.channel
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:f6c7b51a74ea8b6a11e26192fc4268df07b855a8423dcd23f199a3d956bc2844 # 25.3.0
@@ -44,5 +51,7 @@ entries:
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:8f95cdb5e48ab98b10a7d5c8e50dbc6d14967b589bf15d94a44701168af69752 # 25.11.0
   schema: olm.bundle
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827 # 26.3.0
+  schema: olm.bundle
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691 # 26.7.0
   schema: olm.bundle
 schema: olm.template.basic

--- a/operators/stackable-hbase-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-hbase-operator/catalog-templates/v4.20.yaml
@@ -20,11 +20,20 @@ entries:
   - name: hbase-operator.v25.11.0
   - name: hbase-operator.v26.3.0
     replaces: hbase-operator.v25.11.0
+  - name: hbase-operator.v26.7.0
+    replaces: hbase-operator.v26.3.0
   name: stable
+  package: stackable-hbase-operator
+  schema: olm.channel
+- entries:
+  - name: hbase-operator.v26.7.0
+  name: '26.7'
   package: stackable-hbase-operator
   schema: olm.channel
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:8f95cdb5e48ab98b10a7d5c8e50dbc6d14967b589bf15d94a44701168af69752 # 25.11.0
   schema: olm.bundle
 - image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:1ae7cbe9ff0d1d2f0f1e664ed2a8139c274a153b7b201e5e55015c6bcd145827 # 26.3.0
+  schema: olm.bundle
+- image: registry.connect.redhat.com/stackable/stackable-apache-hbase-operator@sha256:b7c571d188f5e59f34139be2a08cd3b6bb298b9adb2dd56aa807904f254f6691 # 26.7.0
   schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-hbase-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `hbase-operator.v26.7.0`
- `stable` extended with `hbase-operator.v26.7.0` replacing `hbase-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.