### PR TITLE
operator nutanixcsioperator (3.8.0)

### DIFF
--- a/operators/nutanixcsioperator/3.8.0/manifests/crd.nutanix.com_nutanixcsistorages.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/crd.nutanix.com_nutanixcsistorages.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: nutanixcsistorages.crd.nutanix.com
+spec:
+  group: crd.nutanix.com
+  names:
+    kind: NutanixCsiStorage
+    listKind: NutanixCsiStorageList
+    plural: nutanixcsistorages
+    singular: nutanixcsistorage
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NutanixCsiStorage is the Schema for the nutanixcsistorages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of NutanixCsiStorage
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of NutanixCsiStorage
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanix-csi-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanix-csi-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: nutanix-csi-operator
+    control-plane: controller-manager
+  name: nutanix-csi-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanix-csi-operator-manager-config_v1_configmap.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanix-csi-operator-manager-config_v1_configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+
+    leaderElection:
+      leaderElect: true
+      resourceName: 811c9dc5.nutanix.com
+kind: ConfigMap
+metadata:
+  name: nutanix-csi-operator-manager-config

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanix-csi-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanix-csi-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: nutanix-csi-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Storage
-    containerImage: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
+    containerImage: registry.connect.redhat.com/nutanix/nutanix-csi-operator@sha256:947729af2b3c2de85913b15cf3c3b378a3502383273327d81224071390ac9fd8
     createdAt: "2026-08-20T06:56:45Z"
     description: An Operator for deploying and managing the Nutanix CSI Driver
     features.operators.openshift.io/csi: "true"
@@ -348,32 +348,32 @@ spec:
                 - --leader-election-id=nutanixcsioperator
                 env:
                 - name: RELATED_IMAGE_NUTANIX_CSI
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:a6b0458ac61cc575ffe83f65cc0c03426dcb16054063521b2ca627e9b893484c
                 - name: RELATED_IMAGE_NUTANIX_CSI_PRECHECK
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-precheck
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:dee4c711ec1f8f4dd475b2ec8ba968d1156b28a08a3af38cc5b0fcaf69952b34
                 - name: RELATED_IMAGE_AUTHSIDECAR
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-authagent
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:454834cf7625596e6d2ce50b939d7c49a89749f765c04fb429cdf6d5a015197a
                 - name: RELATED_IMAGE_PULSE
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-pulse
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:514fc3cf04e2cfe38ca39fed2b0415d402d5d180a78137bbc36f5b6fcd760eb4
                 - name: RELATED_IMAGE_PROVISIONER
-                  value: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+                  value: registry.k8s.io/sig-storage/csi-provisioner@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
                 - name: RELATED_IMAGE_PROVISIONER_LEGACY
-                  value: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+                  value: registry.k8s.io/sig-storage/csi-provisioner@sha256:04c55b93a032ad8075cae540d60fc740a72c31006590dbdb61ad4ab9813959d0
                 - name: RELATED_IMAGE_ATTACHER
-                  value: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
+                  value: registry.k8s.io/sig-storage/csi-attacher@sha256:b9dc9a714a484ccdeeb6f86d88d4db9b7a5ecfc5a55da6db3a60bb3fa33c278a
                 - name: RELATED_IMAGE_SNAPSHOTTER
-                  value: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+                  value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:42af0929bcd60a43499825c078a60ff0534e08af8fbeb283aa391be40feb9f3e
                 - name: RELATED_IMAGE_SNAPSHOTTER_BETA
-                  value: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
+                  value: registry.k8s.io/sig-storage/csi-snapshotter@sha256:9af9bf28430b00a0cedeb2ec29acadce45e6afcecd8bdf31c793c624cfa75fa7
                 - name: RELATED_IMAGE_RESIZER
-                  value: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+                  value: registry.k8s.io/sig-storage/csi-resizer@sha256:a2d40c1c3ccb0c48b467125a6652c4dd5dcbf0d295641c9989581cfc690f6cf3
                 - name: RELATED_IMAGE_LIVENESSPROBE
-                  value: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
+                  value: registry.k8s.io/sig-storage/livenessprobe@sha256:06da0d5b8908072f2e4522692aee8dc119fba7247a9658497e1153992cd777e9
                 - name: RELATED_IMAGE_HEALTHMONITOR
-                  value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+                  value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:430c1f2267152ce6e4547ebbad225a2b399d03e5894f2f39ba233a38e4750a47
                 - name: RELATED_IMAGE_REGISTRAR
-                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
-                image: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
+                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
+                image: registry.connect.redhat.com/nutanix/nutanix-csi-operator@sha256:947729af2b3c2de85913b15cf3c3b378a3502383273327d81224071390ac9fd8
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -469,31 +469,31 @@ spec:
   provider:
     name: Nutanix
   relatedImages:
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:a6b0458ac61cc575ffe83f65cc0c03426dcb16054063521b2ca627e9b893484c
     name: nutanix-csi
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-precheck
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:dee4c711ec1f8f4dd475b2ec8ba968d1156b28a08a3af38cc5b0fcaf69952b34
     name: nutanix-csi-precheck
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-authagent
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:454834cf7625596e6d2ce50b939d7c49a89749f765c04fb429cdf6d5a015197a
     name: authsidecar
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-pulse
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:514fc3cf04e2cfe38ca39fed2b0415d402d5d180a78137bbc36f5b6fcd760eb4
     name: pulse
-  - image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+  - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
     name: provisioner
-  - image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+  - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:04c55b93a032ad8075cae540d60fc740a72c31006590dbdb61ad4ab9813959d0
     name: provisioner-legacy
-  - image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
+  - image: registry.k8s.io/sig-storage/csi-attacher@sha256:b9dc9a714a484ccdeeb6f86d88d4db9b7a5ecfc5a55da6db3a60bb3fa33c278a
     name: attacher
-  - image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+  - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:42af0929bcd60a43499825c078a60ff0534e08af8fbeb283aa391be40feb9f3e
     name: snapshotter
-  - image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
+  - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:9af9bf28430b00a0cedeb2ec29acadce45e6afcecd8bdf31c793c624cfa75fa7
     name: snapshotter-beta
-  - image: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+  - image: registry.k8s.io/sig-storage/csi-resizer@sha256:a2d40c1c3ccb0c48b467125a6652c4dd5dcbf0d295641c9989581cfc690f6cf3
     name: resizer
-  - image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
+  - image: registry.k8s.io/sig-storage/livenessprobe@sha256:06da0d5b8908072f2e4522692aee8dc119fba7247a9658497e1153992cd777e9
     name: livenessprobe
-  - image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+  - image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:430c1f2267152ce6e4547ebbad225a2b399d03e5894f2f39ba233a38e4750a47
     name: healthmonitor
-  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
     name: registrar
   replaces: nutanixcsioperator.v3.7.2
   version: 3.8.0

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
@@ -19,8 +19,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Storage
-    containerImage: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
-    createdAt: "2026-08-20T06:35:58Z"
+    containerImage: quay.io/redhat-isv-containers/609b04503048c1ac9a6fec43:v3.8.0
+    createdAt: "2026-08-20T06:56:45Z"
     description: An Operator for deploying and managing the Nutanix CSI Driver
     features.operators.openshift.io/csi: "true"
     features.operators.openshift.io/disconnected: "true"
@@ -373,7 +373,7 @@ spec:
                   value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
                 - name: RELATED_IMAGE_REGISTRAR
                   value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
-                image: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
+                image: quay.io/redhat-isv-containers/609b04503048c1ac9a6fec43:v3.8.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
@@ -495,5 +495,7 @@ spec:
     name: healthmonitor
   - image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
     name: registrar
+  - image: registry.connect.redhat.com/nutanix/nutanix-csi-operator@sha256:947729af2b3c2de85913b15cf3c3b378a3502383273327d81224071390ac9fd8
+    name: operator
   replaces: nutanixcsioperator.v3.7.2
   version: 3.8.0

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
@@ -1,0 +1,499 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "crd.nutanix.com/v1alpha1",
+          "kind": "NutanixCsiStorage",
+          "metadata": {
+            "name": "nutanixcsistorage"
+          },
+          "spec": {
+            "ntnxInitConfigMap": {
+              "usePC": true
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Storage
+    containerImage: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
+    createdAt: "2026-08-20T06:35:58Z"
+    description: An Operator for deploying and managing the Nutanix CSI Driver
+    features.operators.openshift.io/csi: "true"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: <3.8.0
+    operatorframework.io/suggested-namespace: openshift-cluster-csi-drivers
+    operators.openshift.io/infrastructure-features: '["csi","disconnected"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://github.com/nutanix/csi-operator
+    support: Nutanix Support Team
+  name: nutanixcsioperator.v3.8.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Deploy a new instance of Nutanix CSI Driver
+      displayName: Nutanix CSI Storage
+      kind: NutanixCsiStorage
+      name: nutanixcsistorages.crd.nutanix.com
+      version: v1alpha1
+  description: "# Important\nPlease read the following instructions carefully before
+    upgrading from 2.6.x to 3.8.0, for more information please refer to [documentation](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v3_8:CSI-Volume-Driver-v3_8)\n-
+    Please do not upgrade to the CSI 3.x operator if:\n    * You are using LVM volumes.\n\n-
+    CSI 3.8.0 supports PC service account-based authentication in Nutanix Volumes
+    and Nutanix Files. Instead of using username and password secrets, Prism Central
+    administrators can now create service accounts, configure RBAC, and use generated
+    API keys for secure storage provisioning. Create a Nutanix Prism Central secret
+    with service account key as shown [here](#create-a-nutanix-pc-secret) \n\n   Note:
+    In order to use this feature you should uninstall the driver(delete existing nutanixcsistorage
+    resource), create a nutanix-pc-secret with the service account key as shown [here](#create-a-nutanix-pc-secret)
+    and install the driver again by passing the newly created secret name in pcSecretName
+    and authType: \"service-auth\" in nutanixcsistorage spec.\n   \n- CSI 3.7 supports
+    topology-aware storage provisioning across multiple Prism Element clusters without
+    requiring Prism Central. This capability simplifies daily operations by provisioning
+    storage automatically based on compute locality, thereby reducing the need for
+    manual configuration of pod placement across failure domains.\n- CSI 3.7 allows
+    Kubernetes pods with Nutanix-backed persistent volumes to failover to different
+    nodes, even when Prism Central (PC) is not available. \nhttps://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v3_8:csi-csi_driver_disconnect_pc_pod_failover_c.html\n-
+    CSI 3.7 with Nutanix Files now supports independent IP addresses for NFS mount
+    endpoint versus REST API endpoint.\n\n- Nutanix CSI 3.7.1 introduces ReadWriteMany
+    (RWX) support for Nutanix Volumes. When enabled, this feature automatically deploys
+    internal CN-RWX components to enable simultaneous read/write access to persistent
+    volumes. To enable this feature, add the following to the nutanixcsistorage spec
+    while creating the resource (new installations), or edit the existing nutanixcsistorage
+    resource and add the following to the spec (existing installations):\n\n   ```yaml\n
+    \  volumeRWXSupport:\n     enabled: true\n   ```\n\n- To upgrade from the CSI
+    2.6.x to CSI 3.8 (interacting with Prism Central) operator\n    * Create a Nutanix
+    Prism Central secret as explained below.\n    * Delete the csidriver object from
+    the cluster:\n\n        ```\n        oc delete csidriver csi.nutanix.com\n        ```\n\n
+    \   * In the installed operators, go to Nutanix CSI Operator and change the subscription
+    channel from stable to stable-3.x. \n    If you have installed the operator with
+    automatic update approval, the operator will be automatically upgraded to CSI
+    3.8, and then the nutanixcsistorage resource will be upgraded.\n    An update
+    plan will be generated for manual updates. Upon approval, the operator will be
+    successfully upgraded.\n    \n- Direct upgrades from CSI 2.6.x to CSI 3.8 interacting
+    with Prism Element are not supported.\n    The only solution is to recreate the
+    nutanixcsistorage instance by following the below procedure:\n    - In the installed
+    operators, go to Nutanix CSI Operator and delete the nutanixcsistorage instance.\n
+    \   - Next change the subscription channel from stable to stable-3.x.\n    - Verify
+    the following points:\n        - Ensure a Nutanix Prism Element secret is present
+    in the namespace.\n        - Ensure that all the storage classes with provisioner:
+    csi.nutanix.com have a controller publish secret as explained below.\n\n            ```\n
+    \           csi.storage.k8s.io/controller-publish-secret-name: ntnx-pe-secret\n
+    \           csi.storage.k8s.io/controller-publish-secret-namespace: openshift-cluster-csi-drivers\n
+    \           ```\n\n            If this secret is not present in the storage class
+    please delete and recreate the storage classes with the required secrets.\n    -
+    Create a new instance of nutanixcsistorage from this operator by specifying `usePC:
+    false` in YAML spec section.\n    - Caution: Moving from CSI driver interacting
+    with Prism Central to CSI driver interacting with Prism Element is not supported.\n
+    \   \n- Troubleshooting:\n    \n    If the upgrade was unsuccessful and you want
+    to revert to version CSI 2.6.x, please delete the csidriver object as explained
+    above, uninstall the operator (no need to delete the nutanixcsistorage custom
+    resource), and install version CSI 2.6.x from the stable channel.\n# Overview
+    \nThe Nutanix CSI Operator for Kubernetes packages, deploys, manages, and upgrades
+    the Nutanix CSI Driver on Kubernetes and OpenShift for dynamic provisioning of
+    persistent volumes on the Nutanix Enterprise Cloud platform.\nThe Nutanix Container
+    Storage Interface (CSI) Driver for Kubernetes leverages Nutanix Volumes and Nutanix
+    Files to provide scalable and persistent storage for stateful applications.\nWith
+    the Nutanix CSI Provider, you can:\n*  **Provide persistent storage to your containers**\n
+    \   * Leverage PVC resources to consume dynamically Nutanix storage\n    * With
+    Files storage classes, applications on multiple pods can access the same storage
+    and have the benefit of multi-pod read and write access. \n## Warning\nIf you
+    upgrade from a previous version, make sure to validate your existing StorageClass
+    parameters against the corresponding [documentation](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v3_8:CSI-Volume-Driver-v3_8)\n##
+    Supported Access mode\n| Storage Class mode | ReadWriteOnce | ReadOnlyMany | ReadWriteMany
+    |\n|--------------------|---------------|--------------|---------------|\n| Nutanix
+    Volumes    | yes           | yes          | no            |\n| Nutanix Files      |
+    yes           | yes          | yes           |\n## Supported orchestration platforms\nThe
+    following table details orchestration platforms suitable for deployment of the
+    Nutanix CSI driver.\n| Orchestration platform | Version | Architecture |\n|------------------------|---------|--------------|\n|
+    Red Hat OpenShift      | 4.14    | x86          |\n| Red Hat OpenShift      |
+    4.15    | x86          |\n| Red Hat OpenShift      | 4.16    | x86          |\n|
+    Red Hat OpenShift      | 4.17    | x86          |\n| Red Hat OpenShift      |
+    4.18    | x86          |\n| Red Hat OpenShift      | 4.19    | x86          |\n|
+    Red Hat OpenShift      | 4.20    | x86          |\n| Red Hat OpenShift      |
+    4.21    | x86          |\n| Red Hat OpenShift      | 4.22    | x86          |\n##
+    Configuring k8s secret and storage class\nTo use this driver, create the relevant
+    storage classes and secrets and deploy your NutanixCsiStorage instance by following
+    the [documentation](https://portal.nutanix.com/page/documents/details?targetId=CSI-Volume-Driver-v3_8:CSI-Volume-Driver-v3_8)
+    or the example in below section:\n### Create a Nutanix PE secret\n```yaml\napiVersion:
+    v1\nkind: Secret\nmetadata:\n  name: ntnx-pe-secret\n  namespace: openshift-cluster-csi-drivers\nstringData:\n
+    \ # prism-ip:prism-port:username:password.\n  key: 1.2.3.4:9440:admin:password\n
+    \ files-key: \"fileserver01.sample.com:csi:password1\"\n```\n### Create a Nutanix
+    PC secret\n- basic authentication\n```yaml\napiVersion: v1\nkind: Secret\nmetadata:\n
+    \ name: ntnx-pc-secret\n  namespace: openshift-cluster-csi-drivers\nstringData:\n
+    \ # prism-ip:prism-port:username:password.\n  key: 1.2.3.4:9440:admin:password\n```\n-
+    service account based authentication\n```yaml\napiVersion: v1\nkind: Secret\nmetadata:\n
+    \ name: ntnx-pc-secret\n  namespace: openshift-cluster-csi-drivers\ntype: Opaque\nstringData:\n
+    \ host: 1.2.3.4\n  port: 9440\n  key_type: \"api-key\"\n  key_value: \"xxxxxxxxxxx\"\n
+    \ auth_type: \"service-auth\"\n```\n### Create a NutanixCsiStorage resource to
+    deploy your driver\nYou can do it directly inside the Operator UI with the `Create
+    instance` button or with the following resource\n```yaml\napiVersion: crd.nutanix.com/v1alpha1\nkind:
+    NutanixCsiStorage\nmetadata:\n  name: nutanixcsistorage\n  namespace: openshift-cluster-csi-drivers\nspec:
+    \n  ntnxInitConfigMap:\n    usePC : true (false for PE based installations. Default
+    is true.)\n```\n### Create storage classes\n- volume mode example for 3.x installation\n```yaml\nkind:
+    StorageClass\napiVersion: storage.k8s.io/v1\nmetadata:\n  name: nutanix-volume\nprovisioner:
+    csi.nutanix.com\nparameters:\n  csi.storage.k8s.io/provisioner-secret-name: ntnx-pe-secret\n
+    \ csi.storage.k8s.io/provisioner-secret-namespace: openshift-cluster-csi-drivers\n
+    \ csi.storage.k8s.io/node-publish-secret-name: ntnx-pe-secret\n  csi.storage.k8s.io/node-publish-secret-namespace:
+    openshift-cluster-csi-drivers\n  csi.storage.k8s.io/controller-expand-secret-name:
+    ntnx-pe-secret\n  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-cluster-csi-drivers\n
+    \ csi.storage.k8s.io/controller-publish-secret-name: ntnx-pe-secret\n  csi.storage.k8s.io/controller-publish-secret-namespace:
+    openshift-cluster-csi-drivers\n  csi.storage.k8s.io/fstype: ext4\n  storageContainer:
+    default-container\n  storageType: NutanixVolumes\n  #description: \"description
+    added to each storage object created by the driver\"\n  #hypervisorAttached: ENABLED\nallowVolumeExpansion:
+    true\nreclaimPolicy: Delete\n```\n- volume mode example for 2.x installation\n```yaml\nkind:
+    StorageClass\napiVersion: storage.k8s.io/v1\nmetadata:\n  name: nutanix-volume\nprovisioner:
+    csi.nutanix.com\nparameters:\n  csi.storage.k8s.io/provisioner-secret-name: ntnx-pe-secret\n
+    \ csi.storage.k8s.io/provisioner-secret-namespace: openshift-cluster-csi-drivers\n
+    \ csi.storage.k8s.io/node-publish-secret-name: ntnx-pe-secret\n  csi.storage.k8s.io/node-publish-secret-namespace:
+    openshift-cluster-csi-drivers\n  csi.storage.k8s.io/controller-expand-secret-name:
+    ntnx-pe-secret\n  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-cluster-csi-drivers\n
+    \ csi.storage.k8s.io/controller-publish-secret-name: ntnx-pe-secret\n  csi.storage.k8s.io/controller-publish-secret-namespace:
+    openshift-cluster-csi-drivers\n  csi.storage.k8s.io/fstype: ext4\n   storageContainer:
+    default-container\n   storageType: NutanixVolumes\n   #description: \"description
+    added to each storage object created by the driver\"\n   #isSegmentedIscsiNetwork:
+    \"false\"\n   #whitelistIPMode: ENABLED\n   #chapAuth: ENABLED\n   #isLVMVolume:
+    \"false\"\n   #numLVMDisks: 4\n allowVolumeExpansion: true\n reclaimPolicy: Delete\n```\n-
+    dynamic files mode example\n```yaml\nkind: StorageClass\napiVersion: storage.k8s.io/v1\nmetadata:\n
+    \   name: nutanix-dynfiles\nprovisioner: csi.nutanix.com\nparameters:\n  dynamicProv:
+    ENABLED\n  nfsServerName: fs\n  csi.storage.k8s.io/provisioner-secret-name: ntnx-pe-secret\n
+    \ csi.storage.k8s.io/provisioner-secret-namespace: openshift-cluster-csi-drivers\n
+    \ csi.storage.k8s.io/node-publish-secret-name: ntnx-pe-secret\n  csi.storage.k8s.io/node-publish-secret-namespace:
+    openshift-cluster-csi-drivers\n  csi.storage.k8s.io/controller-expand-secret-name:
+    ntnx-pe-secret\n  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-cluster-csi-drivers\n
+    \ csi.storage.k8s.io/controller-publish-secret-name: ntnx-pe-secret\n  csi.storage.k8s.io/controller-publish-secret-namespace:
+    openshift-cluster-csi-drivers\n  storageType: NutanixFiles\n  squashType: \"none\"\n
+    \ #description: \"description added to each storage object created by the driver\"\nallowVolumeExpansion:
+    true\n```"
+  displayName: Nutanix CSI Operator
+  icon:
+  - base64data: /9j/4AAQSkZJRgABAQABLAEsAAD/4QCiRXhpZgAATU0AKgAAAAgABgESAAMAAAABAAEAAAEaAAUAAAABAAAAVgEbAAUAAAABAAAAXgEoAAMAAAABAAIAAAExAAIAAAAVAAAAZodpAAQAAAABAAAAfAAAAAAAAAEsAAAAAQAAASwAAAABUGl4ZWxtYXRvciBQcm8gMi4wLjUAAAACoAIABAAAAAEAAAIAoAMABAAAAAEAAAIAAAAAAP/hCZlodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDYuMC4wIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXA6TWV0YWRhdGFEYXRlPSIyMDIxLTAzLTAxVDA5OjIyOjM5WiIgeG1wOkNyZWF0b3JUb29sPSJQaXhlbG1hdG9yIFBybyAyLjAuNSIvPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDw/eHBhY2tldCBlbmQ9InciPz4A/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ1B2M2Y8AsgTpgAmY7PhCfv/AABEIAgACAAMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgv/xAC1EAACAQMDAgQDBQUEBAAAAX0BAgMABBEFEiExQQYTUWEHInEUMoGRoQgjQrHBFVLR8CQzYnKCCQoWFxgZGiUmJygpKjQ1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4eLj5OXm5+jp6vHy8/T19vf4+fr/xAAfAQADAQEBAQEBAQEBAAAAAAAAAQIDBAUGBwgJCgv/xAC1EQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2wBDAAEBAQEBAQIBAQICAgICAgMCAgICAwQDAwMDAwQFBAQEBAQEBQUFBQUFBQUGBgYGBgYHBwcHBwgICAgICAgICAj/2wBDAQEBAQICAgMCAgMIBQUFCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAj/3QAEACD/2gAMAwEAAhEDEQA/AP7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/0P7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/0f7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/0v7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/0/7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD/1P7+KKKKACiivF/Hv7QXwn+G+oHSPE+qIt2oBe2t1aaRM9N4UHb9DzXjZ7xFgMroPFZliYUYbc05KKv2u2tfIUpJas9oor5W/wCGzPgP/wBBC7/8BZP8KP8Ahsz4D/8AQQu//AWT/Cvh/wDiN3B//Q6of+DYf5mft4dz6por5W/4bM+A/wD0ELv/AMBZP8KP+GzPgP8A9BC7/wDAWT/Cj/iN3B//AEOqH/g2H+Ye3h3Pqmivlb/hsz4D/wDQQu//AAFk/wAKP+GzPgP/ANBC7/8AAWT/AAo/4jdwf/0OqH/g2H+Ye3h3Pqmivlb/AIbM+A//AEELv/wFk/wo/wCGzPgP/wBBC7/8BZP8KP8AiN3B/wD0OqH/AINh/mHt4dz6por5W/4bM+A//QQu/wDwFk/wo/4bM+A//QQu/wDwFk/wo/4jdwf/ANDqh/4Nh/mHt4dz6por5W/4bM+A/wD0ELv/AMBZP8Klg/bH+A88qxf2lcJuONz20gUfU4px8bOD27LOqH/g2H+Ye3h3PqSisfQPEOieKdJh1zw7dQ3lpOu6KeBgyt/gR3B5Hetiv0rD4inWpxq0pKUZK6ad009mmtGmahRRRWwBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUV558U/iz8Nvgj4HvfiT8WtasNA0LTk33epalKIokzwAM8szHhVUFmPABrWhQnVnGnTi5SeiS1bfZIirVjCLnN2S3b2R6HRX4u3/8AwX7/AOCZ1jeSWn/CW6rN5blfNg0e6aNsd1O0ZH4VU/4iBv8Agmd/0NOt/wDgmuv8K+4j4W8SNXWWVf8AwCX+R8s+Pck/6Dqf/ga/zP2tor8Uv+Igb/gmd/0NOt/+Ca6/wo/4iBv+CZ3/AENOt/8Agmuv8Kf/ABCviX/oV1f/AACX+Qv9fck/6Dqf/gaP2tor8Uv+Igb/AIJnf9DTrf8A4Jrr/Cj/AIiBv+CZ3/Q063/4Jrr/AAo/4hXxL/0K6v8A4BL/ACD/AF9yT/oOp/8AgaP2tor8Uv8AiIG/4Jnf9DTrf/gmuv8ACj/iIG/4Jnf9DTrf/gmuv8KP+IV8S/8AQrq/+AS/yD/X3JP+g6n/AOBo/a2ivxS/4iBv+CZ3/Q063/4Jrr/Cj/iIG/4Jnf8AQ063/wCCa6/wo/4hXxL/ANCur/4BL/IP9fck/wCg6n/4Gj9raK/FL/iIG/4Jnf8AQ063/wCCa6/wo/4iBv8Agmd/0NOt/wDgmuv8KP8AiFfEv/Qrq/8AgEv8g/19yT/oOp/+Bo/a2ivgP9l//gp3+xT+1/4jPgv4K+MrW51zY0kWi6lFJY3s6IMsYY5gvmbRyQhLAZOMAmvvyvk81yfF4Gq6GNoypz7STT+5n0GAzLD4qn7XDVFOPdNNfgFFFFeadp//1f7+KKKKAMHxTqN3o/hjUtWsE8ye1sLi4hj67pI42ZR+JAFfztalqN9rGoT6rqcrz3NzK0880hyzu5yzE+pJr+kIgMCrDIPBBr8l/wBpX9lPUvBlxdeO/h/E1xo7u091ZxjMlnuOSVA+9EPblR145r+E/pveHec5rgMFmeXxdSlhuf2kFulLl9+3VJJqXVLXa7XFjKbaTXQ+GKKKK/yrPMCiiigAooooAKKKKACiiigAooooA94+CHx88V/BbWN9gxutLncG902RvkftvT+64Hfv3zX7P/D34i+Ffid4ci8S+E7lZoZABJGeJYZMcpIvVWH5HqMiv56K9K+F3xV8W/CXxHH4h8LTY5AubWTJhuI+6SKMfgRyD0r+sfo8/SdxvCdSGW5k3VwTe28qd+sPLq4bdVZ3v1UMS46PY/oGorxz4N/Gvwl8ZtB/tLQnEV3Cq/btPkYGWBj3/wBpCc7Wxz9eK9jr/XfIOIMFmmDpZhl1ZVKVRXjJbP8A4K2aeqej1PVjJNXQUUUV7AwooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiivz3/AOCgv/BR34F/8E+fhv8A8JH8QbmPUPEmowyHw34RtZVF7fuvHmMOTFbq3DzMMZ4Xc3Fenk+TYrMMTTweDpudSbskt/8Ahu72S1Zw5lmVDB0J4nEzUYR1bf8AX4dT239rD9rv4G/sYfCi8+Lnxy1aOws4EZbGxjw99qVzjKW1pDnMkjnjPCqPmdlUFh/nvf8ABRT/AIKZ/HH/AIKE+P8A7d4umk0nwhptw7+HfCFtIfs1sDkCefGPOuWXgyN90ZCBQTnwz9sT9tH46/twfFm7+K/xt1Mzu7smlaPbZj0/S7Un5Le1hycKoxl2Jdz8zsSc18nV/ot4O+BuF4ehHG4y1TEtb7qHlHz7y3eysr3/AIz8SPFSvnEnhsNeFBdOsvOXl2j992FFFFfv5+QhRRRQAUUUUAFFFFABRRRQAUUUUAdl8O/HXiv4Y+O9I+IfgW6mstY0XUYNS026tyVkjngcOhGOeowR3HFf6w/gnVtQ1/wZpGu6tA1tdXul2t3c2z/eilmiV3Q+6sSK/i7/AOCPP/BEjxT8XtX0L9qn9qe1m0rwjbTQav4d8MToUutaKESQzXCsMxWhIDAfelGMYU5r+2lVVFCIAABgAdABX+f/ANKLjLLcxx2GweCkpzocynJbXdvdv1tZ36Ju29z+vfAjhrG4LC18Tik4xq8vKnvpf3rdL30727WHUUUV/K5+9n//1v7+KKKKACmuiSIY5AGVgQykZBB6ginUUNAfm5+0n+yIHE/jv4UW/wA3Mt9o8XfuZIB/NP8Avn0r81ZYpIZGhmUq6MVZWGCCOCCPUV/SbXxN+0b+yhpvxCE3jLwEkdrre0vPbDCQ3hA/AJIf73Q9/Wv89PpH/RIjiva57wpStU3nRW0u8qa6S7w2f2bPR8OIwt/eifkRRV7U9M1HRr+XStWgltrmBzFNBOpR0ZTghlIBBFUa/wAzatKUJOE1ZrRp7o80KKKKgAooooAKKKKACiiigAooooA6bwh4w8ReBNfg8S+F7mS1u4DlXQ8Mp6qw6Mp7g8V+yP7P/wC0j4d+Mmmppt9ssdehT/SLIn5ZsdZICeSp6leq+45r8SKvaZqeo6Nfw6rpM8ttc28glhnhYo6OpyCrDkEV+8eB/j5mvBeMvRftMNN+/Sb0f96P8s132ezT0tvRruD8j+kKivib9nH9q/TviGIfBvj147TW9oSC5OEhvMD8Akn+z0Pb0r7Zr/ZPgHxByriXLoZnlFbnhLdfai+sZLo1+O6bTTPWhNSV0FFFFfalhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRX85P/AAVt/wCC3/hr9l8aj+zz+y9cWms/EHy2ttV1tCs9joDOMFRjKzXi/wBz7sZxvyflr6jhDg7H55jY4HLqfNJ7vpFd5Pol/wABXZ4XEfEmEyrDSxWMnyxW3dvsl1f9PQ+pP+CpX/BXf4W/sDeFp/BPg82fiP4m3tv/AMS7QBJug04SD5brUSh3KoHzJCMPJxyqndX8Bvxx+OnxT/aP+JWo/Fv4yavc61rupy+ZcXVy3CqPuxRIPljjQcKigACuC8VeKvEvjnxHe+MPGN/d6pqupXMl5f6hfStNcXE8p3PJI7klmJPJJrAr/Srwu8Jsv4Zw1qS560l79RrV+S7R8uu7vpb+JOPPELF55XvU92nH4YLZeb7vz+4KKKK/Vj8/CiiigAooooAKKKKACiiigAoorr/APgDxr8UvGGn/AA/+HWl3uta1qtylnp+m6fEZZ55pDhVVR+ZJwAMkkAZqKtWMIuc3ZLVt7IuFOUpKMVds5zT9Ov8AV7+HS9Lhlubm5lWC3t4FLySSOcKqKvJYk4AHWv7GP+CRX/BCa08JRad+0t+21psFzqjNHe+HPAd0olitF4ZLjU1YbXmJ5W35VBguSxKL9d/8EnP+CKHgr9jq3svjj+0Lb2Gv/Ex4RJaW523Nh4eLj5lt+qSXQHytOMheREQCWb+gGv4a8afpDSxPtMqyCpaG0qi3l3UO0e8t3001f9U+GXg5GhyZhm8bz3jB7Lzl3flsuuuzURI0EcYCqoAVQMAAdABTqKK/j8/owKKKKAP/1/7+KKKKACiiigAooooA+Z/2gP2bvDvxk01tSstljrsKf6NegfLLj/lnOB1U9A3VfcZB/G7xh4O8ReBNfn8NeKLaS1u4GwyOOGXsynoynsRX9FNeO/GP4KeE/jNoP9m66nlXcKt9h1CNQZYGPb/aQnqvf2PNfx59Ir6LeF4mjUzbJkqWMWrW0avlLtPtLrtLo1yYjDKWq3PwRor0r4o/Cnxb8JPEcnh7xRDgZJtruMEw3EfZ0Y/qDyD1rzWv8lM4yfFZfiqmCxtJ06lN2lGSs013PLaadmFFFFeaIKKKKACiiigAooooAKKKKAHxyyQyLNCzK6kMrKcEEdCCK/Sn9mz9rtXEHgP4r3GG4isdZlPXsI7g/wAn/wC+vWvzTor9K8LvFbN+EsxjmGV1N9JwfwTXaS/J7p7GlKq4O6P6TkdJEEkZDKwBVgcgg9CDTq/JL9nD9rG/8Cvb+CviHLJc6LkRW942XlsgeAD3aIenJUdOOK/WDTtRsNXsYtT0uaO4t50EkM0LB0dW5BBHBFf7NeEHjNlHGWA+tZfLlqRtz02/eg/1i+klo/J3S9elVU1dF2iiiv1w1CiiigAooooAKKKKACiiigAooooAKKKKACiiigAqG4uLe0t3urt0iiiQySSSEKqKoyWYngADkk1g+MPGPhX4f+Gb3xn431C00rSdNt3ur/UL6RYYIIkGWd3bAAFfw4f8FbP+C3vin9qS41T9n39l66vtF+HQeSx1PWF3W174ijUlXBAIeGyk7RnDyp/rQoJjH6N4ceGWY8S4v2GEjywj8c38MV+r7Lr5K7PjONOOcHkmH9riHeT+GK3l/ku7/N6H17/wV2/4LtiePUf2Z/2I9SYAmSz8S+PrV8bl5V7bS2HPPO+49OI+pYfyN3FxPdzvdXTvLLI5kkkkJZnZjksxPJJPJJqGiv8AS3gXgHLuHsEsHgIW/mk/ik+7f5LZdD+IeK+LsZnGJeJxcvRLaK7Jfm92FFFFfanzAUUUUAFFFFABRRRQAUUUUAFFFfaH7EP7CXx0/bx+LEHw2+ENg62kTpJrviK6Rhp+lWxPzSzSAYLkfciX53PAGMkcGZ5ph8Fh54rF1FCEFdt7JHXgcDWxNaNDDwcpSdkluzyL9nX9m/4xftVfFGw+EHwR0a51nWb5slIhiG2hBAe4uJT8sUKZyzsfYZJAP+gP/wAEyf8AglD8HP8Agn54Kh1u6jg8QfEXULYDXPFMyZEO/k2tgjf6mBehb78h5Y42qv0D+wl+wB8Cf2A/hcvgT4T2nn6neJG/iDxLeKpv9TnQdXYD5IlJPlxL8qg9yST9y1/nl4y+O+Iz2UsBlzdPDL5Sqecu0e0fm+iX9j+GvhPRymMcXjEp1390PTu+7+S7sooor+cz9mCiiigAooooA//Q/v4ooooAKKKKACiiigAooooA4b4hfDrwr8TvDk3hnxZbLNDID5cg4lhfHEkbdVYfr0ORX4wfHD4B+K/gtrGy+ButLnciy1KNfkbuEcfwuB1HfqK/disTxH4b0Pxbo0/h/wAR20V3Z3KbJYJhlSPUehHUEcg9K/njx3+jzlnGeFdVWpYuC9ypbf8Auz7x/GO66p4VqCmvM/nKor6z/aH/AGYNc+E95J4h8OLJe+H5Gysv3pbUn+CUD+H0foe+D1+TK/xy414IzPh7MKmWZtRdOpD7mukovZxfRr87o8icHF2YUUUV8mSFFFFABRRRQAUUUUAFFFFABX1D+z7+0r4h+D1+ukaoXvtBmf8AfWjHLwE9ZISTwfVeh9jzXy9RX0/B/GWZZDj6WZ5VXdOrDZrZrqmtnF9U9CoTcXdH9FvhPxb4f8caDb+JvC9zHd2dyu6OWM5wR1Vh1VlPBU8g10dfgx8GPjj4t+DGufbtGb7RYzODe6bKxEUy+o/uuB0YfjkcV+0nw0+KHhL4reHU8ReFJ968Ce3fAmgcj7ki5OD6Hoe1f7FeAn0i8t4yw6w9S1LFwXvU76S7yp33j3W8et1Zv1qGIU/U9Dooor+jzoCiiigAooooAKKKKACiiigAooooAK8f+O/x7+E/7NHww1L4wfGrWbXRNB0uPfPdXLfNJIfuQwxjLSzSHhI1BYn2ya8p/bG/bV+BP7D3wquPij8bNTSAFXTSdGt2VtQ1S5AysFtESCSTjc5wiDliK/z1f2/f+CjHx3/4KBfEhvFHxIuTYeH7KZ/+Ee8KWTn7FYRHgMenmzsv35WGT0AVeK/bPCTwXxvElZVql6eGi/en1f8Adh3fd7R83o/zDxD8TMNklP2ULTrNaR7ecuy8t3+J9Ff8FRv+CufxY/b78VyeDvC8l34d+Genzn+zfDsb7JdQdTxd6iyn945H3Is7Ix0BYsx/HWiiv9IeHeHMFlWEhgcBSUIR2S/Nvq31b1P4qznOsTmGInisXUcpS6/ouyXRBRRRXtnlhRRRQAUUUUAFFFFABRRRQAUUV+8v/BJz/gjB48/bT1ez+M3xuS68PfDC2cTRttKX2vup4htM48u3/wCelwc8fKgJJZPneKeKsDk2Dnjswq8kI/e30SXVvt+h7OQ5Bi8zxMcJg4c0n9yXdvokfMn/AATU/wCCWXxk/wCChvjU3WnibQfAemXawa/4umiLIGADNbWathZrnaQSM7UBBcjIB/0F/wBmn9mL4M/sk/Cqw+D3wP0iLS9JsY18x+GubyfGHuLqXAMs0h5ZjwOihVAFejfDX4a+BPg94F0z4afDPS7TRtC0i2W00/TbGMRxRRrzwB1ZiSzMeWYkkkk13Nf5s+K3jBjuJsRyu9OhF+7D/wBul3l+C2XVv+2eAPDnC5HR5l79aS96X6R7L8X16JFFFFfj5+jBRRRQAUUUUAFFFFAH/9H+/iiiigAooooAKKKKACiiigAooooAr3dpa39tJZX0Uc0MqGOWKVQyOrDBDKeCCOoNflf+0h+yRc+FBceOfhjBJPpgJlu9NTLy2oPJaMHLPGO45KjnkAkfqxSEBgVYZB4INflPi14PZRxhl7weZQtON+Sovig/J9U/tRej8mk1nVpKasz+bEgg4NJX6iftJ/sjQ6x53jr4VwCO7+aW+0mPhJu5eAfwv6r0btg9fzAngntZ3trlHjkjYpJG4KsrKcEEHkEHqK/xl8VvCPN+EMxeBzOn7r+Ca+Ga7p911i9U/KzfkVaTg7Miooor8vMgooooAKKKKACiiigAooooAK7/AOHHxK8V/CzxJF4l8KXBikX5ZoWyYp4+6SL3B/MHkciuAorvyvNcTgcTTxeDqunUg04yi7NNdUxptao/d/4JfHfwp8adE+06awttRgUfbtNkb54z/eT+8h7EdOhxXuNfzneGfFGveDtag8Q+GrmW0u7dt0csRwfcEdwe4PBr9h/2ev2mtB+LtlHoWtmOy1+NMSW+cR3O0cvDn8ynUe45r/WT6Of0qMNxHGnk+eyVPGbRltGr6dIz7x2e8f5V6mHxPNo9z6qooor+zTrCiiigAooooAKKKKACvzU/4KOf8FNvgp/wT0+Hov8AxNLFrHjHU4X/AOEd8I20oFxORx59xjJgtlPWRh8xyqZOcfN3/BVf/gsb8Of2FdCvPhb8MPsfiL4o3Vttt9PL77TRfNXKXN/tOSwBDJbghn4LFVOT/BF8W/i58R/jr8QNR+KXxY1e71vXdVnM97qF65d2J6Ko6KijhUUBVHAFf014MeAdbOXDMs2i4YfdLaVT/KPnu/s91+HeJni5Sy1SwWXtSrdXuof5y8unXseoftXftbfG39s34t3vxh+OGqPfX9wTHZ2UWUstPtgfktrSHJEcaj6sx+ZizEmvmiiiv9BMDgaOFoww+HgoQirJJWSXZI/kDF4urXqSrVpOUpO7b3bCiiiuo5wooooAKKKKACiiigAooooAKcqs7BEBLE4AHJJPYVo6LouseJNXttA8P2txe317OltaWdrG0s00shCoiIoLMzE4AAya/tG/4JF/8ELdK+Ea2H7SH7ZunW2oeKCI7zw/4NuQs1rpP8Sz3q8rLdDgrHykXfL/AHfgfEHxGy7hzBvFY2V5P4YL4pPy8u72XrZP67g/gzGZ1iVQwsdF8UntFefn2W7/ABPj7/gkb/wQp1H4nrpP7S/7Z+nSWnhxjHqHh/wRdBkuNTUENHPqCHBjtm4Kwn5pB98BDhv7O9N0zTdG0+DSdHt4LS0tolgtrW2jWKKKNBhURFAVVUDAAGAKuKqqoVQAAMADoBS1/ml4geIuY8R4x4rHS91fDBfDFeXn3e79LI/t7hDg3B5LhvYYWOr+KT3k/Py7LZfeFFFFfBH1gUUUUAFFFFABRRRQAUUUUAf/0v7+KKKKACiiigAooooAKKKKACiiigAooooAK+O/2i/2WdI+KEU3ivwiI7PX1Xc4+7FebR0k9HPQP+dfYlFfIcc8CZXxHl1TLM2oqpTl98X0lF9JLo/k7ptEzgpKzP5w9a0TVvDuqTaLrlvLa3du5jmgmUq6sPUGsuv3J+PP7PPhn40aSZvks9ZgT/RNRVeuOkcoH3kP5r1HcH8ZvHXgTxN8OfEU3hfxXbNb3UPIz9yRD0dG6MpxwR/Ov8bvHT6P2acGYvmlerhZv3KqX/ks/wCWX4S3XVLyK1BwfkcfRRRX8/mAUUUUAFFFFABRRRQAUUUUAFWrG+vdMvItR06WSCeCRZYZoWKOjqchlYYIIPQiqtFXCcoyUouzQH6x/s3ftaWXjMQ+CfiTKlvq20Ja6g+FiuyONrkYCSn8Fbtg4B+7a/mxR2jYOhIYHII4IIr9Ff2bP2u309YPAnxXuN0AIistYl+9GOixznuo7OeR/FxyP9KPo4fS4VX2WRcWVbS2hXfXtGq+/afX7WvvP0cPiukz9OaKjiliniWaBldHUMjocqwPIII6g1JX+iiaaujvCiiimAV5h8bvFOt+Bvgz4u8a+Go/N1HSPDOqapYRY3bri1tZJYht75dRx3r0+op4IbmF7a5RZI5FKSI4yrKwwQQeoI6itsPUjCpGco3Sadu/kZ1oOUJRi7Nrfsf5I3i/xT4i8ceK9T8Z+Lru4v8AVdWv59R1K9u3Mk09zcyGSWSR25ZmdiST1Nc7X9LX/BXr/giF4n+Auo61+0x+ylY3ereB5ZptU1zw3bqZrvQFcmSWSFVG6SxTJPd4U+8Silh/NLX+u3BfGGXZ3gYYzLZpx2a2cX/K10a+7qrrU/zs4n4cxmV4ueGxsbS3v0ku6fW//D6hRRRX1h88FFFFABRRRQAUUUUAFFFFABXffDD4W/EP40eOdP8Ahr8KtHvtd13VZ1trDTNPjMksrscewVR1ZmIVRySAK9M/Zd/ZY+NH7YXxZsvg58DtIn1TU7n99dTKpFrYWqsA91dy42xQpkDcx5YhVyzAH/QW/wCCbP8AwS6+Cv8AwT1+H6jSUTXfHOpQg+IfFt0g81iQM21muP3Fsh6AZdzlnY/Kq/j3iv4w4HhmhyaVMRJe7D/26XaP4vZdWv0jw/8ADfFZ5V5vgox+KX6R7v8ABdeifzX/AMEpf+CMfw7/AGI9MsvjB8YorPxD8UZoA4uf9bZ6F5q/NDZA8NMAdr3GM9QhCklv3Uoor/NnijirHZzjJ47MKrnOX3JdEl0S7fqf2xkOQYXLcNHC4OHLFfe33b6t9wooor549gKKKKACiiigAooooAKKKKACiiigD//T/v4ooooAKKKKACiiigAooooAKKKKACiiigAooooAK8r+LPwf8IfGDw+dF8SxbZYwxs76MDzrdz3U9weMqeDXqlFeXneSYTMsJVwOPoqpSqK0oyV01/Wz3T1WopRTVmfgN8Wvg74v+D3iBtG8SRb4XYmzvogfJuEHQqT0bHVTyD+Bryiv6IfHPgXwx8RfDs/hjxZapc2sy8bh88b9njbqrDsR9OhIr8Z/jz+zx4n+DGqfaMPeaNO5FpqCD7p/55zAfcf07N27gf5HfSI+i9jOFpzzTKU6uCb16ypX6S7x7T+UrOzfl18M46rY+dqKKK/kQ5AooooAKKKKACiiigAooooAKKKKAPs/9nL9qrVfhvPB4Q8bPJd6CxCRynLTWWehXu0fqvbqPQ/rfo+saXr+mQ6zos8Vza3CCSGeFgyOp7giv5wa+kPgH+0X4l+DGpCyl33uiTyA3VgzcoT1khJ+63qOjd/Wv7h+jl9K6tkbp5JxHN1MLtGpq5UuyfWUPxj0urI7cPiraS2P3AorlPBfjXw38QfD0HifwrcpdWlwuQy/eRu6OvVWXuDXV1/qrgcdRxVGGIw1RThNJxkndNPZprRpnpphRRRXUAyWKOeNoZlV0dSrowyGB4IIPUGv5Mf+Cu3/AAQlttZi1H9pj9iXTfLvgZL3xJ4BtVAjnHLPc6Yo+7J3e36MOY8EFW/rRor7PgbjzMeH8asZl87fzRfwyXaS/J7roz5rirhPB5xhnhsXG/Z9Yvun/SfU/wAii8s7zTryXT9QilguIJGhngmUpJHIhwyurAFWUgggjINVq/vM/wCCtH/BEvwj+1zFffHr9nKK00L4kJEZb+wAWGx8QFBx5mMLFdEcCXo/Af8AvV/C3418E+Lvhx4rv/AvjzTrzSNY0u6ks9Q02/iaGeCaIlWR0bBBBH49RX+l3hv4nZfxLhPb4V8tSPxwe8X+sez++z0P4h424FxmSYj2VdXg/hktn/k+6/NanL0UUV+jnxQUUUUAFFFFABX3d+wZ/wAE+Pjp+398UY/BHwwtjZ6NazRnxF4pu42NjpluxG4kjHmzFf8AVwqwLHGSq5YfQv8AwTB/4JM/Fv8A4KC+LB4l1Lz/AA78OtNuVj1fxLLGd9068ta2CtgSS4+8/wByPIzk4U/6An7P37Pfwk/Zf+FumfB34K6Rb6PoelxBIoYRmSaT+Oe4k+9LNIeXdiST7YFfzl4y+PGHyKM8vy5qpiXv1jT833l2j832f7R4a+E9bNXHGY1OFD8Z+nZd393deSfsWfsOfAr9hP4VxfDP4MWGJJQkms67dhW1DVLhBjzbiRQOBk7UXCIDgDqT9iUUV/nlmWZ4jGV54rFVHOc3dt6ts/sbBYGjhqUaGHgoxjoktkFFFFcJ1BRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//1P7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigArL1rRNJ8R6XNouuW8V1a3CGOaCZQysp9Qf51qUVlXoQqwlSqxUoyVmnqmnumuqA/Hb9oz9ljVvhlcTeK/BqS3mgMxd1GXlss/wv3ZB2ft39a+OK/pLnghuYXt7hFkjkUo6OAVZTwQQeCDX5hftJfsiyaMs/jv4VwNJagmW90mP5mhHUvCOpQd16gcjjNf5i/SP+iVPA+1z3hak5UtXOitXDq5U+8e8d49LrRediMLb3on540UrKysVYEEHBB6g0lf5/HAFFFFABRRRQAUUUUAFFFFABRRRQB658IfjN4u+DniBdW8PyeZbSMv23T5GPlXCDqD/dbH3WHI9xxX7S/Cv4t+Efi94eXXfDEvzKALqzkI863c/wALgdvRhwa/n+rtPAPxA8UfDTxHD4o8J3L29xH8rqOUljJ5jkXoynHQ98EcgGv6g+j99JTH8H1o4LF3rYKT1h1hfeVO/wB7jtLyep00MQ4aPY/ocor5/wDgV+0F4W+NGjgQEWerwKPtmnSEZ/66RH+JD+YPBHQn6Ar/AGB4Y4owGc4GlmWWVlVpVFdNfk+qa2aeqejPVjJNXQUUUV75QV+RX/BT/wD4JM/Cb/goF4Om8R6OLXw78SbC2xo3iZY/3d15Y+W11EIN0kTfdWQZeLgjcBsP660V7fD3EWMyrFwx2AquE47Nfk11T6p6M8zOMnw2Pw88Li4KUJdP1XZroz/KJ/aB/Z7+Lf7MHxQ1D4QfGrSLjRtb058PDMMxzREkJNBIPlkifGVdSQfqCK8Vr/Tw/b2/4J7fAr/goB8Mf+EM+KFolrrNgkjeHPFNrGv2/TJnHIV+C8DkDzIWO1sA8MAR/nq/tq/sN/Hb9hP4s3Pww+Mun/uWdpNF1+zDPp2q2oPyzW8hAwcffjYB0bgjGCf9H/CPxpwfElFUKtqeJitYdJf3od13W681q/4r8RPDHE5JUdWnedBvSXVeUuz7PZ+Wx8c0UVLDDNczLb26NJI7BERASzMTgAAckk1+3H5cRV/Qr/wSW/4Im+Mv2s9Q0748/tHQXWh/DWJ1ubPT2DRX/iHByqxZGYrQ/wAcp5cfKg5Lr9b/APBIv/ghFL4kh0z9pb9t/Stlg7JfeHfAF8PnuUGGjuNUj/hjbgrbNyw/1oAO0/2GWlpa2FrHY2MUcMEMaxQwxKEREQYVVUcAADAA4Ar+PvGn6Q0cN7TKcgqXntOoto91DvLvLZdLvVf0d4ZeDjrcmYZvC0d4we785dl5detlo+c8DeBfB3wz8I6f4D+H+m2ej6Npdslpp+m2ESwwQRIMBVRQB7k9Sck5Jrq6KK/hupUlOTnN3b3b6n9UQgopRirJBRRRUFBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQB/9X+/iiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD4K/aR/ZJtfFvneOPhpEsGp4L3emoAsV0eu+P+7J6jo3sc5/Ky7tLqwupLG+jeGaGRopYpVKujqcMrKeQQeCDX9JFfJ/7Q/wCzFofxbtJfEPh/y7LxBGmUmxiK62jhJsd+wfqO+RX8F/SP+iZTzT2ue8MU1Gvq50lpGp3cOin3W0vKXxcWIwt/eifi/RW54j8N654S1mfw/wCIraW0u7d9ksMowQfUeoPYjg1h1/l1icNUo1JUa0XGUW001ZprdNPZo8xoKKKKwAKKKKACiiigAooooAKKKKANfQdf1nwxq0OueH7mW0u7dxJDPC21lI/n7joa/X79nb9qPRfipbw+GPFLRWXiBU2heFivNo5aL0fuU/Livxqqe1urmyuUvLOR4pYnEkckZKsrKcggjkEGv2rwY8cc24Mx3tsI+ejNr2lJv3ZLuv5ZJbSXo01obUazg9D+kmivz9/Zt/a4t/EPk+BvilOkV/8ALFZao+FS4PQJKeiyejdG+vX9AQQRkcg8giv9l/DjxLynirLoZllNXmjtKL+KEv5ZLo/wa1TaPWp1FJXQtFFFffmgV87/ALT37LHwT/a/+FV98IPjno0Gq6Zdxsbeb7l3Y3GCEubWYfNFKh5BHB+6wZSVP0RRXVgsbWw1aGIw83CcXdNOzTXVMwxOFp16cqNaKlGSs09U0fwS/Hj/AIN0P23/AAJ4/udL+DKaR4x8OyTt/Z2qG9isrlYSflFzBLt2uBjcULAnOPSv2e/4JW/8EJfC37L2rQ/HP9q5NM8S+N4CH0XRoT9o0rRnHPnncqi4ueysw2R9VUvhl/o8or9k4h+kHxJmWX/2fVqximrSlFWlJdm76X62SvttofmuT+D+S4LGfXKdNyad0pO8YvyVunS7dvUQAAYHQUtFFfiJ+ohRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH/1v7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigDwj44fATwr8adF8q+VbXVIFP2LUkX50/2H/vxk9j06ivxg+Ifw58VfC/xHL4Z8WW5hmQ5jkHMU0fZ427qfzHQ81/QtXmvxR+FXhP4s+G5PD/ieBWO0m1ulAE1vIRw6N1+o6Eda/k/6Q30Y8FxZTnmWWpUsalvtGpbpPz6Ke/R3VrctfDqWq3P5+aK3/FXh+78J+JtQ8MX+DNp95NZykdC0LlCR9cVgV/jvisLUoVZ0asbSi2muzTs1955LQUUUVzgFFFFABRRRQAUUUUAFFFFACgkHI6iv0B/Zu/a5uPDot/AvxQnaWwBWGz1WTJktweAkx5LRjs3VR1yOn5+0V9/4ceJebcK5jHMspq8stpRfwzj/ACyXVfit009TSnUcXdH9JVvcW93Al1aSJLFIoeOSNgysp5BBHBBHQipq/Jj9j347+INC8XWfwu1yVrnStRYwWfmHLWs5GU2n+45+Ur2JBGMEH9Z6/wBqPBrxbwXGWTxzTCQcJRfLOD15ZpJtX6pppp9V2aaXr0qqmroKKKK/WTUKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//1/7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigArh/iF8Q/C/wAMvDU3ifxVcJDDEp8qPP7yaTHEca9WY/p1PFcx8YfjR4S+DWgf2pr7+bdTBhZafGR5s7L6eig4yx4H14r8Wvil8WPFvxc8Rv4g8UTcAkWtpGT5NvH2VAf1J5Jr+XfpBfSVwHCFGWBwdquNktI9IX2lP81Hd+S1OaviFDRbnL+MfEdx4v8AFmpeKrobZNRvpr11HRTM5bH4ZxXN0UV/jVjMXUxFadetK8pttvu27t/eeS3fUKKKK5hBRRRQAUUUUAFFFFABRRRQAUUV9wfs4fsnaj48e38afEGKS20XIlt7RspLegdM91iPrwWHTA5r7fw/8PM14mzGGWZTR55vd/ZiuspPol972SbaRdOm5OyKX7HvwW8QeKPHdn8RL+JoNI0mX7RHM4x9ouFHyJH6hT8zN04x1Nfr7VLTdN0/R7GLS9Khit7eBBHDBCoREVegUDgCrtf7U+CXhDheDMmWWUKntJyfNUm9OaTSWi6RSSSXzerZ7FGkoKwUUUV+wGoUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//0P7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACvmr4/ftHeG/g1pjWFrsvtdmT/RrFT8sW7pJMR0UdQvVunAyRwH7Rv7VumfDhZvB/gZ47vXNpWacYeGyJHfs0n+z0Hf0r8k9V1XUtc1GbVtYnlubm4cyzTzsXd2bqWY8k1/Dn0jvpX0ckVXJOHJqeJ1U6m8aXkukpr7ove7ulx4jE20jubPjLxn4j8feIJ/E3im5e6u5z8zueFUdEQdFUdgOK5aiiv8rMbja2JrTxGIm5zm2227tt7tt6ts8xu+4UUUVyiCiiigAooooAKKKKACiiigAp8cck0ixRKWZiFVVGSSegAFW9N03UNYv4tL0mCW5uZ5BFDBApd3djgBVGSSa/Wf9nH9k/Tvh8IfGXj5I7rWtoeC1OHhsye/cPJ79F7c81+v+D3gtm/GWP8AquAjy0429pUa92C/WT6RWr62V2taVFzdkeafs2fsiACDx38WLfniWx0eX8xJcD+Sf99elfpIiJGgjjAVVAVVUYAA6ACnUV/sz4X+FeUcJZdHL8qp26zm/inLvJ/ktktkevTpKCsgooor9INAoorxz49fH74S/sy/C/U/jD8atZtND0LSoTJNc3LfPK/8EEEY+eWaQ/KkaAsx6Ct8LhalapGjRi5Sk7JLVtvZJdzKvXhShKpUklFatvRJeZ7HRX8Qvx4/4OY/2n9Y+IFy37O/hzwtovhmC4ZbJPEFrNf39zEp4aZkniSPcOSiAkf3jX7J/wDBLv8A4Ld/Db9tjUIvg98aotO8HfEN1/4l9ukrLpus7R8y2jyklJx18hmLMOULYIH61xB4E8SZbgP7RxGHTgleSi7yiu7S6Lra9up+e5R4r5JjcX9So1veeibVlJ9k3+F7X6H7z0UUV+PH6OFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAf/0f7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooqnqGoWOlWUuo6nNHb28KGSaaZgiIq8ksx4AFRUqRhFzm7JbsC0zKil3ICgZJPAAHc1+cf7Sf7Xa24n8CfCi4zJzFfaxH0XsY7c9z6v+XrXmv7SH7Wd943a48E/DmWS30fLRXN8uUlvB0IXusR/AsOuBxXwvX+av0j/pcOt7XIeFKto6qdZbvvGm+3efX7Omr8/EYr7MCSWWWeVp52Z3dizuxyWJ5JJPUmo6KK/ztbbd2eeFFFFIAooooAKKKKACiiigAooooAK6bwj4Q8ReOteg8NeF7aS6u7hsLHGOFHdmPRVHcngV0Xwv+Ffiz4teJI/DvhaEtyGubpwRDbx93dv5Ack8Cv2j+DXwS8J/BjQf7O0RBNeTKv27UZFAlmYdv9lAeig/rX9JeAf0csx4yxCxNW9HBwfvVLaytvGnfd93tHrd+6+ihh3PXocV+z/+zb4d+DmnJqd/svtemT/SL0j5Ydw5jgB6AdC3VvYcD6aoor/YjhDg/LsiwFLLMqoqnShsl1fVt7uT6t6s9aMFFWQUUUV9MUFFFfmX/wAFIP8Agp58F/8Agnp8PTda88Wt+NNRhb/hHfCNvKFmmbGBcXRGTDbIerEbmPyoCcketkeR4vMsVTwWBpOdSbskv60S6t6Jbnn5pmuHwVCeJxU1GEd2/wCt+y6nvP7Zn7bXwL/YZ+FU3xQ+NGorGXDx6Potuym/1S4UZ8q2iJycZG9z8qAgsRkA/wCen+3z/wAFEvjt/wAFAfibJ4v+Jdx9g0K0mk/4R3wpZOxstOgJwuc/62crjzJmALHO0KuFHi/7VP7V3xp/bI+Ld58YvjfqkmoajcfubS2UlbWwtQxKW1rFkiOJck4HLElmJJJr5ur/AEa8H/BHCcO01isTapiWtZdIeUP1lu/JaP8AjDxG8UcRnM3h6F4UFsusvOX6LZeb1Crunajf6Rfw6rpU8ttdW0qz29xAxSSORDuV0ZeQwIyCOlUqK/d2k1Zn5OnbVH9k/wDwSJ/4LsWnjBNO/Zp/bZ1KC21UGOy8OeO7phFDdrwqW+psflSYHhbj5VcYD4YF2/q3R0kQSRkMrAFWByCD0INf5ENf00f8Ejv+C5eu/AmTSv2bv2uryfUvBeY7DRPFc5aW70NeFjiuDy0tmvAzy8Q6ZUYH8Z+NP0eOf2mbcP09d50l17uC7949fs9j+l/DLxkceTL84nptGo/yl/8AJff3P7eKKydB17RPFOi2viPw3d29/p99AlzZ3tpIssM0UgyrxupKspByCDWtX8TSi4tpqzR/T8ZJq6CiiipGFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//0v7+KKKKACiiigAooooAKKKKACiiigAooooAKKKKACiivPviT8TfCfwr8OyeI/Fc4jQAiCBMGaeQDhI17n36DvXn5rmuGwOGqYzGVVTpwV5Sk7JJdWxNpas6DxV4q0DwVoVx4k8T3MVpZ2y7pJZTgZ7Ko6lieAByT0r8df2g/wBpjxB8X79tG0gvY6DC/wC6tVOJLgj/AJaTEdf9lRwPc81w3xo+Oni340a19r1dvs9hC5NlpsbExxA8ZY/xOR1b8gBXidf5NfSK+lRieJJVMnyOTpYPZvaVX16xh2ju95dl5mIxPNpHYKKKK/jQ4wooooAKKKKACiiigAooooAKKKKACvdvgj8BPFfxp1jy9PBtdMgcC91KRTsQd1T+8+Og7d8V3f7PP7MWu/Fm8j8QeIVkstAjbLTH5ZLog/ciHp/efoO2TX7B+G/DWh+ENFg8PeHLaK0s7ZNkUMQwB6k+pPUk8k9a/tH6Of0VsRxE6ec59F08JvGO0qvp1jD+9vL7P8y7MPhub3pbGD8PPhz4U+GHhyLw14TtlhhQAyynmWZ8cvI3UsfyHQYFd1RRX+sOWZZh8Fh6eEwlNQpwSUYxVkkuiSPTStogoooruGFFISFBZjgDkk1/MT/wVz/4LnaJ8Fkv/wBnD9ju/h1HxeRJa6/4ug2yWejE/KYbRuRNdjnc2NkXHLPkJ9bwZwTmGfY2OCy+nzN7v7MV3k+i/F7JNnz3E3E+DynDPFYydl0XVvsl1f5bs+sv+Cq3/BZT4cfsNaTd/Cf4Vm18RfFC4t9sdjuD2eieauUnviDy4BDJAOW4LYU8/wAE3xU+K/xF+N3j3Ufid8VtXvdc13VZ2uL7Ub6QvI7E9B2VV6KqgKo4AArktd13W/FGtXXiPxJd3OoahfXEl3e315K00880rFnkkkclndmJJYkkmsqv9K/DLwqy/hnC8lBc9WS9+b3fku0ey++7P4j454+xmeV+eq+WnH4YLZeb7vz+6wUUUV+oHwgUUUUAFFFFAH7d/wDBKf8A4LF/Eb9hXXoPhh8TjeeI/hhezBZtOL77rRnc83NiWOCn/PSAkKw5Uqw+b+9z4RfF74cfHj4d6X8V/hNq1prWg6xbi4sb+zcMjDoysOqujAq6NhlYEEZFf5NFfpP/AME6f+Cmvxv/AOCevj4X3hSSXWfB+oXKSeIfB9zMy21wOFaa3JyILkKMCQL82AHBAGP5n8Z/AOjnKnmWVJQxG7W0anr2l57Pr3X7h4aeLlXLXHBZg3Kj0e7h/nHy6dOx/pc0V80/sqftb/A/9sz4V2nxc+Bmqrf2E6qt3ZzhY77T7gjLW93CGby5F6cEq3VWZcGvpav8+sdgK2FrTw+Jg4Ti7NNWafmj+wMLiqVenGtRkpRlqmtU0FFFFch0BRRRQAUUUUAFFFFABRRRQAUUUUAFFFFAH//T/v4ooooAKKKKACiiigAooooAKKKKACiiigAoor5Z/aD/AGmPD/wgsZNF0cx32vyp+5tgcx2+4cSTEenUL1PsOa+X4x4zy3IMvqZnmtZU6cOr3b6KK3cn0SJnNRV2dx8a/jp4T+C+h/a9VYXGoTqfsOmxsPMkI/ib+6g7sfoK/F74lfEzxX8VfEkviXxVOZHb5YIFJEUEfZI17Ad+5PJ5rnvFHirX/Getz+IvE1zLd3dw26SWU5+gA6BR2A4Fc/X+Onj19InMuMsS6EL0sJB+7Tvv2lPvLsto7K7u35NfEOfoFFFFfzkc4UUUUAFFFFABRRRQAUUUUAFFFSwQTXUyW1sjSSSMEREBZmYnAAA5JJ7U4xbdkBFX3p+zd+yTdeLvs/jn4mQyQaWSJbTTnykt0B0aQfeWM9hwWHTAIJ9M/Zs/ZFi0ryfHfxUgD3XEljpEn3Ye4ecd29E6Dvk9P0PVQoCqAABgAdq/0Y+jh9Efn9lnvFlLTeFB9e0qq7dodftfyv0MPhftSK9nZ2mn2sdjYRRwwxII4oolCoijgBQOABVmiiv9JYQUUoxVkj0AoooqgCkZlRSzkAAZJPQClryz45aF4k8UfBTxh4Z8HMyavqPhfVbHS2U7SLue0kjhwex3kc9q2w9JTqRg3ZNpX7eZnWm4wlJK9lt3P5Iv+Cvv/Bc/VfGdxrX7Lf7GWpTWejpLNpXiXxxZkpPfeWxSa306QYZICQVadcNIv3DsOW/lRd3lcySEszElmY5JJ6kmtTXtI1bw/rl7oOvwzW1/ZXc1pe29wpSWKeFykiOrYIZWBBBGQaya/wBcOB+CMuyHAxweXQst3LrJ92+vl0WyP88OKuKcZm2KlicZK76LpFdkv6b6hRRRX2R80FFFFABRRRQAUUUUAFFFFAH1t+xt+2p8c/2HPi3bfFb4K6nJAciHV9GnZm0/VbTPzQXUOcMO6OPnjbDKQa/0Jv8Agn5/wUZ+Bf8AwUF+GY8UfDu5Fh4i0+NE8SeFLxwL2wlYffUcedbufuSpx/C21gRX+ZHXr3wM+PPxY/Zt+JOn/Fr4L6zdaHrumyiSC6tj8rrn5opYzlJYn6MjgqR1Ffini34MYLiWi61O1PExXuz6P+7Puuz3XS60f6f4eeJmKySp7Kd50W9Y9vOPZ+Wz8tz/AFgqK/HT/gl1/wAFdfhP+3z4Wt/Bfil7Tw78TLK2B1Pw+77YdQ8sfPdacXOXQ9WiyXj/ANpfmr9i6/ze4j4bxuU4ueBx9JwnHo+vmn1T6NH9q5NnWGzDDxxWEqKUZf1Z9muwUUUV4Z6gUUUUAFFFFABRRRQAUUUUAFFFFAH/1P7+KKKKACiiigAooooAKKKKACiiigAopkkkcMbTTMqIilmZjgADkkk9AK/M79pL9rtrxZ/AnwouMREmK+1mI8uOhS3PYHu/f+E45r8z8UvFjKOEcuePzSpq78kF8c32ivzb0XXojOrVUFdnpf7SP7Wdl4IE3gr4cSx3Or4KXV8uHisyf4V6h5R+IXvk5A/KO/v77VL2XUdSmkuLidzLNPMxd3djkszHkkmqzu8jmSQlmY5JPJJPc02v8ZvF7xlzfjHMHi8wny0439nTXwwX6yf2pPV+Ssl5FWs5vUKKKK/JDIKKKKACiiigAooooAKKKKACiiuu8D+BvEvxE8RQ+GPCls9zdTHOB91EHV3PRVHcmuvAYCviq8MNhqbnObSjFK7beySW7GlfRGJo2jar4h1OHRtEt5bq6uHEcMEKlndj0AAr9df2dP2V9K+GMcPizxgI7zXiu5F4aGzyOif3n7Fvy9a734C/s7+GvgxpQuG2XutTp/peoMv3c9Y4QfuoPXq3U+g+i6/1X+jl9FKhkSpZ3xDBVMVo4w3jS830lPz2i9rvU9PD4bl1luFFFFf28dgUUUUAFFFFABRRRQB/Pv8A8Faf+CKXhH9sKDUfj1+z3FZaH8TFhNxe2pAhsvEJjX7sxXiO7YDasxGHOBIQPnH8KfjrwJ4y+GXi6/8AAfxB0y80fWdLuGtNQ02/jMU8EqHBVlP6EcEcgkV/raV+SX/BTv8A4JPfCH/goH4MfXtOS18PfEbToCNG8URR4Fyqg4tL8KMywk/dbl4zypwSp/qbwW+kBVyv2eV5zJzobRnu6fk+rh97j0utD8F8TfCGGP58flkVGru47Kf+UvwfXXU/zjKK9v8A2hv2dPi9+yz8UtQ+Dvxt0ifR9b05/mjlGYp4STsnt5B8ssMgGVdeOxwQQPEK/vrC4qlXpxrUZqUZK6ad00+qZ/I+Iw9SlOVKrFxktGno0woooroMQooooAKKKKACiiigAooooA6Pwh4w8U/D/wAUWHjXwTqF3pWr6XdR3un6jYytDPbzxHcjo68gg1/cd/wSS/4LeeF/2pIrH9n/APahurLRPiEkSwaXrDlbex8QFRjbyQkV4epj4WTkpz8tfwnVPbXNxZXMd5ZyPFLE6yRSxkq6OpyrKRyCDyCK/OvEbwzy7iXCewxceWcfgmvii/1T6rr5PU+z4L44xmSYj2uHd4v4ovaS/R9n+a0P9dmiv5EP+CRf/Bd1Fh0z9mb9tzUUXYUsfDnxBvH2jacLHbaqzcDbwEucjjAk5Bc/12RyRyxrLEwZWAZWU5BB5BBHUGv80uO+Acx4exrwePh/hkvhku6f5rddT+3uFOLsHnGGWJwkvVdYvs1+T2fQfRRRXxJ9OFFFFABRRRQAUUUUAFFFFAH/1f7+KKKKACiiigAooooAKKKKACs7VtX0zQdOm1fWZ4ra1t0Mk08zBURR1JJrH8ZeM/DngDw/P4n8U3KWtpbrlnc8s3ZEHVmY8ADrX41/H79o3xJ8ZtSNhb77LRIHzbWKtzIR0kmI+83oOi9vWvwXxx8fcr4Lwf71qriZr3KSer/vS/lh57vZX1tjWrKCPQP2jv2q9T+Is0/g/wADPJaaErGOWcZWW9x3b+7H6L1PU+g+LKKK/wAbOPeP804lzGpmebVnOctv5YrpGK6RX/Bd22zyJzcndhRRRXxhAUUUUAFFFFABRRRQAUUUUAFFFfQ3wI/Z58UfGjVfPQNZ6NA4F3qLjg+scQP33x+C9z0B+h4W4VzDOsdSy3K6Lq1ZuyS/Ft7JLdt6JblRg5OyON+E/wAIPF/xg8QronhmLbErA3d7KCIbdD1ZiOp9FHJ/UftL8JPg74R+Dvh8aN4cjDzSBTeX0ijzrhx3Y9lHO1egrpvAvgLwv8OPDsPhjwnapbW0K8kcvK/d5G6sx7k/QYAArsa/2D+j/wDRty/g+hHGYq1bGSWs+kL7xp3+5y3l5LQ9Whh1DV7hRRRX9OHSFFFFABRRRQAUUUUAFFFFABRRRQB8K/t3f8E+/gP+358Mm8FfFWzW31azjc+H/FFoii/0yZh/A3HmRMcb4mO1vY4Nf56n7a/7C3x4/YR+Kk/w2+MmnkW8kjvoniC0DNp+qWwPyywSY4OMb42w6Hgiv9RWvnr9p39lv4Lfte/Ce/8Ag58ctIi1PSr1D5Mwwl3ZXAHyXNpMBuimQ8gjg/dYMpKn928IPG3F8OVFhcRephm9Y9Y+cP1js/J6n5R4jeF+HzqDr0bQrrZ9JeUv0e680f5UlFfqN/wUo/4JbfGn/gnr45E2pRXGueBNTuHTQPF1vEfJJ6i1vAuRBcheQGwsgBKE7WC/lzX+jeRZ7hMzwtPG4Gqp057Nfl5NdU9V1P4vzXKcRgcRPC4qDjOO6f8AWq7PqFFFFeuecFFFFABRRRQAUUUUAFFFFABX9Gv/AASQ/wCC3nib9mC50v8AZ5/aguLrWPh4xSx0vW2Yy3vh5ekYwcmazXgFM7ol5TIXYf5yqK+X4u4OwGeYKeBzGnzRez6xfRxfRr/gNNaHu8O8SYvKsTHFYOfLJb9muzXVf0rM/wBb7wl4t8MePfDNj4z8F39rqmlalbJd2GoWUiywTwyDKujqSCD/APWroq/zr/8Aglt/wV2+Kf7AfiVPBPis3niP4aahch9R0BpN02nOxw11pxc4RsffiyEkxzhsGv79Pgb8dfhV+0j8M9M+L3wa1i11rQtVhE1tdW7fMjfxRTIfmjljPyujAFTX+a3il4S4/hnE2q+/Rk/cmlo/KXaXl13V+n9t8B+IWEzyhen7tWPxQ6rzXdefTqeuUUUV+UH6AFFFFABRRRQAUUUUAf/W/v4ooooAKKKKACiiigArzL4p/Fnwj8I/Dza94pmwWBFraR4M1w4/hRTj8SeB3rj/AI5/tAeFfgvox+0lbvVp1P2LTY2+Y/8ATSU/wRj8z0Hcj8YviB8QvFPxM8Ry+J/Fly9xPJ8sak/u4YwfljjXoqjPQdTknkmv5L+kP9J7B8KU55ZljVXGtbbxpX6z7y7Q+crK1+WviVHRbnUfGD40eLvjJr51XX3MVrGzfYtPjYmGBD0/3mx1YjJ9hxXkNFFf5FZ9n2MzTF1cfmFZ1KtR3lKTu2/62S0S0SSPKlJt3YUUUV5AgooooAKKKKACiiigAooooAKKUAsQqgkk4AFfoR+zb+yNLrqweOvilA8VmSJbLSZMq8w6h5hwVQ9l6sOvHX9B8NvDLNuKsxjluU0uZ7yk9Iwj/NJ9F2W72SbNKdNydkecfs6fstax8ULiHxT4uSWz0BG3DOUlvMfwx9wh7v8AlzyP140PQtH8NaVDoeg28VraW6COGCFdqqB/nk9TWjBbwWsCW1qixxxqEjjQBVVRwAAOABUtf7MeDPgflPBmB9hg489aS/eVWvek+y/liukV6u71PXpUVBaBRRRX7OahRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQBwXxO+F/gD4zeBdR+GvxP0q01rQ9Wt2tr/Tr5BJFIjex6MDyrAgg4IINfwc/8FYP+CMfj39ifWL34w/BWO+8Q/C+4lMxlKmW90Euf9TeFR88AJxHcYHGFf5hub/QDqhqml6brmm3Gjazbw3dpdwvb3VrcoskU0UilXR0YEMrAkEEYIr9O8M/FTMOGcV7TDvmpS+ODekvNdpdn8mmj4bjjgLB55Q5Ky5Zr4ZrdeT7ruvus9T/ACLqK/qO/wCCuf8AwQr1H4Sx6n+0p+xrYzXvhpWe81/wVbKZLjSlOWeexAyZLZerRfeiHI3KDt/lyZWVirAgg4IPUGv9LOC+N8vz/BRxuX1Lrqn8UX2kuj/B7ptH8RcT8LYzKMS8LjIWfR9JLun/AE11Eooor64+dCiiigAooooAKKKKACiiigAr9Bv+Cf3/AAUb+Ov/AAT8+JSeJfh9cvqHhu9nT/hI/CV3IfsV/ECAWXr5Nwq/clUZHRgy8V+fNFebm+T4XH4aphMZTU6c1Zp7f8P2e63R3ZbmVfCV4YnDTcZx1TX9fh1P9S/9jz9tL4Fftv8Awrg+KfwR1MXEeFj1TSbnCX+mXJGWguYgTgg52sCUccqSK+sa/wArv9kz9rv43/sXfFq0+L3wO1WSwvIsQ39jJl7LUbUnL213DnbIjdj95DhkIYA1/oPf8E5/+CmXwQ/4KEfDldS8LTxaR4w06JR4j8H3Ug+1Wz4x58GcefbOfuyLkr91wrcV/nV4xeBuK4fnLG4K9TDN77uHlLy7S26Oz3/svw38VKGcRWGxNoV106S84+fdfNXW36TUUUV/Px+vhRRRQAUUUUAf/9f+/iiiigAoopCQBk9BQAtfI/7RH7UOifCm2l8NeGWivdfdMbM7orTcOGl9W7hPz46+c/tJftb23hrzvA/wvnSbUMGO81NMNHbHoUiPRpPU9F9z0/LW6urm+uZLy9keWaVzJLLISzMzHJJJ5JJr+B/pH/S0p5b7XIuF6ilW1U6q1UO6h0c+8to9Ly24sRire7E0fEHiHWvFOrz674huZbu7uHMk08zbmYn+Q9AOBWNRRX+XuIxFStUlVqycpSd227tt7tt7tnmNhRRRWIBRRRQAUUUUAFFFFABRRRQAVPa2tze3MdnZxvLNK6xxRRgs7uxwqqBySTwAK0/D3h3WvFesQaB4et5Lq7uHCQwxDLE/0A7k8Cv2C/Z2/Zg0X4TWsXiPxH5V74gdMmUDMVpuHKRZ6tjgv37YHX9s8FvAzNuM8b7LCr2dCD/eVWvdj5L+aTW0V6tpam1Gi5s84/Zt/ZItvC/k+OfidEs2o4ElnpjgNHbHqHlH8UnoOi+5xj77oor/AGX8OfDbKeFsuhluU0uWK1k38U5fzSfV/gtkktD16dNRVkFFFFfelhRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFACMoYFWAIIwQe9fy5f8ABXT/AIIWad8WX1H9pP8AY0sLex8S7Xu/EHgu3URW2qsMs09iBhYrk/xRcJJ1G1uG/qOor6/grjjMMgxscbl9Sz6p/DJdpLqvxW6aZ87xNwvg83wzwuMhddH1i+6f9X6n+Rfq2k6poOqXOia3bzWl5ZzvbXVrcoY5YZY2KujowBVlIIIIyDWfX+gJ/wAFXv8AgjF4B/bY0q++MXwVisPD3xRhgMpmKiCy18xjiK9KjCzkDalxgnOA/wAvzL/Bx8Tfhf8AED4NeONQ+G3xQ0m80TXNKuGtr7Tr5DHLG6/oVPVWBIYcgkV/pZ4Z+KeX8TYX2mHfLVj8cG9Y+a7x7P77PQ/iLjjgHGZHX5Ky5oP4ZrZ+T7PuvuutTgqKKK/TT4YKKKKACiiigAooooAKKKKACvS/hF8YviZ8BviBp3xS+EWsXmha9pcwns7+ybaykHlWU5V0boyOCrDggivNKKyr0IVYSp1YqUWrNPVNPo0aUqsqclODs1qmt0f6Fn/BK3/gsZ8NP27dFtfhj8S3sPDfxRt7b9/pQfyrTWfKXMk+neYxO7ALvb7mdBkgsoJH7aV/kceHvEOu+Etds/FHhe8udP1HT7mO8sb6zkaKeCeJgySRuuCrKRkEV/bL/wAEjP8AguTofx8Sw/Zy/a6vLTSvGahLXQvFMrCG01zsIrjOFhu/Q5CS/wCyw+b+D/Gn6Pk8B7TNcig5Ut5U93Dzj3j5bx81t/WPhl4wxxfJgM1laptGfSXk+0vPZ+T3/piooor+TD+gwooooA//0P7+KKKKACvy5/aY/azutYkuvh78M5jDaKzW9/qkZw8+04ZISPupnqw5btgdf0o8VWd/qHhfUrDSm2XU9hcQ2z5xtleNlQ59mIr+dW7tbmxupLK8jaKaGRopY3GGR1OCpHYg1/DX01/FDOMlwODyvLJOnDFKfPNb2jyrkT6X5ve6tWSsr348ZUcUkupASScnknkk0lFFf5SHlhRRRQAUUUUAFFFFABRRRQAUUUUAFdx8Pvh34q+JviOLwz4Tt2nnk5dzxHCg6vI3RVH5noOa6j4PfBXxf8ZNeGmaBH5VrEw+26hKD5UCH/0JiOijk+w5r9pfhd8KPCPwk8PLoPhaAAkA3V24BmuHA5Z2/kOg7V/Uf0ffo1Y/i+tHHYy9HBResus7bxp3+5y2Xm9DpoYdz1exx/wN+AXhX4LaNttFW61WdB9t1J1+dv8AYjz9yMeg69T7e90UV/r/AMM8MYDJsDSy7LKKpUqasor831be7bu29Wz1oxSVkFFFFe8MKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAr8uf+ClH/AAS2+C3/AAUJ8B+bqUUGh+O9MgYaB4ut48SjjP2a8C/6+2Y84b5ozkoRlg36jUV6+RZ9i8sxVPG4Gq4VIbNfk+6fVPRnnZrlOHx2HnhcVTUoS3T/AK0fZ9D/ACpf2nv2WvjT+yB8WL/4OfHLSJtL1WzbdBL9+1vrZj+7ubSYfLLE46EcqcqwVwyj55r/AFFv21v2FvgP+3d8LJvhv8ZdP/fxI76Lr9mFTUNLuGHEsEhHK5xvjbKOOCO9f56X7d3/AAT7+PH7AnxNfwT8VbNrnSbuVz4f8UWkbfYNThU5BRufLlA5eJjuX3HNf6OeEHjbhOI6Sw2ItTxMVrHpLzh+sd15rU/i/wARvC/EZLN16N50G9H1j5S/R7PyZ8LUUUV+6n5QFFFFABRRRQAUUUUAFFFFABT45HidZYmKspDKynBBHQg+tMooA/rL/wCCPH/BcfVtIvdD/ZP/AGwbya9tJ5odI8LeNrh981uzkRw2uoMxy8eSFSbO5eA2QMj+xQEEZHQ1/ki+DfDfiTxj4t0zwp4OgnutW1G+gstNt7YEyyXMzhYwmOc7iOe1f6yfgiw1fSvBekaX4gl+0X9tpdrb304/5aXEcSrK/wDwJwTX+fX0neBstyvG4bG4GKg6/M5RW11b3kul769LrTqf2D4GcVY3H4WvhsW+ZUuXlk97O+jfW1tOv4HUUUUV/Lh+7n//0f7+KKKKACvnv4h/swfCP4lau+v63ZzW97LzPcafL5LSkd3XDKT74ye5r6Eor5/iThTLM4w/1TNcLCtC97TipJPur7PzWpMop6M+Nv8Ahhf4J/8APTW//ApP/jVH/DC/wT/56a3/AOBSf/Gq+yaK/Pv+JfeCf+hLR/8AAER7CHY+Nv8Ahhf4J/8APTW//ApP/jVH/DC/wT/56a3/AOBSf/Gq+yaKP+JfeCf+hLR/8AQewh2Pjb/hhf4J/wDPTW//AAKT/wCNUf8ADC/wT/56a3/4FJ/8ar7Joo/4l94J/wChLR/8AQewh2Pjb/hhf4J/89Nb/wDApP8A41R/wwv8E/8Anprf/gUn/wAar7Joo/4l94J/6EtH/wAAQewh2Pjb/hhf4J/89Nb/APApP/jVH/DC/wAE/wDnprf/AIFJ/wDGq+yaKP8AiX3gn/oS0f8AwBB7CHY+Nv8Ahhf4J/8APTW//ApP/jVSwfsOfBGGVZX/ALYlAOSkl0u0+x2xqfyNfYlFOP0f+CU7rJaP/gCD2EOxzXhLwd4Z8C6JF4d8J2cVlZw/ciiB5J6szEksx7kkk10tFFfq+DwdHD0oUMPBQhFWUUkkktkktEl2RqkFFFFdIBRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAUUUUAFFFFABRRRQAV438eP2fvg9+0z8Obz4T/ABx0Kz8QaFe4aS0uwQUkX7ksMiFZIpFP3XRgw9cZFeyUVvhcVVoVI1qM3GUXdNOzT7prVMyr0IVYSp1IqUXo09U15o/Ay/8A+Db3/gnPeXkl1AfHtsjsWW3g1qIxoD2XzLR2x9WJqp/xDaf8E7P+fn4h/wDg5t//AJCr9/qK/QF4vcULT+06n/gTPkH4c5F/0Aw/8BR+AP8AxDaf8E7P+fn4h/8Ag5t//kKj/iG0/wCCdn/Pz8Q//Bzb/wDyFX7/AFFP/iL/ABR/0M6n/gQv+IcZF/0Aw+4/AH/iG0/4J2f8/PxD/wDBzb//ACFR/wAQ2n/BOz/n5+If/g5t/wD5Cr9/qKP+Iv8AFH/Qzqf+BB/xDjIv+gGH3H4A/wDENp/wTs/5+fiH/wCDm3/+QqP+IbT/AIJ2f8/PxD/8HNv/APIVfv8AUUf8Rf4o/wChnU/8CD/iHGRf9AMPuPwB/wCIbT/gnZ/z8/EP/wAHNv8A/IVH/ENp/wAE7P8An5+If/g5t/8A5Cr9/qKP+Iv8Uf8AQzqf+BB/xDjIv+gGH3H4A/8AENp/wTs/5+fiH/4Obf8A+QqP+IbT/gnZ/wA/PxD/APBzb/8AyFX7/UUf8Rf4o/6GdT/wIP8AiHGRf9AMPuPy+/ZN/wCCPf7DX7HHjWL4l/DLw9eaj4jtgwsda8TXZ1Cez3jDNbptjhjcjgSCPeBkBhk5/UGiivjs6z/G5lW+sY+vKrPa8m27dtdl5H0mWZRhcFS9jhKShHskl/TCiiivIPRP/9L+/iiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA/9P+/iiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA/9T+/iiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA/9X+/iiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA/9b+/iiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA/9k=
+    mediatype: image/jpeg
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - crd.nutanix.com
+          resources:
+          - nutanixcsistorages
+          - nutanixcsistorages/status
+          - nutanixcsistorages/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - csidrivers
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - '*'
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - '*'
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - list
+          - watch
+          - get
+          - patch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: nutanix-csi-operator-controller-manager
+      deployments:
+      - label:
+          control-plane: controller-manager
+        name: nutanix-csi-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                - --leader-election-id=nutanixcsioperator
+                env:
+                - name: RELATED_IMAGE_NUTANIX_CSI
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0
+                - name: RELATED_IMAGE_NUTANIX_CSI_PRECHECK
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-precheck
+                - name: RELATED_IMAGE_AUTHSIDECAR
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-authagent
+                - name: RELATED_IMAGE_PULSE
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-pulse
+                - name: RELATED_IMAGE_PROVISIONER
+                  value: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+                - name: RELATED_IMAGE_PROVISIONER_LEGACY
+                  value: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+                - name: RELATED_IMAGE_ATTACHER
+                  value: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
+                - name: RELATED_IMAGE_SNAPSHOTTER
+                  value: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+                - name: RELATED_IMAGE_SNAPSHOTTER_BETA
+                  value: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
+                - name: RELATED_IMAGE_RESIZER
+                  value: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+                - name: RELATED_IMAGE_LIVENESSPROBE
+                  value: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
+                - name: RELATED_IMAGE_HEALTHMONITOR
+                  value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+                - name: RELATED_IMAGE_REGISTRAR
+                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+                image: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 15m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              imagePullSecrets:
+              - name: regcred
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
+              priorityClassName: system-cluster-critical
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: nutanix-csi-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: nutanix-csi-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Nutanix
+  - CSI
+  - Volumes
+  - Files
+  - Storage
+  links:
+  - name: Documentation
+    url: https://portal.nutanix.com/page/documents/list?type=software&filterKey=product&filterVal=CSI
+  maintainers:
+  - email: cloudnative@nutanix.com
+    name: Nutanix Cloud Native
+  maturity: beta
+  provider:
+    name: Nutanix
+  relatedImages:
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0
+    name: nutanix-csi
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-precheck
+    name: nutanix-csi-precheck
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-authagent
+    name: authsidecar
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os:v3.8.0-pulse
+    name: pulse
+  - image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+    name: provisioner
+  - image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+    name: provisioner-legacy
+  - image: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
+    name: attacher
+  - image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
+    name: snapshotter
+  - image: registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
+    name: snapshotter-beta
+  - image: registry.k8s.io/sig-storage/csi-resizer:v2.2.0
+    name: resizer
+  - image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
+    name: livenessprobe
+  - image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
+    name: healthmonitor
+  - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+    name: registrar
+  replaces: nutanixcsioperator.v3.7.2
+  version: 3.8.0

--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Storage
-    containerImage: quay.io/redhat-isv-containers/609b04503048c1ac9a6fec43:v3.8.0
+    containerImage: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
     createdAt: "2026-08-20T06:56:45Z"
     description: An Operator for deploying and managing the Nutanix CSI Driver
     features.operators.openshift.io/csi: "true"
@@ -373,7 +373,7 @@ spec:
                   value: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
                 - name: RELATED_IMAGE_REGISTRAR
                   value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
-                image: quay.io/redhat-isv-containers/609b04503048c1ac9a6fec43:v3.8.0
+                image: registry.connect.redhat.com/nutanix/nutanix-csi-operator:v3.8.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/operators/nutanixcsioperator/3.8.0/metadata/annotations.yaml
+++ b/operators/nutanixcsioperator/3.8.0/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: nutanixcsioperator
+  operators.operatorframework.io.bundle.channels.v1: stable-3.x
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: "v4.14-v4.22"
+  com.redhat.delivery.operator.bundle: "true"
+  com.redhat.delivery.backport: "false"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable-3.x"

--- a/operators/nutanixcsioperator/3.8.0/release-config.yaml
+++ b/operators/nutanixcsioperator/3.8.0/release-config.yaml
@@ -1,0 +1,7 @@
+---
+merge: true
+catalog_templates:
+  - template_name: basic.yaml
+    channels:
+      - stable-3.x
+    replaces: nutanixcsioperator.v3.7.2


### PR DESCRIPTION
## Summary
- Release Nutanix CSI Operator 3.8.0 bundle payload.
- Copy generated `manifests` and `metadata` into `operators/nutanixcsioperator/3.8.0`.
- Add `release-config.yaml` with `replaces: nutanixcsioperator.v3.7.2`.

## Test Plan
- [x] Update local operator version files.
- [x] Run `make bundle`.
- [x] Sync bundle payload into certified-operators fork.