### PR TITLE
Catalog update [stackable-trino-operator] [v4.18,v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.18/stackable-trino-operator/catalog.yaml
+++ b/catalogs/v4.18/stackable-trino-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-trino-operator
 schema: olm.channel
 ---
 entries:
+- name: trino-operator.v26.7.0
+name: "26.7"
+package: stackable-trino-operator
+schema: olm.channel
+---
+entries:
 - name: trino-operator.v25.3.0
 - name: trino-operator.v25.7.0
   replaces: trino-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: trino-operator.v25.7.0
 - name: trino-operator.v26.3.0
   replaces: trino-operator.v25.11.0
+- name: trino-operator.v26.7.0
+  replaces: trino-operator.v26.3.0
 name: stable
 package: stackable-trino-operator
 schema: olm.channel
@@ -362,5 +370,70 @@ relatedImages:
 - image: quay.io/stackable/trino-operator@sha256:3e3f549dccffd7a04fc16fca6d0f6b770ee7401eec46bb4301701466423006da
   name: trino-operator
 - image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
+name: trino-operator.v26.7.0
+package: stackable-trino-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-trino-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+      description: Stackable Operator for Trino
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/trino-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Trino
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - trino
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+  name: trino-operator
+- image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.19/stackable-trino-operator/catalog.yaml
+++ b/catalogs/v4.19/stackable-trino-operator/catalog.yaml
@@ -31,6 +31,12 @@ package: stackable-trino-operator
 schema: olm.channel
 ---
 entries:
+- name: trino-operator.v26.7.0
+name: "26.7"
+package: stackable-trino-operator
+schema: olm.channel
+---
+entries:
 - name: trino-operator.v25.3.0
 - name: trino-operator.v25.7.0
   replaces: trino-operator.v25.3.0
@@ -38,6 +44,8 @@ entries:
   replaces: trino-operator.v25.7.0
 - name: trino-operator.v26.3.0
   replaces: trino-operator.v25.11.0
+- name: trino-operator.v26.7.0
+  replaces: trino-operator.v26.3.0
 name: stable
 package: stackable-trino-operator
 schema: olm.channel
@@ -362,5 +370,70 @@ relatedImages:
 - image: quay.io/stackable/trino-operator@sha256:3e3f549dccffd7a04fc16fca6d0f6b770ee7401eec46bb4301701466423006da
   name: trino-operator
 - image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
+name: trino-operator.v26.7.0
+package: stackable-trino-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-trino-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+      description: Stackable Operator for Trino
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/trino-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Trino
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - trino
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+  name: trino-operator
+- image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/stackable-trino-operator/catalog.yaml
+++ b/catalogs/v4.20/stackable-trino-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-trino-operator
 schema: olm.channel
 ---
 entries:
+- name: trino-operator.v26.7.0
+name: "26.7"
+package: stackable-trino-operator
+schema: olm.channel
+---
+entries:
 - name: trino-operator.v25.11.0
 - name: trino-operator.v26.3.0
   replaces: trino-operator.v25.11.0
+- name: trino-operator.v26.7.0
+  replaces: trino-operator.v26.3.0
 name: stable
 package: stackable-trino-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/trino-operator@sha256:3e3f549dccffd7a04fc16fca6d0f6b770ee7401eec46bb4301701466423006da
   name: trino-operator
 - image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
+name: trino-operator.v26.7.0
+package: stackable-trino-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-trino-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+      description: Stackable Operator for Trino
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/trino-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Trino
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - trino
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+  name: trino-operator
+- image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/stackable-trino-operator/catalog.yaml
+++ b/catalogs/v4.21/stackable-trino-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-trino-operator
 schema: olm.channel
 ---
 entries:
+- name: trino-operator.v26.7.0
+name: "26.7"
+package: stackable-trino-operator
+schema: olm.channel
+---
+entries:
 - name: trino-operator.v25.11.0
 - name: trino-operator.v26.3.0
   replaces: trino-operator.v25.11.0
+- name: trino-operator.v26.7.0
+  replaces: trino-operator.v26.3.0
 name: stable
 package: stackable-trino-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/trino-operator@sha256:3e3f549dccffd7a04fc16fca6d0f6b770ee7401eec46bb4301701466423006da
   name: trino-operator
 - image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
+name: trino-operator.v26.7.0
+package: stackable-trino-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-trino-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+      description: Stackable Operator for Trino
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/trino-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Trino
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - trino
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+  name: trino-operator
+- image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/stackable-trino-operator/catalog.yaml
+++ b/catalogs/v4.22/stackable-trino-operator/catalog.yaml
@@ -19,9 +19,17 @@ package: stackable-trino-operator
 schema: olm.channel
 ---
 entries:
+- name: trino-operator.v26.7.0
+name: "26.7"
+package: stackable-trino-operator
+schema: olm.channel
+---
+entries:
 - name: trino-operator.v25.11.0
 - name: trino-operator.v26.3.0
   replaces: trino-operator.v25.11.0
+- name: trino-operator.v26.7.0
+  replaces: trino-operator.v26.3.0
 name: stable
 package: stackable-trino-operator
 schema: olm.channel
@@ -174,5 +182,70 @@ relatedImages:
 - image: quay.io/stackable/trino-operator@sha256:3e3f549dccffd7a04fc16fca6d0f6b770ee7401eec46bb4301701466423006da
   name: trino-operator
 - image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
+name: trino-operator.v26.7.0
+package: stackable-trino-operator
+properties:
+- type: olm.package
+  value:
+    packageName: stackable-trino-operator
+    version: 26.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      capabilities: Full Lifecycle
+      categories: Storage
+      containerImage: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+      description: Stackable Operator for Trino
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: stackable-operators
+      repository: https://github.com/stackabletech/trino-operator
+      support: Stackable GmbH
+    apiServiceDefinitions: {}
+    crdDescriptions: {}
+    description: |
+      The Stackable Data Platform was designed with openness and flexibility in mind. It provides a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino and Apache Spark. All data apps work together seamlessly, and can be added or removed in no time. Based on Kubernetes, it runs everywhere - on-prem or in the cloud.
+
+      For more information please visit our [web page](https://stackable.tech/en/open-source-data-platform)
+    displayName: Stackable Operator for Trino
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - trino
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    maintainers:
+    - email: info@stackable.tech
+      name: Stackable GmbH
+    maturity: stable
+    minKubeVersion: 1.23.0
+    provider:
+      name: Stackable GmbH
+      url: https://stackable.tech
+relatedImages:
+- image: quay.io/stackable/sdp/trino-operator@sha256:b332f74f649af9d3f54f0d7c936b9a25a4248c68dfb71f9231a4bd2ea5da66f7
+  name: trino-operator
+- image: registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9
   name: ""
 schema: olm.bundle

--- a/operators/stackable-trino-operator/catalog-templates/v4.18.yaml
+++ b/operators/stackable-trino-operator/catalog-templates/v4.18.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: trino-operator.v25.7.0
   - name: trino-operator.v26.3.0
     replaces: trino-operator.v25.11.0
+  - name: trino-operator.v26.7.0
+    replaces: trino-operator.v26.3.0
   name: stable
   package: stackable-trino-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:b4a6e6cb374ca7226cbd1f90563f0d03669ff1168d999ca2ff5fc7be80cac588 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: trino-operator.v26.7.0
+  name: '26.7'
+  package: stackable-trino-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:448b119ee427df47019b35103dfc5fbc79f52dc06cfdc71a81410593fdde9d7c # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-trino-operator/catalog-templates/v4.19.yaml
+++ b/operators/stackable-trino-operator/catalog-templates/v4.19.yaml
@@ -35,6 +35,8 @@ entries:
     replaces: trino-operator.v25.7.0
   - name: trino-operator.v26.3.0
     replaces: trino-operator.v25.11.0
+  - name: trino-operator.v26.7.0
+    replaces: trino-operator.v26.3.0
   name: stable
   package: stackable-trino-operator
   schema: olm.channel
@@ -44,10 +46,18 @@ entries:
 - image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:b4a6e6cb374ca7226cbd1f90563f0d03669ff1168d999ca2ff5fc7be80cac588 # 25.7.0
   schema: olm.bundle
+- entries:
+  - name: trino-operator.v26.7.0
+  name: '26.7'
+  package: stackable-trino-operator
+  schema: olm.channel
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:448b119ee427df47019b35103dfc5fbc79f52dc06cfdc71a81410593fdde9d7c # 25.11.0
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9 # 26.7.0
 schema: olm.template.basic

--- a/operators/stackable-trino-operator/catalog-templates/v4.20.yaml
+++ b/operators/stackable-trino-operator/catalog-templates/v4.20.yaml
@@ -21,7 +21,14 @@ entries:
   - name: trino-operator.v25.11.0
   - name: trino-operator.v26.3.0
     replaces: trino-operator.v25.11.0
+  - name: trino-operator.v26.7.0
+    replaces: trino-operator.v26.3.0
   name: stable
+  package: stackable-trino-operator
+  schema: olm.channel
+- entries:
+  - name: trino-operator.v26.7.0
+  name: '26.7'
   package: stackable-trino-operator
   schema: olm.channel
 - schema: olm.bundle
@@ -30,4 +37,7 @@ entries:
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:9fc26806429755de86ca89e43dc3cba824782681d990e4304c4c5a4a445357c9 # 26.3.0
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/stackable/stackable-trino-operator@sha256:f24607e7ec598e3efadc5570a83d86669faa806bad42ae42828370f26c0a94b9 # 26.7.0
 schema: olm.template.basic


### PR DESCRIPTION
Adds the 26.7.0 bundle to the `stackable-trino-operator` catalogs for OpenShift 4.18 through 4.22.

The bundle itself was certified and merged separately. This adds it to the version graph:

- a `26.7` channel containing `trino-operator.v26.7.0`
- `stable` extended with `trino-operator.v26.7.0` replacing `trino-operator.v26.3.0`

Templates `v4.18.yaml`, `v4.19.yaml` and `v4.20.yaml` were updated and the file-based catalogs re-rendered with `make catalogs`; `v4.20.yaml` serves 4.20, 4.21 and 4.22 per `ci.yaml`. `make validate-catalogs` passes for every rendered catalog.