### PR TITLE
Catalog update [stackable-airflow-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-airflow-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-airflow-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-airflow-operator
 schema: olm.channel
 ---
 entries:
+- name: airflow-operator.v26.7.0
+name: "26.7"
+package: stackable-airflow-operator
+schema: olm.channel
+---
+entries:
 - name: airflow-operator.v25.3.0
 - name: airflow-operator.v25.7.0
   replaces: airflow-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: airflow-operator.v25.7.0
 - name: airflow-operator.v26.3.0
   replaces: airflow-operator.v25.11.0
+- name: airflow-operator.v26.7.0
+  replaces: airflow-operator.v26.3.0
 name: stable
 package: stackable-airflow-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/airflow-operator@sha256:e4afd038f3798157aa6f103997b68b3080f67570c751258c80cf8083d22aa9f7
   name: airflow-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
+name: airflow-operator.v26.7.0
+package: stackable-airflow-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-airflow-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+      description: Stackable Operator for Apache Airflow
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/airflow-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Airflow
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - airflow
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+  name: airflow-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-airflow-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-airflow-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-airflow-operator
 schema: olm.channel
 ---
 entries:
+- name: airflow-operator.v26.7.0
+name: "26.7"
+package: stackable-airflow-operator
+schema: olm.channel
+---
+entries:
 - name: airflow-operator.v25.3.0
 - name: airflow-operator.v25.7.0
   replaces: airflow-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: airflow-operator.v25.7.0
 - name: airflow-operator.v26.3.0
   replaces: airflow-operator.v25.11.0
+- name: airflow-operator.v26.7.0
+  replaces: airflow-operator.v26.3.0
 name: stable
 package: stackable-airflow-operator
 schema: olm.channel
@@ -332,5 +340,70 @@ relatedImages:
 - image: quay.io/stackable/airflow-operator@sha256:e4afd038f3798157aa6f103997b68b3080f67570c751258c80cf8083d22aa9f7
   name: airflow-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
+name: airflow-operator.v26.7.0
+package: stackable-airflow-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-airflow-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+      description: Stackable Operator for Apache Airflow
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/airflow-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Airflow
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - airflow
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+  name: airflow-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-airflow-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-airflow-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-airflow-operator
 schema: olm.channel
 ---
 entries:
+- name: airflow-operator.v26.7.0
+name: "26.7"
+package: stackable-airflow-operator
+schema: olm.channel
+---
+entries:
 - name: airflow-operator.v25.11.0
 - name: airflow-operator.v26.3.0
   replaces: airflow-operator.v25.11.0
+- name: airflow-operator.v26.7.0
+  replaces: airflow-operator.v26.3.0
 name: stable
 package: stackable-airflow-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/airflow-operator@sha256:e4afd038f3798157aa6f103997b68b3080f67570c751258c80cf8083d22aa9f7
   name: airflow-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
+name: airflow-operator.v26.7.0
+package: stackable-airflow-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-airflow-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+      description: Stackable Operator for Apache Airflow
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/airflow-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Airflow
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - airflow
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+  name: airflow-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-airflow-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-airflow-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-airflow-operator
 schema: olm.channel
 ---
 entries:
+- name: airflow-operator.v26.7.0
+name: "26.7"
+package: stackable-airflow-operator
+schema: olm.channel
+---
+entries:
 - name: airflow-operator.v25.11.0
 - name: airflow-operator.v26.3.0
   replaces: airflow-operator.v25.11.0
+- name: airflow-operator.v26.7.0
+  replaces: airflow-operator.v26.3.0
 name: stable
 package: stackable-airflow-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/airflow-operator@sha256:e4afd038f3798157aa6f103997b68b3080f67570c751258c80cf8083d22aa9f7
   name: airflow-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
+name: airflow-operator.v26.7.0
+package: stackable-airflow-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-airflow-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+      description: Stackable Operator for Apache Airflow
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/airflow-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Airflow
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - airflow
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+  name: airflow-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-airflow-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-airflow-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-airflow-operator
 schema: olm.channel
 ---
 entries:
+- name: airflow-operator.v26.7.0
+name: "26.7"
+package: stackable-airflow-operator
+schema: olm.channel
+---
+entries:
 - name: airflow-operator.v25.11.0
 - name: airflow-operator.v26.3.0
   replaces: airflow-operator.v25.11.0
+- name: airflow-operator.v26.7.0
+  replaces: airflow-operator.v26.3.0
 name: stable
 package: stackable-airflow-operator
 schema: olm.channel
@@ -164,5 +172,70 @@ relatedImages:
 - image: quay.io/stackable/airflow-operator@sha256:e4afd038f3798157aa6f103997b68b3080f67570c751258c80cf8083d22aa9f7
   name: airflow-operator
 - image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
+name: airflow-operator.v26.7.0
+package: stackable-airflow-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-airflow-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+      description: Stackable Operator for Apache Airflow
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/airflow-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Apache Airflow
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - airflow
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/airflow-operator@sha256:c51a8c591ad0ae0d2f6a7605f5e0beeed086fe04299ece4f9574e67a3f3b5861
+  name: airflow-operator
+- image: registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead
   name: ""
 schema: olm.bundle

--- a/operators/stackable-airflow-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-airflow-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: airflow-operator.v25.7.0
   - name: airflow-operator.v26.3.0
     replaces: airflow-operator.v25.11.0
+  - name: airflow-operator.v26.7.0
+    replaces: airflow-operator.v26.3.0
   name: stable
   package: stackable-airflow-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:ffee816bc94bea75ed3e393c6e2f4378ed77df1e8988ada9583b429d3e8328b8 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: airflow-operator.v26.7.0
+  name: '26.7'
+  package: stackable-airflow-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:983b65960949b01b01a60f23271f3072c048c5fa2e23ab3303fe28ebafb40576 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-airflow-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-airflow-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: airflow-operator.v25.7.0
   - name: airflow-operator.v26.3.0
     replaces: airflow-operator.v25.11.0
+  - name: airflow-operator.v26.7.0
+    replaces: airflow-operator.v26.3.0
   name: stable
   package: stackable-airflow-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:ffee816bc94bea75ed3e393c6e2f4378ed77df1e8988ada9583b429d3e8328b8 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: airflow-operator.v26.7.0
+  name: '26.7'
+  package: stackable-airflow-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:983b65960949b01b01a60f23271f3072c048c5fa2e23ab3303fe28ebafb40576 # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-airflow-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-airflow-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: airflow-operator.v25.11.0
   - name: airflow-operator.v26.3.0
     replaces: airflow-operator.v25.11.0
+  - name: airflow-operator.v26.7.0
+    replaces: airflow-operator.v26.3.0
   name: stable
+  package: stackable-airflow-operator
+  schema: olm.channel
+- entries:
+  - name: airflow-operator.v26.7.0
+  name: '26.7'
   package: stackable-airflow-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:93bd8e61664c474d4ab7111af70646b0a9b52987ae687344c13abe9e6f196901 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-apache-airflow-operator@sha256:68e808623aee1da285022340becc4e469cea0093afd304b1c4af7f4d3e3c5ead # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-airflow-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `airflow-operator.v26.7.0`
- `stable` extended with `airflow-operator.v26.7.0` replacing `airflow-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.