### PR TITLE
Catalog update [stackable-spark-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-spark-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-spark-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-spark-operator
 schema: olm.channel
 ---
 entries:
+- name: spark-operator.v26.7.0
+name: "26.7"
+package: stackable-spark-operator
+schema: olm.channel
+---
+entries:
 - name: spark-operator.v25.3.0
 - name: spark-operator.v25.7.0
   replaces: spark-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: spark-operator.v25.7.0
 - name: spark-operator.v26.3.0
   replaces: spark-operator.v25.11.0
+- name: spark-operator.v26.7.0
+  replaces: spark-operator.v26.3.0
 name: stable
 package: stackable-spark-operator
 schema: olm.channel
@@ -382,5 +390,70 @@ relatedImages:
 - image: quay.io/stackable/spark-k8s-operator@sha256:5d3932531218bb7684141eb4ba6133900a9d52b00bb60493f9378efd470113b6
   name: spark-k8s-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
+name: spark-operator.v26.7.0
+package: stackable-spark-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-spark-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+      description: Stackable Operator for Apache Spark
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/spark-k8s-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Spark
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - spark-k8s
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+  name: spark-k8s-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-spark-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-spark-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-spark-operator
 schema: olm.channel
 ---
 entries:
+- name: spark-operator.v26.7.0
+name: "26.7"
+package: stackable-spark-operator
+schema: olm.channel
+---
+entries:
 - name: spark-operator.v25.3.0
 - name: spark-operator.v25.7.0
   replaces: spark-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: spark-operator.v25.7.0
 - name: spark-operator.v26.3.0
   replaces: spark-operator.v25.11.0
+- name: spark-operator.v26.7.0
+  replaces: spark-operator.v26.3.0
 name: stable
 package: stackable-spark-operator
 schema: olm.channel
@@ -382,5 +390,70 @@ relatedImages:
 - image: quay.io/stackable/spark-k8s-operator@sha256:5d3932531218bb7684141eb4ba6133900a9d52b00bb60493f9378efd470113b6
   name: spark-k8s-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
+name: spark-operator.v26.7.0
+package: stackable-spark-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-spark-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+      description: Stackable Operator for Apache Spark
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/spark-k8s-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Spark
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - spark-k8s
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+  name: spark-k8s-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-spark-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-spark-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-spark-operator
 schema: olm.channel
 ---
 entries:
+- name: spark-operator.v26.7.0
+name: "26.7"
+package: stackable-spark-operator
+schema: olm.channel
+---
+entries:
 - name: spark-operator.v25.11.0
 - name: spark-operator.v26.3.0
   replaces: spark-operator.v25.11.0
+- name: spark-operator.v26.7.0
+  replaces: spark-operator.v26.3.0
 name: stable
 package: stackable-spark-operator
 schema: olm.channel
@@ -184,5 +192,70 @@ relatedImages:
 - image: quay.io/stackable/spark-k8s-operator@sha256:5d3932531218bb7684141eb4ba6133900a9d52b00bb60493f9378efd470113b6
   name: spark-k8s-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
+name: spark-operator.v26.7.0
+package: stackable-spark-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-spark-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+      description: Stackable Operator for Apache Spark
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/spark-k8s-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Spark
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - spark-k8s
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+  name: spark-k8s-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-spark-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-spark-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-spark-operator
 schema: olm.channel
 ---
 entries:
+- name: spark-operator.v26.7.0
+name: "26.7"
+package: stackable-spark-operator
+schema: olm.channel
+---
+entries:
 - name: spark-operator.v25.11.0
 - name: spark-operator.v26.3.0
   replaces: spark-operator.v25.11.0
+- name: spark-operator.v26.7.0
+  replaces: spark-operator.v26.3.0
 name: stable
 package: stackable-spark-operator
 schema: olm.channel
@@ -184,5 +192,70 @@ relatedImages:
 - image: quay.io/stackable/spark-k8s-operator@sha256:5d3932531218bb7684141eb4ba6133900a9d52b00bb60493f9378efd470113b6
   name: spark-k8s-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
+name: spark-operator.v26.7.0
+package: stackable-spark-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-spark-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+      description: Stackable Operator for Apache Spark
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/spark-k8s-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Spark
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - spark-k8s
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+  name: spark-k8s-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-spark-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-spark-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-spark-operator
 schema: olm.channel
 ---
 entries:
+- name: spark-operator.v26.7.0
+name: "26.7"
+package: stackable-spark-operator
+schema: olm.channel
+---
+entries:
 - name: spark-operator.v25.11.0
 - name: spark-operator.v26.3.0
   replaces: spark-operator.v25.11.0
+- name: spark-operator.v26.7.0
+  replaces: spark-operator.v26.3.0
 name: stable
 package: stackable-spark-operator
 schema: olm.channel
@@ -184,5 +192,70 @@ relatedImages:
 - image: quay.io/stackable/spark-k8s-operator@sha256:5d3932531218bb7684141eb4ba6133900a9d52b00bb60493f9378efd470113b6
   name: spark-k8s-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
+name: spark-operator.v26.7.0
+package: stackable-spark-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-spark-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+      description: Stackable Operator for Apache Spark
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/spark-k8s-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Spark
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - spark-k8s
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/spark-k8s-operator@sha256:3166e600771606ef59945c33447d2d1a74da2c4302880678883f3fa5e0fc5c05
+  name: spark-k8s-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1
   name: ""
 schema: olm.bundle

--- a/operators/stackable-spark-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-spark-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: spark-operator.v25.7.0
   - name: spark-operator.v26.3.0
     replaces: spark-operator.v25.11.0
+  - name: spark-operator.v26.7.0
+    replaces: spark-operator.v26.3.0
   name: stable
   package: stackable-spark-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:916d6051452282647b3eefa7ffea525a8de69fdc2c72c32d87cc56720c7b16e4 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: spark-operator.v26.7.0
+  name: '26.7'
+  package: stackable-spark-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:211d435f78730b3fa265df3f6a1a9c4649b060f1bad2b1709c935740deb94057 # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-spark-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-spark-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: spark-operator.v25.7.0
   - name: spark-operator.v26.3.0
     replaces: spark-operator.v25.11.0
+  - name: spark-operator.v26.7.0
+    replaces: spark-operator.v26.3.0
   name: stable
   package: stackable-spark-operator
   schema: olm.channel
@@ -44,12 +46,20 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:916d6051452282647b3eefa7ffea525a8de69fdc2c72c32d87cc56720c7b16e4 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: spark-operator.v26.7.0
+  name: '26.7'
+  package: stackable-spark-operator
+  schema: olm.channel
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:211d435f78730b3fa265df3f6a1a9c4649b060f1bad2b1709c935740deb94057 # 25.11.0
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1 # 26.7.0
 schema: olm.template.basic
 
 schema: olm.template.basic

--- a/operators/stackable-spark-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-spark-operator/catalog-templates/v4.20.yaml
@@ -20,7 +20,14 @@ entries:
   - name: spark-operator.v25.11.0
   - name: spark-operator.v26.3.0
     replaces: spark-operator.v25.11.0
+  - name: spark-operator.v26.7.0
+    replaces: spark-operator.v26.3.0
   name: stable
+  package: stackable-spark-operator
+  schema: olm.channel
+- entries:
+  - name: spark-operator.v26.7.0
+  name: '26.7'
   package: stackable-spark-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -29,4 +36,7 @@ entries:
 - schema: olm.bundle
   image:
     registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:7681f5ca846dfbd10a51c2a4f258b0a56a2f09254e0ba9375d5ad244466ce571 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-spark-k8s-operator@sha256:a6782bb855072f4590216deb57eb269be9987e9612b2de36ff9090062b5110d1 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-spark-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `spark-operator.v26.7.0`
- `stable` extended with `spark-operator.v26.7.0` replacing `spark-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.