### PR TITLE
Catalog update [stackable-kafka-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-kafka-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-kafka-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-kafka-operator
 schema: olm.channel
 ---
 entries:
+- name: kafka-operator.v26.7.0
+name: "26.7"
+package: stackable-kafka-operator
+schema: olm.channel
+---
+entries:
 - name: kafka-operator.v25.3.0
 - name: kafka-operator.v25.7.0
   replaces: kafka-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: kafka-operator.v25.7.0
 - name: kafka-operator.v26.3.0
   replaces: kafka-operator.v25.11.0
+- name: kafka-operator.v26.7.0
+  replaces: kafka-operator.v26.3.0
 name: stable
 package: stackable-kafka-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/kafka-operator@sha256:abf5f6951de40e51b5be76788eead2b018569ff1cfe465c8dd21e11e60a4a30c
   name: kafka-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
+name: kafka-operator.v26.7.0
+package: stackable-kafka-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-kafka-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+      description: Stackable Operator for Apache Kafka
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/kafka-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Kafka
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+  name: kafka-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-kafka-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-kafka-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-kafka-operator
 schema: olm.channel
 ---
 entries:
+- name: kafka-operator.v26.7.0
+name: "26.7"
+package: stackable-kafka-operator
+schema: olm.channel
+---
+entries:
 - name: kafka-operator.v25.3.0
 - name: kafka-operator.v25.7.0
   replaces: kafka-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: kafka-operator.v25.7.0
 - name: kafka-operator.v26.3.0
   replaces: kafka-operator.v25.11.0
+- name: kafka-operator.v26.7.0
+  replaces: kafka-operator.v26.3.0
 name: stable
 package: stackable-kafka-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/kafka-operator@sha256:abf5f6951de40e51b5be76788eead2b018569ff1cfe465c8dd21e11e60a4a30c
   name: kafka-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
+name: kafka-operator.v26.7.0
+package: stackable-kafka-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-kafka-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+      description: Stackable Operator for Apache Kafka
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/kafka-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Kafka
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+  name: kafka-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-kafka-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-kafka-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-kafka-operator
 schema: olm.channel
 ---
 entries:
+- name: kafka-operator.v26.7.0
+name: "26.7"
+package: stackable-kafka-operator
+schema: olm.channel
+---
+entries:
 - name: kafka-operator.v25.11.0
 - name: kafka-operator.v26.3.0
   replaces: kafka-operator.v25.11.0
+- name: kafka-operator.v26.7.0
+  replaces: kafka-operator.v26.3.0
 name: stable
 package: stackable-kafka-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/kafka-operator@sha256:abf5f6951de40e51b5be76788eead2b018569ff1cfe465c8dd21e11e60a4a30c
   name: kafka-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
+name: kafka-operator.v26.7.0
+package: stackable-kafka-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-kafka-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+      description: Stackable Operator for Apache Kafka
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/kafka-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Kafka
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+  name: kafka-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-kafka-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-kafka-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-kafka-operator
 schema: olm.channel
 ---
 entries:
+- name: kafka-operator.v26.7.0
+name: "26.7"
+package: stackable-kafka-operator
+schema: olm.channel
+---
+entries:
 - name: kafka-operator.v25.11.0
 - name: kafka-operator.v26.3.0
   replaces: kafka-operator.v25.11.0
+- name: kafka-operator.v26.7.0
+  replaces: kafka-operator.v26.3.0
 name: stable
 package: stackable-kafka-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/kafka-operator@sha256:abf5f6951de40e51b5be76788eead2b018569ff1cfe465c8dd21e11e60a4a30c
   name: kafka-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
+name: kafka-operator.v26.7.0
+package: stackable-kafka-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-kafka-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+      description: Stackable Operator for Apache Kafka
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/kafka-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Kafka
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+  name: kafka-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-kafka-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-kafka-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-kafka-operator
 schema: olm.channel
 ---
 entries:
+- name: kafka-operator.v26.7.0
+name: "26.7"
+package: stackable-kafka-operator
+schema: olm.channel
+---
+entries:
 - name: kafka-operator.v25.11.0
 - name: kafka-operator.v26.3.0
   replaces: kafka-operator.v25.11.0
+- name: kafka-operator.v26.7.0
+  replaces: kafka-operator.v26.3.0
 name: stable
 package: stackable-kafka-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/kafka-operator@sha256:abf5f6951de40e51b5be76788eead2b018569ff1cfe465c8dd21e11e60a4a30c
   name: kafka-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
+name: kafka-operator.v26.7.0
+package: stackable-kafka-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-kafka-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+      description: Stackable Operator for Apache Kafka
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/kafka-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Kafka
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - kafka
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/kafka-operator@sha256:d6229c25f0a99c7ef3adf5f3a91ed530a870ef72a3a378f948c60c71a27f17a1
+  name: kafka-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0
   name: ""
 schema: olm.bundle

--- a/operators/stackable-kafka-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-kafka-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: kafka-operator.v25.7.0
   - name: kafka-operator.v26.3.0
     replaces: kafka-operator.v25.11.0
+  - name: kafka-operator.v26.7.0
+    replaces: kafka-operator.v26.3.0
   name: stable
   package: stackable-kafka-operator
   schema: olm.channel
@@ -44,11 +46,19 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:bc6b416914d7dd066667809358d725ba1d245fe468e77e34fa459c10de2a09a6 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: kafka-operator.v26.7.0
+  name: '26.7'
+  package: stackable-kafka-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:59b651c4353f3908af5feee8f44f66385b20caab983a477087c434244f4f9234 # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0 # 26.7.0
 schema: olm.template.basic
 

--- a/operators/stackable-kafka-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-kafka-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: kafka-operator.v25.7.0
   - name: kafka-operator.v26.3.0
     replaces: kafka-operator.v25.11.0
+  - name: kafka-operator.v26.7.0
+    replaces: kafka-operator.v26.3.0
   name: stable
   package: stackable-kafka-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:bc6b416914d7dd066667809358d725ba1d245fe468e77e34fa459c10de2a09a6 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: kafka-operator.v26.7.0
+  name: '26.7'
+  package: stackable-kafka-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:59b651c4353f3908af5feee8f44f66385b20caab983a477087c434244f4f9234 # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-kafka-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-kafka-operator/catalog-templates/v4.20.yaml
@@ -20,7 +20,14 @@ entries:
   - name: kafka-operator.v25.11.0
   - name: kafka-operator.v26.3.0
     replaces: kafka-operator.v25.11.0
+  - name: kafka-operator.v26.7.0
+    replaces: kafka-operator.v26.3.0
   name: stable
+  package: stackable-kafka-operator
+  schema: olm.channel
+- entries:
+  - name: kafka-operator.v26.7.0
+  name: '26.7'
   package: stackable-kafka-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:cfd0f29381559f07d26498ab150505762ec646424ebbf6644293d82cd7bc7714 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-kafka-operator@sha256:7643d3c128b9494e6835ac55b562e2322e52b4d472edf7bdef0347ff01b1f5a0 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-kafka-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `kafka-operator.v26.7.0`
- `stable` extended with `kafka-operator.v26.7.0` replacing `kafka-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.