### PR TITLE
Catalog update [stackable-opensearch-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-opensearch-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-opensearch-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opensearch-operator
 schema: olm.channel
 ---
 entries:
+- name: opensearch-operator.v26.7.0
+name: "26.7"
+package: stackable-opensearch-operator
+schema: olm.channel
+---
+entries:
 - name: opensearch-operator.v25.11.0
 - name: opensearch-operator.v26.3.0
   replaces: opensearch-operator.v25.11.0
+- name: opensearch-operator.v26.7.0
+  replaces: opensearch-operator.v26.3.0
 name: stable
 package: stackable-opensearch-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opensearch-operator@sha256:3a28a7ad2cae8a45da96ec186171088805649b68cd83c53595b3b78e008a8fa7
   name: opensearch-operator
 - image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
+name: opensearch-operator.v26.7.0
+package: stackable-opensearch-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opensearch-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+      description: Stackable Operator for OpenSearch
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opensearch-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for OpenSearch
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opensearch
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+  name: opensearch-operator
+- image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-opensearch-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-opensearch-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opensearch-operator
 schema: olm.channel
 ---
 entries:
+- name: opensearch-operator.v26.7.0
+name: "26.7"
+package: stackable-opensearch-operator
+schema: olm.channel
+---
+entries:
 - name: opensearch-operator.v25.11.0
 - name: opensearch-operator.v26.3.0
   replaces: opensearch-operator.v25.11.0
+- name: opensearch-operator.v26.7.0
+  replaces: opensearch-operator.v26.3.0
 name: stable
 package: stackable-opensearch-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opensearch-operator@sha256:3a28a7ad2cae8a45da96ec186171088805649b68cd83c53595b3b78e008a8fa7
   name: opensearch-operator
 - image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
+name: opensearch-operator.v26.7.0
+package: stackable-opensearch-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opensearch-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+      description: Stackable Operator for OpenSearch
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opensearch-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for OpenSearch
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opensearch
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+  name: opensearch-operator
+- image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-opensearch-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-opensearch-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opensearch-operator
 schema: olm.channel
 ---
 entries:
+- name: opensearch-operator.v26.7.0
+name: "26.7"
+package: stackable-opensearch-operator
+schema: olm.channel
+---
+entries:
 - name: opensearch-operator.v25.11.0
 - name: opensearch-operator.v26.3.0
   replaces: opensearch-operator.v25.11.0
+- name: opensearch-operator.v26.7.0
+  replaces: opensearch-operator.v26.3.0
 name: stable
 package: stackable-opensearch-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opensearch-operator@sha256:3a28a7ad2cae8a45da96ec186171088805649b68cd83c53595b3b78e008a8fa7
   name: opensearch-operator
 - image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
+name: opensearch-operator.v26.7.0
+package: stackable-opensearch-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opensearch-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+      description: Stackable Operator for OpenSearch
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opensearch-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for OpenSearch
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opensearch
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+  name: opensearch-operator
+- image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-opensearch-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-opensearch-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opensearch-operator
 schema: olm.channel
 ---
 entries:
+- name: opensearch-operator.v26.7.0
+name: "26.7"
+package: stackable-opensearch-operator
+schema: olm.channel
+---
+entries:
 - name: opensearch-operator.v25.11.0
 - name: opensearch-operator.v26.3.0
   replaces: opensearch-operator.v25.11.0
+- name: opensearch-operator.v26.7.0
+  replaces: opensearch-operator.v26.3.0
 name: stable
 package: stackable-opensearch-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opensearch-operator@sha256:3a28a7ad2cae8a45da96ec186171088805649b68cd83c53595b3b78e008a8fa7
   name: opensearch-operator
 - image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
+name: opensearch-operator.v26.7.0
+package: stackable-opensearch-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opensearch-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+      description: Stackable Operator for OpenSearch
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opensearch-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for OpenSearch
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opensearch
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+  name: opensearch-operator
+- image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-opensearch-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-opensearch-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-opensearch-operator
 schema: olm.channel
 ---
 entries:
+- name: opensearch-operator.v26.7.0
+name: "26.7"
+package: stackable-opensearch-operator
+schema: olm.channel
+---
+entries:
 - name: opensearch-operator.v25.11.0
 - name: opensearch-operator.v26.3.0
   replaces: opensearch-operator.v25.11.0
+- name: opensearch-operator.v26.7.0
+  replaces: opensearch-operator.v26.3.0
 name: stable
 package: stackable-opensearch-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/opensearch-operator@sha256:3a28a7ad2cae8a45da96ec186171088805649b68cd83c53595b3b78e008a8fa7
   name: opensearch-operator
 - image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
+name: opensearch-operator.v26.7.0
+package: stackable-opensearch-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-opensearch-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+      description: Stackable Operator for OpenSearch
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/opensearch-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for OpenSearch
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - opensearch
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/opensearch-operator@sha256:1d8a1b468e98db25d27a5b0782bec30a946cbf686d80542cb1f3124a3e51e712
+  name: opensearch-operator
+- image: registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02
   name: ""
 schema: olm.bundle

--- a/operators/stackable-opensearch-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-opensearch-operator/catalog-templates/v4.18.yaml
@@ -20,7 +20,14 @@ entries:
   - name: opensearch-operator.v25.11.0
   - name: opensearch-operator.v26.3.0
     replaces: opensearch-operator.v25.11.0
+  - name: opensearch-operator.v26.7.0
+    replaces: opensearch-operator.v26.3.0
   name: stable
+  package: stackable-opensearch-operator
+  schema: olm.channel
+- entries:
+  - name: opensearch-operator.v26.7.0
+  name: '26.7'
   package: stackable-opensearch-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-opensearch-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-opensearch-operator/catalog-templates/v4.19.yaml
@@ -20,7 +20,14 @@ entries:
   - name: opensearch-operator.v25.11.0
   - name: opensearch-operator.v26.3.0
     replaces: opensearch-operator.v25.11.0
+  - name: opensearch-operator.v26.7.0
+    replaces: opensearch-operator.v26.3.0
   name: stable
+  package: stackable-opensearch-operator
+  schema: olm.channel
+- entries:
+  - name: opensearch-operator.v26.7.0
+  name: '26.7'
   package: stackable-opensearch-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-opensearch-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-opensearch-operator/catalog-templates/v4.20.yaml
@@ -20,7 +20,14 @@ entries:
   - name: opensearch-operator.v25.11.0
   - name: opensearch-operator.v26.3.0
     replaces: opensearch-operator.v25.11.0
+  - name: opensearch-operator.v26.7.0
+    replaces: opensearch-operator.v26.3.0
   name: stable
+  package: stackable-opensearch-operator
+  schema: olm.channel
+- entries:
+  - name: opensearch-operator.v26.7.0
+  name: '26.7'
   package: stackable-opensearch-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:ae82752c3d36142003884af4bf992d67dbd539b3ae902b07db6d6329dc23a7fb # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-opensearch-operator@sha256:3eab0d5932c1926a3b9345876f89cad843c4b2e35cb3fe15f070164b8b10cc02 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-opensearch-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `opensearch-operator.v26.7.0`
- `stable` extended with `opensearch-operator.v26.7.0` replacing `opensearch-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.