### PR TITLE
Catalog update [stackable-druid-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-druid-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-druid-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-druid-operator
 schema: olm.channel
 ---
 entries:
+- name: druid-operator.v26.7.0
+name: "26.7"
+package: stackable-druid-operator
+schema: olm.channel
+---
+entries:
 - name: druid-operator.v25.3.0
 - name: druid-operator.v25.7.0
   replaces: druid-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: druid-operator.v25.7.0
 - name: druid-operator.v26.3.0
   replaces: druid-operator.v25.11.0
+- name: druid-operator.v26.7.0
+  replaces: druid-operator.v26.3.0
 name: stable
 package: stackable-druid-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/druid-operator@sha256:6b935446992ed4de8826f79c704175cac4c250ea0fd2cbfd7b8f27436b43ef0a
   name: druid-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
+name: druid-operator.v26.7.0
+package: stackable-druid-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-druid-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+      description: Stackable Operator for Apache Druid
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/druid-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Druid
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - druid
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+  name: druid-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-druid-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-druid-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-druid-operator
 schema: olm.channel
 ---
 entries:
+- name: druid-operator.v26.7.0
+name: "26.7"
+package: stackable-druid-operator
+schema: olm.channel
+---
+entries:
 - name: druid-operator.v25.3.0
 - name: druid-operator.v25.7.0
   replaces: druid-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: druid-operator.v25.7.0
 - name: druid-operator.v26.3.0
   replaces: druid-operator.v25.11.0
+- name: druid-operator.v26.7.0
+  replaces: druid-operator.v26.3.0
 name: stable
 package: stackable-druid-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/druid-operator@sha256:6b935446992ed4de8826f79c704175cac4c250ea0fd2cbfd7b8f27436b43ef0a
   name: druid-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
+name: druid-operator.v26.7.0
+package: stackable-druid-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-druid-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+      description: Stackable Operator for Apache Druid
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/druid-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Druid
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - druid
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+  name: druid-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-druid-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-druid-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-druid-operator
 schema: olm.channel
 ---
 entries:
+- name: druid-operator.v26.7.0
+name: "26.7"
+package: stackable-druid-operator
+schema: olm.channel
+---
+entries:
 - name: druid-operator.v25.11.0
 - name: druid-operator.v26.3.0
   replaces: druid-operator.v25.11.0
+- name: druid-operator.v26.7.0
+  replaces: druid-operator.v26.3.0
 name: stable
 package: stackable-druid-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/druid-operator@sha256:6b935446992ed4de8826f79c704175cac4c250ea0fd2cbfd7b8f27436b43ef0a
   name: druid-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
+name: druid-operator.v26.7.0
+package: stackable-druid-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-druid-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+      description: Stackable Operator for Apache Druid
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/druid-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Druid
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - druid
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+  name: druid-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-druid-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-druid-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-druid-operator
 schema: olm.channel
 ---
 entries:
+- name: druid-operator.v26.7.0
+name: "26.7"
+package: stackable-druid-operator
+schema: olm.channel
+---
+entries:
 - name: druid-operator.v25.11.0
 - name: druid-operator.v26.3.0
   replaces: druid-operator.v25.11.0
+- name: druid-operator.v26.7.0
+  replaces: druid-operator.v26.3.0
 name: stable
 package: stackable-druid-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/druid-operator@sha256:6b935446992ed4de8826f79c704175cac4c250ea0fd2cbfd7b8f27436b43ef0a
   name: druid-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
+name: druid-operator.v26.7.0
+package: stackable-druid-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-druid-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+      description: Stackable Operator for Apache Druid
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/druid-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Druid
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - druid
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+  name: druid-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-druid-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-druid-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-druid-operator
 schema: olm.channel
 ---
 entries:
+- name: druid-operator.v26.7.0
+name: "26.7"
+package: stackable-druid-operator
+schema: olm.channel
+---
+entries:
 - name: druid-operator.v25.11.0
 - name: druid-operator.v26.3.0
   replaces: druid-operator.v25.11.0
+- name: druid-operator.v26.7.0
+  replaces: druid-operator.v26.3.0
 name: stable
 package: stackable-druid-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/druid-operator@sha256:6b935446992ed4de8826f79c704175cac4c250ea0fd2cbfd7b8f27436b43ef0a
   name: druid-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
+name: druid-operator.v26.7.0
+package: stackable-druid-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-druid-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+      description: Stackable Operator for Apache Druid
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/druid-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Druid
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - druid
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/druid-operator@sha256:fa9157c669f4de5f515ed6a8b46967d4ca5c5f3255be34af238675decb011abd
+  name: druid-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25
   name: ""
 schema: olm.bundle

--- a/operators/stackable-druid-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-druid-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: druid-operator.v25.7.0
   - name: druid-operator.v26.3.0
     replaces: druid-operator.v25.11.0
+  - name: druid-operator.v26.7.0
+    replaces: druid-operator.v26.3.0
   name: stable
   package: stackable-druid-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:f0bca5f12bf9e0cc1cd3800c2e23afaeb817ab94dcfe6aa10912be245d3ddec0 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: druid-operator.v26.7.0
+  name: '26.7'
+  package: stackable-druid-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:2167a293d682cad01573dbfefb91c0a4cf2feb18566922893d3e1f12dee10854 # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-druid-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-druid-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: druid-operator.v25.7.0
   - name: druid-operator.v26.3.0
     replaces: druid-operator.v25.11.0
+  - name: druid-operator.v26.7.0
+    replaces: druid-operator.v26.3.0
   name: stable
   package: stackable-druid-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:f0bca5f12bf9e0cc1cd3800c2e23afaeb817ab94dcfe6aa10912be245d3ddec0 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: druid-operator.v26.7.0
+  name: '26.7'
+  package: stackable-druid-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:2167a293d682cad01573dbfefb91c0a4cf2feb18566922893d3e1f12dee10854 # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-druid-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-druid-operator/catalog-templates/v4.20.yaml
@@ -20,11 +20,21 @@ entries:
   - name: druid-operator.v25.11.0
   - name: druid-operator.v26.3.0
     replaces: druid-operator.v25.11.0
+  - name: druid-operator.v26.7.0
+    replaces: druid-operator.v26.3.0
   name: stable
+  package: stackable-druid-operator
+  schema: olm.channel
+- entries:
+  - name: druid-operator.v26.7.0
+  name: '26.7'
   package: stackable-druid-operator
   schema: olm.channel
 - schema: olm.bundle
   image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:2167a293d682cad01573dbfefb91c0a4cf2feb18566922893d3e1f12dee10854 # 25.11.0
 - schema: olm.bundle
   image: registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:612888103b50f62fcb1b9513bf85bf2bfc59abb39103db22361ae2a9987cb067 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-druid-operator@sha256:3bcea19d8cf5f1b829482eaa8abfe24f20773fa00dd8b3f072a5efadd81e8d25 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-druid-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `druid-operator.v26.7.0`
- `stable` extended with `druid-operator.v26.7.0` replacing `druid-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.