### PR TITLE
Catalog update [stackable-superset-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-superset-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-superset-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-superset-operator
 schema: olm.channel
 ---
 entries:
+- name: superset-operator.v26.7.0
+name: "26.7"
+package: stackable-superset-operator
+schema: olm.channel
+---
+entries:
 - name: superset-operator.v25.3.0
 - name: superset-operator.v25.7.0
   replaces: superset-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: superset-operator.v25.7.0
 - name: superset-operator.v26.3.0
   replaces: superset-operator.v25.11.0
+- name: superset-operator.v26.7.0
+  replaces: superset-operator.v26.3.0
 name: stable
 package: stackable-superset-operator
 schema: olm.channel
@@ -362,5 +370,70 @@ relatedImages:
 - image: quay.io/stackable/superset-operator@sha256:d05b00657b3739ff944bdeec74ae05bd52b98dd02b85c68b16495a6e1a1c3557
   name: superset-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
+name: superset-operator.v26.7.0
+package: stackable-superset-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-superset-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+      description: Stackable Operator for Apache Superset
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/superset-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Superset
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - superset
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+  name: superset-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-superset-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-superset-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-superset-operator
 schema: olm.channel
 ---
 entries:
+- name: superset-operator.v26.7.0
+name: "26.7"
+package: stackable-superset-operator
+schema: olm.channel
+---
+entries:
 - name: superset-operator.v25.3.0
 - name: superset-operator.v25.7.0
   replaces: superset-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: superset-operator.v25.7.0
 - name: superset-operator.v26.3.0
   replaces: superset-operator.v25.11.0
+- name: superset-operator.v26.7.0
+  replaces: superset-operator.v26.3.0
 name: stable
 package: stackable-superset-operator
 schema: olm.channel
@@ -362,5 +370,70 @@ relatedImages:
 - image: quay.io/stackable/superset-operator@sha256:d05b00657b3739ff944bdeec74ae05bd52b98dd02b85c68b16495a6e1a1c3557
   name: superset-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
+name: superset-operator.v26.7.0
+package: stackable-superset-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-superset-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+      description: Stackable Operator for Apache Superset
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/superset-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Superset
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - superset
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+  name: superset-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-superset-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-superset-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-superset-operator
 schema: olm.channel
 ---
 entries:
+- name: superset-operator.v26.7.0
+name: "26.7"
+package: stackable-superset-operator
+schema: olm.channel
+---
+entries:
 - name: superset-operator.v25.11.0
 - name: superset-operator.v26.3.0
   replaces: superset-operator.v25.11.0
+- name: superset-operator.v26.7.0
+  replaces: superset-operator.v26.3.0
 name: stable
 package: stackable-superset-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/superset-operator@sha256:d05b00657b3739ff944bdeec74ae05bd52b98dd02b85c68b16495a6e1a1c3557
   name: superset-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
+name: superset-operator.v26.7.0
+package: stackable-superset-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-superset-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+      description: Stackable Operator for Apache Superset
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/superset-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Superset
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - superset
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+  name: superset-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-superset-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-superset-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-superset-operator
 schema: olm.channel
 ---
 entries:
+- name: superset-operator.v26.7.0
+name: "26.7"
+package: stackable-superset-operator
+schema: olm.channel
+---
+entries:
 - name: superset-operator.v25.11.0
 - name: superset-operator.v26.3.0
   replaces: superset-operator.v25.11.0
+- name: superset-operator.v26.7.0
+  replaces: superset-operator.v26.3.0
 name: stable
 package: stackable-superset-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/superset-operator@sha256:d05b00657b3739ff944bdeec74ae05bd52b98dd02b85c68b16495a6e1a1c3557
   name: superset-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
+name: superset-operator.v26.7.0
+package: stackable-superset-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-superset-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+      description: Stackable Operator for Apache Superset
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/superset-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Superset
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - superset
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+  name: superset-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-superset-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-superset-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-superset-operator
 schema: olm.channel
 ---
 entries:
+- name: superset-operator.v26.7.0
+name: "26.7"
+package: stackable-superset-operator
+schema: olm.channel
+---
+entries:
 - name: superset-operator.v25.11.0
 - name: superset-operator.v26.3.0
   replaces: superset-operator.v25.11.0
+- name: superset-operator.v26.7.0
+  replaces: superset-operator.v26.3.0
 name: stable
 package: stackable-superset-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/superset-operator@sha256:d05b00657b3739ff944bdeec74ae05bd52b98dd02b85c68b16495a6e1a1c3557
   name: superset-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
+name: superset-operator.v26.7.0
+package: stackable-superset-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-superset-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+      description: Stackable Operator for Apache Superset
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/superset-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Superset
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - superset
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/superset-operator@sha256:ba45489c4f52552faee9a1961ed42737ba85a335795e50cfd38928eaf54f7bf1
+  name: superset-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec
   name: ""
 schema: olm.bundle

--- a/operators/stackable-superset-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-superset-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: superset-operator.v25.7.0
   - name: superset-operator.v26.3.0
     replaces: superset-operator.v25.11.0
+  - name: superset-operator.v26.7.0
+    replaces: superset-operator.v26.3.0
   name: stable
   package: stackable-superset-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:2dcb87ee6a11a84b7ac13e3818614e7e6a9692ac766d508c588c09420a0b8776 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: superset-operator.v26.7.0
+  name: '26.7'
+  package: stackable-superset-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:55e2b7a946db2dd9b2111784d5d4d664b2d622611a2076ad70363e110d70fde7 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-superset-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-superset-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: superset-operator.v25.7.0
   - name: superset-operator.v26.3.0
     replaces: superset-operator.v25.11.0
+  - name: superset-operator.v26.7.0
+    replaces: superset-operator.v26.3.0
   name: stable
   package: stackable-superset-operator
   schema: olm.channel
@@ -44,11 +46,19 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:2dcb87ee6a11a84b7ac13e3818614e7e6a9692ac766d508c588c09420a0b8776 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: superset-operator.v26.7.0
+  name: '26.7'
+  package: stackable-superset-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:55e2b7a946db2dd9b2111784d5d4d664b2d622611a2076ad70363e110d70fde7 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec # 26.7.0
 schema: olm.template.basic
 

--- a/operators/stackable-superset-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-superset-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: superset-operator.v25.11.0
   - name: superset-operator.v26.3.0
     replaces: superset-operator.v25.11.0
+  - name: superset-operator.v26.7.0
+    replaces: superset-operator.v26.3.0
   name: stable
+  package: stackable-superset-operator
+  schema: olm.channel
+- entries:
+  - name: superset-operator.v26.7.0
+  name: '26.7'
   package: stackable-superset-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:f3fee5fcf7d7deb8efe8b48a7d381cc12b2dbf5a8dafa41b0093bf6a911f4893 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-superset-operator@sha256:7d0307ed8503a759a2bcc35276aa0469cff46c3f8b8d963c8b16f2c026be9eec # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-superset-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `superset-operator.v26.7.0`
- `stable` extended with `superset-operator.v26.7.0` replacing `superset-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.