### PR TITLE
Catalog update [stackable-nifi-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-nifi-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-nifi-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-nifi-operator
 schema: olm.channel
 ---
 entries:
+- name: nifi-operator.v26.7.0
+name: "26.7"
+package: stackable-nifi-operator
+schema: olm.channel
+---
+entries:
 - name: nifi-operator.v25.3.0
 - name: nifi-operator.v25.7.0
   replaces: nifi-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: nifi-operator.v25.7.0
 - name: nifi-operator.v26.3.0
   replaces: nifi-operator.v25.11.0
+- name: nifi-operator.v26.7.0
+  replaces: nifi-operator.v26.3.0
 name: stable
 package: stackable-nifi-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/nifi-operator@sha256:7614369bad130595c3e19d1a2b7ab5666ac03997ed036306da14e6c99609efca
   name: nifi-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
+name: nifi-operator.v26.7.0
+package: stackable-nifi-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-nifi-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+      description: Stackable Operator for Apache NiFi
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/nifi-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache NiFi
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - nifi
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+  name: nifi-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-nifi-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-nifi-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-nifi-operator
 schema: olm.channel
 ---
 entries:
+- name: nifi-operator.v26.7.0
+name: "26.7"
+package: stackable-nifi-operator
+schema: olm.channel
+---
+entries:
 - name: nifi-operator.v25.3.0
 - name: nifi-operator.v25.7.0
   replaces: nifi-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: nifi-operator.v25.7.0
 - name: nifi-operator.v26.3.0
   replaces: nifi-operator.v25.11.0
+- name: nifi-operator.v26.7.0
+  replaces: nifi-operator.v26.3.0
 name: stable
 package: stackable-nifi-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/nifi-operator@sha256:7614369bad130595c3e19d1a2b7ab5666ac03997ed036306da14e6c99609efca
   name: nifi-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
+name: nifi-operator.v26.7.0
+package: stackable-nifi-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-nifi-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+      description: Stackable Operator for Apache NiFi
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/nifi-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache NiFi
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - nifi
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+  name: nifi-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-nifi-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-nifi-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-nifi-operator
 schema: olm.channel
 ---
 entries:
+- name: nifi-operator.v26.7.0
+name: "26.7"
+package: stackable-nifi-operator
+schema: olm.channel
+---
+entries:
 - name: nifi-operator.v25.11.0
 - name: nifi-operator.v26.3.0
   replaces: nifi-operator.v25.11.0
+- name: nifi-operator.v26.7.0
+  replaces: nifi-operator.v26.3.0
 name: stable
 package: stackable-nifi-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/nifi-operator@sha256:7614369bad130595c3e19d1a2b7ab5666ac03997ed036306da14e6c99609efca
   name: nifi-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
+name: nifi-operator.v26.7.0
+package: stackable-nifi-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-nifi-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+      description: Stackable Operator for Apache NiFi
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/nifi-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache NiFi
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - nifi
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+  name: nifi-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-nifi-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-nifi-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-nifi-operator
 schema: olm.channel
 ---
 entries:
+- name: nifi-operator.v26.7.0
+name: "26.7"
+package: stackable-nifi-operator
+schema: olm.channel
+---
+entries:
 - name: nifi-operator.v25.11.0
 - name: nifi-operator.v26.3.0
   replaces: nifi-operator.v25.11.0
+- name: nifi-operator.v26.7.0
+  replaces: nifi-operator.v26.3.0
 name: stable
 package: stackable-nifi-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/nifi-operator@sha256:7614369bad130595c3e19d1a2b7ab5666ac03997ed036306da14e6c99609efca
   name: nifi-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
+name: nifi-operator.v26.7.0
+package: stackable-nifi-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-nifi-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+      description: Stackable Operator for Apache NiFi
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/nifi-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache NiFi
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - nifi
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+  name: nifi-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-nifi-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-nifi-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-nifi-operator
 schema: olm.channel
 ---
 entries:
+- name: nifi-operator.v26.7.0
+name: "26.7"
+package: stackable-nifi-operator
+schema: olm.channel
+---
+entries:
 - name: nifi-operator.v25.11.0
 - name: nifi-operator.v26.3.0
   replaces: nifi-operator.v25.11.0
+- name: nifi-operator.v26.7.0
+  replaces: nifi-operator.v26.3.0
 name: stable
 package: stackable-nifi-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/nifi-operator@sha256:7614369bad130595c3e19d1a2b7ab5666ac03997ed036306da14e6c99609efca
   name: nifi-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
+name: nifi-operator.v26.7.0
+package: stackable-nifi-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-nifi-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+      description: Stackable Operator for Apache NiFi
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/nifi-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache NiFi
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - nifi
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/nifi-operator@sha256:33a05b17d6a857df7ec566c7b4aba0368c86a24ec8acf09aafb64ec0dcef24cf
+  name: nifi-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288
   name: ""
 schema: olm.bundle

--- a/operators/stackable-nifi-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-nifi-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: nifi-operator.v25.7.0
   - name: nifi-operator.v26.3.0
     replaces: nifi-operator.v25.11.0
+  - name: nifi-operator.v26.7.0
+    replaces: nifi-operator.v26.3.0
   name: stable
   package: stackable-nifi-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:efcce89937bf5ec062f36bdd3a5417b98d6d140c027c2cc615c87fb04f6d1602 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: nifi-operator.v26.7.0
+  name: '26.7'
+  package: stackable-nifi-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:66f83e489da98272e561125e19a92d9b8347fca790e413ca627211a6f487472c # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-nifi-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-nifi-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: nifi-operator.v25.7.0
   - name: nifi-operator.v26.3.0
     replaces: nifi-operator.v25.11.0
+  - name: nifi-operator.v26.7.0
+    replaces: nifi-operator.v26.3.0
   name: stable
   package: stackable-nifi-operator
   schema: olm.channel
@@ -44,11 +46,19 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:efcce89937bf5ec062f36bdd3a5417b98d6d140c027c2cc615c87fb04f6d1602 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: nifi-operator.v26.7.0
+  name: '26.7'
+  package: stackable-nifi-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:66f83e489da98272e561125e19a92d9b8347fca790e413ca627211a6f487472c # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288 # 26.7.0
 schema: olm.template.basic
 

--- a/operators/stackable-nifi-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-nifi-operator/catalog-templates/v4.20.yaml
@@ -20,7 +20,14 @@ entries:
   - name: nifi-operator.v25.11.0
   - name: nifi-operator.v26.3.0
     replaces: nifi-operator.v25.11.0
+  - name: nifi-operator.v26.7.0
+    replaces: nifi-operator.v26.3.0
   name: stable
+  package: stackable-nifi-operator
+  schema: olm.channel
+- entries:
+  - name: nifi-operator.v26.7.0
+  name: '26.7'
   package: stackable-nifi-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:eccc2f7b5a04d4f51d0a1e90a5d04a93fb7b8bb69e9c00b9bccf55c4a320e521 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-nifi-operator@sha256:b5503acd4fe9a325540d3d0fb472214bd469ef0c5f754145e41331d777c8d288 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-nifi-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `nifi-operator.v26.7.0`
- `stable` extended with `nifi-operator.v26.7.0` replacing `nifi-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.