### PR TITLE
operator nutanixcsioperator (3.8.0)

### DIFF
--- a/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
+++ b/operators/nutanixcsioperator/3.8.0/manifests/nutanixcsioperator.clusterserviceversion.yaml
@@ -348,13 +348,13 @@ spec:
                 - --leader-election-id=nutanixcsioperator
                 env:
                 - name: RELATED_IMAGE_NUTANIX_CSI
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:a6b0458ac61cc575ffe83f65cc0c03426dcb16054063521b2ca627e9b893484c
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:07591226c360f5cef9629bb122e16fe869052f68c35831fb2ed6740a1b5254e7
                 - name: RELATED_IMAGE_NUTANIX_CSI_PRECHECK
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:dee4c711ec1f8f4dd475b2ec8ba968d1156b28a08a3af38cc5b0fcaf69952b34
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:c620d53227c7a5689527bbe86f2d1502d70f05afedfb447d956729e6aa968d6c
                 - name: RELATED_IMAGE_AUTHSIDECAR
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:454834cf7625596e6d2ce50b939d7c49a89749f765c04fb429cdf6d5a015197a
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:6845284bc65945c4244f2fbb672637079cda8cb18431d3e97999e43441cb6a13
                 - name: RELATED_IMAGE_PULSE
-                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:514fc3cf04e2cfe38ca39fed2b0415d402d5d180a78137bbc36f5b6fcd760eb4
+                  value: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:bbf72e638debf189bfe57c002497db788d1f7f0dac5e78111f291738ef0bc1d5
                 - name: RELATED_IMAGE_PROVISIONER
                   value: registry.k8s.io/sig-storage/csi-provisioner@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
                 - name: RELATED_IMAGE_PROVISIONER_LEGACY
@@ -469,13 +469,13 @@ spec:
   provider:
     name: Nutanix
   relatedImages:
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:a6b0458ac61cc575ffe83f65cc0c03426dcb16054063521b2ca627e9b893484c
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:07591226c360f5cef9629bb122e16fe869052f68c35831fb2ed6740a1b5254e7
     name: nutanix-csi
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:dee4c711ec1f8f4dd475b2ec8ba968d1156b28a08a3af38cc5b0fcaf69952b34
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:c620d53227c7a5689527bbe86f2d1502d70f05afedfb447d956729e6aa968d6c
     name: nutanix-csi-precheck
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:454834cf7625596e6d2ce50b939d7c49a89749f765c04fb429cdf6d5a015197a
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:6845284bc65945c4244f2fbb672637079cda8cb18431d3e97999e43441cb6a13
     name: authsidecar
-  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:514fc3cf04e2cfe38ca39fed2b0415d402d5d180a78137bbc36f5b6fcd760eb4
+  - image: registry.connect.redhat.com/nutanix/ntnx-csi-os@sha256:bbf72e638debf189bfe57c002497db788d1f7f0dac5e78111f291738ef0bc1d5
     name: pulse
   - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
     name: provisioner


### PR DESCRIPTION
Replace 3.8.0 CSI OS relatedImages with the rebuilt Connect digests. Operator image unchanged.

Made with [Cursor](https://cursor.com)