### PR TITLE
Catalog update [stackable-opa-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-opa-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-opa-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-opa-operator
 schema: olm.channel
 ---
 entries:
+- name: opa-operator.v26.7.0
+name: "26.7"
+package: stackable-opa-operator
+schema: olm.channel
+---
+entries:
 - name: opa-operator.v25.3.0
 - name: opa-operator.v25.7.0
   replaces: opa-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: opa-operator.v25.7.0
 - name: opa-operator.v26.3.0
   replaces: opa-operator.v25.11.0
+- name: opa-operator.v26.7.0
+  replaces: opa-operator.v26.3.0
 name: stable
 package: stackable-opa-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/opa-operator@sha256:196a49259fa1db2b9625f311c1f650c1088f0bd470ba8f33c86b99d44bd1ffb6
   name: opa-operator
 - image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
+name: opa-operator.v26.7.0
+package: stackable-opa-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opa-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+      description: Stackable Operator for the Open Policy Agent
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opa-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for the Open Policy Agent
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opa
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+  name: opa-operator
+- image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-opa-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-opa-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-opa-operator
 schema: olm.channel
 ---
 entries:
+- name: opa-operator.v26.7.0
+name: "26.7"
+package: stackable-opa-operator
+schema: olm.channel
+---
+entries:
 - name: opa-operator.v25.3.0
 - name: opa-operator.v25.7.0
   replaces: opa-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: opa-operator.v25.7.0
 - name: opa-operator.v26.3.0
   replaces: opa-operator.v25.11.0
+- name: opa-operator.v26.7.0
+  replaces: opa-operator.v26.3.0
 name: stable
 package: stackable-opa-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/opa-operator@sha256:196a49259fa1db2b9625f311c1f650c1088f0bd470ba8f33c86b99d44bd1ffb6
   name: opa-operator
 - image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
+name: opa-operator.v26.7.0
+package: stackable-opa-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opa-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+      description: Stackable Operator for the Open Policy Agent
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opa-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for the Open Policy Agent
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opa
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+  name: opa-operator
+- image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-opa-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-opa-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opa-operator
 schema: olm.channel
 ---
 entries:
+- name: opa-operator.v26.7.0
+name: "26.7"
+package: stackable-opa-operator
+schema: olm.channel
+---
+entries:
 - name: opa-operator.v25.11.0
 - name: opa-operator.v26.3.0
   replaces: opa-operator.v25.11.0
+- name: opa-operator.v26.7.0
+  replaces: opa-operator.v26.3.0
 name: stable
 package: stackable-opa-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opa-operator@sha256:196a49259fa1db2b9625f311c1f650c1088f0bd470ba8f33c86b99d44bd1ffb6
   name: opa-operator
 - image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
+name: opa-operator.v26.7.0
+package: stackable-opa-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opa-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+      description: Stackable Operator for the Open Policy Agent
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opa-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for the Open Policy Agent
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opa
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+  name: opa-operator
+- image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-opa-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-opa-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opa-operator
 schema: olm.channel
 ---
 entries:
+- name: opa-operator.v26.7.0
+name: "26.7"
+package: stackable-opa-operator
+schema: olm.channel
+---
+entries:
 - name: opa-operator.v25.11.0
 - name: opa-operator.v26.3.0
   replaces: opa-operator.v25.11.0
+- name: opa-operator.v26.7.0
+  replaces: opa-operator.v26.3.0
 name: stable
 package: stackable-opa-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opa-operator@sha256:196a49259fa1db2b9625f311c1f650c1088f0bd470ba8f33c86b99d44bd1ffb6
   name: opa-operator
 - image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
+name: opa-operator.v26.7.0
+package: stackable-opa-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opa-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+      description: Stackable Operator for the Open Policy Agent
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opa-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for the Open Policy Agent
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opa
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+  name: opa-operator
+- image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-opa-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-opa-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opa-operator
 schema: olm.channel
 ---
 entries:
+- name: opa-operator.v26.7.0
+name: "26.7"
+package: stackable-opa-operator
+schema: olm.channel
+---
+entries:
 - name: opa-operator.v25.11.0
 - name: opa-operator.v26.3.0
   replaces: opa-operator.v25.11.0
+- name: opa-operator.v26.7.0
+  replaces: opa-operator.v26.3.0
 name: stable
 package: stackable-opa-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opa-operator@sha256:196a49259fa1db2b9625f311c1f650c1088f0bd470ba8f33c86b99d44bd1ffb6
   name: opa-operator
 - image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
+name: opa-operator.v26.7.0
+package: stackable-opa-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opa-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+      description: Stackable Operator for the Open Policy Agent
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opa-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for the Open Policy Agent
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opa
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opa-operator@sha256:42cce9d0dc5ad794ff1dd7079026a13a90a7b1b42830b897f8b3195a56ab9b76
+  name: opa-operator
+- image: registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736
   name: ""
 schema: olm.bundle

--- a/operators/stackable-opa-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-opa-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: opa-operator.v25.7.0
   - name: opa-operator.v26.3.0
     replaces: opa-operator.v25.11.0
+  - name: opa-operator.v26.7.0
+    replaces: opa-operator.v26.3.0
   name: stable
   package: stackable-opa-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:434d1d26c0267c04b8ebec0d2ee450235ab973dd0183eb84682aa0485e480a18 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: opa-operator.v26.7.0
+  name: '26.7'
+  package: stackable-opa-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:ed811a4798f167a21613371bfc071c9ebde39a1fa2975f113953130a60f1747d # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-opa-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-opa-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: opa-operator.v25.7.0
   - name: opa-operator.v26.3.0
     replaces: opa-operator.v25.11.0
+  - name: opa-operator.v26.7.0
+    replaces: opa-operator.v26.3.0
   name: stable
   package: stackable-opa-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:434d1d26c0267c04b8ebec0d2ee450235ab973dd0183eb84682aa0485e480a18 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: opa-operator.v26.7.0
+  name: '26.7'
+  package: stackable-opa-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:ed811a4798f167a21613371bfc071c9ebde39a1fa2975f113953130a60f1747d # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-opa-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-opa-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: opa-operator.v25.11.0
   - name: opa-operator.v26.3.0
     replaces: opa-operator.v25.11.0
+  - name: opa-operator.v26.7.0
+    replaces: opa-operator.v26.3.0
   name: stable
+  package: stackable-opa-operator
+  schema: olm.channel
+- entries:
+  - name: opa-operator.v26.7.0
+  name: '26.7'
   package: stackable-opa-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:6a5f9783d56ae4dec3ab8f4f074146a448b6ea83576723945172c7601f28a04c # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-opa-operator@sha256:94a9082f33bc8dde8bee3d3a5cdde143e75b586a79460a49c118ddf62cc6e736 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-opa-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `opa-operator.v26.7.0`
- `stable` extended with `opa-operator.v26.7.0` replacing `opa-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.