### PR TITLE
Amend INK update graph for 1.19.5

### DIFF
--- a/operators/isovalent-networking/catalog-templates/template.yaml
+++ b/operators/isovalent-networking/catalog-templates/template.yaml
@@ -143,6 +143,8 @@ entries:
   schema: olm.channel
   entries:
   - name: clife.v1.19.5-cee.1
+    replaces: clife.v1.18.11-cee.1
+    skipRange: '>=1.18.11-cee.1 <1.19.5-cee.1'
 - image: 
     registry.connect.redhat.com/isovalent/clife-bundle@sha256:7f766dda31c9eb727ca17675e5174f1df7f62b969225a1986e09a643c5955938
   schema: olm.bundle


### PR DESCRIPTION
When adding a bundle for a new minor version and the related channel it is not possible with Red Hat workflow to also have the replace and skipRange specified at the same time. This adds the update graph elements.