### PR TITLE
operator axera-operator (0.9.12)

### DIFF
--- a/operators/axera-operator/0.9.12/manifests/axera-operator-axera-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator-axera-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+  name: axera-operator-axera-admin-role
+rules:
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras
+  verbs:
+  - '*'
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras/status
+  verbs:
+  - get

--- a/operators/axera-operator/0.9.12/manifests/axera-operator-axera-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator-axera-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+  name: axera-operator-axera-editor-role
+rules:
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras/status
+  verbs:
+  - get

--- a/operators/axera-operator/0.9.12/manifests/axera-operator-axera-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator-axera-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+  name: axera-operator-axera-viewer-role
+rules:
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - platform.axerasecurity.com
+  resources:
+  - axeras/status
+  verbs:
+  - get

--- a/operators/axera-operator/0.9.12/manifests/axera-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: axera-operator
+    control-plane: controller-manager
+  name: axera-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: axera-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/axera-operator/0.9.12/manifests/axera-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: axera-operator-metrics-monitor
+  labels:
+    app.kubernetes.io/name: axera-operator
+    control-plane: controller-manager
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: axera-operator

--- a/operators/axera-operator/0.9.12/manifests/axera-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: axera-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/axera-operator/0.9.12/manifests/axera-operator.clusterserviceversion.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-operator.clusterserviceversion.yaml
@@ -1,0 +1,598 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "platform.axerasecurity.com/v1alpha1",
+          "kind": "Axera",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "axera-operator"
+            },
+            "name": "axera"
+          },
+          "spec": {
+            "ai": {
+              "enabled": true,
+              "external": false,
+              "model": "llama3.2:3b"
+            },
+            "app": {
+              "adminUsername": "admin",
+              "corsOrigins": [
+                "http://localhost:3000"
+              ]
+            },
+            "backup": {
+              "enabled": true,
+              "storage": {
+                "type": "pvc",
+                "createPvc": true,
+                "size": "10Gi",
+                "accessMode": "ReadWriteMany"
+              }
+            },
+            "global": {
+              "clusterDomain": "",
+              "imageRegistry": "quay.io/axera",
+              "storageClass": ""
+            },
+            "imagePullSecret": {
+              "enabled": true,
+              "name": "quay-pull-secret"
+            },
+            "kafka": {
+              "external": false
+            },
+            "postgres": {
+              "external": false
+            },
+            "routes": {
+              "frontend": {
+                "enabled": true
+              }
+            },
+            "version": "v9.60.0"
+          }
+        },
+        {
+          "apiVersion": "platform.axerasecurity.com/v1alpha1",
+          "kind": "AxeraFlow",
+          "metadata": {
+            "name": "prod",
+            "namespace": "axera-flow"
+          },
+          "spec": {
+            "clusterName": "ocp-prod",
+            "podCIDR": "10.128.0.0/14",
+            "kafka": {
+              "bootstrapServers": "kafka.example.com:9092",
+              "securityProtocol": "Ssl"
+            },
+            "topics": {
+              "flow": "ocp-prod",
+              "external": "external-flows"
+            },
+            "clusterPublicIP": "203.0.113.10/32",
+            "multiCluster": {
+              "cidr": "203.0.113.10/31",
+              "peers": [
+                {
+                  "name": "ocp-test",
+                  "publicIP": "203.0.113.11/32"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "apiVersion": "platform.axerasecurity.com/v1alpha1",
+          "kind": "AxeraProcess",
+          "metadata": {
+            "name": "prod",
+            "namespace": "axera-process"
+          },
+          "spec": {
+            "clusterName": "ocp-prod",
+            "kafka": {
+              "bootstrapServers": "kafka.example.com:9092",
+              "securityProtocol": "Plaintext"
+            },
+            "installTracingPolicy": true
+          }
+        },
+        {
+          "apiVersion": "platform.axerasecurity.com/v1alpha1",
+          "kind": "AxeraForce",
+          "metadata": {
+            "name": "ambient",
+            "namespace": "axera"
+          },
+          "spec": {
+            "clusterName": "ocp-ambient",
+            "podCIDR": "10.128.0.0/14",
+            "kafka": {
+              "bootstrapServers": "kafka.example.com:9092",
+              "securityProtocol": "SaslSsl",
+              "saslMechanism": "ScramSha512",
+              "saslUsername": "axera-agent"
+            },
+            "flow": {
+              "topic": "ocp-ambient",
+              "externalTopic": "external-flows"
+            },
+            "process": {
+              "topic": "ocp-ambient-process"
+            }
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: Security, Networking, Monitoring, Logging & Tracing
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    containerImage: quay.io/axera/axera-operator@sha256:7e8131a430ff87bc555c767fd22640f6a002ad6ff42654f64755a92b33a313ef
+    createdAt: "2026-08-21T12:00:00Z"
+    description: Deploy and lifecycle-manage the Axera Kubernetes microsegmentation
+      & NDR platform on OpenShift through a single Axera custom resource.
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/AxeraSecurity/axera-operator
+    support: Axera Security
+  name: axera-operator.v0.9.12
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Axera is the Schema for the axeras API — one CR deploys the whole
+        platform.
+      displayName: Axera
+      kind: Axera
+      name: axeras.platform.axerasecurity.com
+      version: v1alpha1
+    - description: AxeraFlow deploys the network-flow agent (eBPF + flowlogs-pipeline)
+        on one monitored cluster, shipping per-cluster flow topics to the central Kafka.
+      displayName: Axera Flow Agent
+      kind: AxeraFlow
+      name: axeraflows.platform.axerasecurity.com
+      version: v1alpha1
+    - description: AxeraProcess deploys the process agent (Cilium Tetragon + fluent-bit)
+        on one monitored cluster, shipping a per-cluster process topic to the central
+        Kafka. Requires the Tetragon CRDs.
+      displayName: Axera Process Agent
+      kind: AxeraProcess
+      name: axeraprocesses.platform.axerasecurity.com
+      version: v1alpha1
+    - description: AxeraForce deploys the combined flow+process "OneBox" agent (one
+        DaemonSet) on one monitored cluster. Requires the Tetragon CRDs.
+      displayName: Axera Force Agent (OneBox)
+      kind: AxeraForce
+      name: axeraforces.platform.axerasecurity.com
+      version: v1alpha1
+  description: |
+    # Axera Microsegmentation & NDR Operator
+
+    Axera is a Kubernetes-native **microsegmentation** and **Network Detection &
+    Response (NDR)** platform for Red Hat OpenShift. This operator deploys and
+    lifecycle-manages the entire Axera platform — API, radar, network-policy
+    watcher, allow/drop monitor, frontend console, and (optionally) in-cluster
+    PostgreSQL, Kafka and an on-prem Ollama AI assistant — from a single `Axera`
+    custom resource.
+
+    ## What it does
+    - **One CR, whole platform.** Create an `Axera` resource and the operator
+      reconciles all of the platform's workloads, services, routes, RBAC, SCC and
+      NetworkPolicies into your namespace.
+    - **Least-privilege NetworkPolicy from observed traffic.** Axera watches real
+      east-west and egress traffic and synthesizes default-deny NetworkPolicy.
+    - **Seamless upgrades.** Bump `spec.version` and the operator rolls every
+      component to the new image tag; status reports per-component health.
+    - **Deep insights.** The operator exposes platform-health Prometheus metrics
+      and ships a ServiceMonitor + PrometheusRule (not-ready, component-down,
+      upgrade-stuck, no-managed-policies alerts), and reflects live health and
+      managed-policy count into the CR status.
+    - **Backup & restore.** Built-in Backup & Restore of the platform databases
+      (internal OR external) — scheduled + ad-hoc `pg_dump` / `pg_restore` with
+      download and point-in-time restore, driven from the in-product Backup &
+      restore page; the storage backing (PVC or NFS) is set via `spec.backup`.
+    - **On-prem AI incident triage.** Provider-agnostic; everything stays in the
+      cluster — suitable for air-gapped and regulated environments.
+
+    ## Getting started
+    Create an `Axera` CR (see the sample). The operator surfaces progress on the CR
+    status (`Phase`, `Ready`, conditions, per-component health and the console URL).
+
+    > Container images are pulled from a private registry — provide a pull secret
+    > via `spec.imagePullSecret`.
+  displayName: Axera Microsegmentation & NDR
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4NCA4NCIgd2lkdGg9Ijg0IiBoZWlnaHQ9Ijg0Ij4KICA8cmVjdCB3aWR0aD0iODQiIGhlaWdodD0iODQiIHJ4PSIxNCIgZmlsbD0iI2ZmZmZmZiIvPgogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDcsOCkiPgogICAgPHBhdGggZD0iTTMyLDAgTDMyLDY4IEwxMCw2OCBaIiBmaWxsPSIjZTExZDQ4Ii8+CiAgICA8cGF0aCBkPSJNMzgsMCBMMzgsNjggTDYwLDY4IFoiIGZpbGw9IiNmNDNmNWUiLz4KICAgIDxyZWN0IHg9IjMyIiB5PSIwIiB3aWR0aD0iNiIgaGVpZ2h0PSI2OCIgZmlsbD0iI2ZmZmZmZiIvPgogICAgPHJlY3QgeD0iMTgiIHk9IjQyIiB3aWR0aD0iMTQiIGhlaWdodD0iNiIgZmlsbD0iI2ZiNzE4NSIvPgogICAgPHJlY3QgeD0iMzgiIHk9IjQyIiB3aWR0aD0iMTQiIGhlaWdodD0iNiIgZmlsbD0iI2ZiNzE4NSIvPgogIDwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - persistentvolumeclaims
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cilium.io
+          resources:
+          - podinfo
+          - tracingpolicies
+          - tracingpoliciesnamespaced
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - k8s.ovn.org
+          resources:
+          - egressips
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - platform.axerasecurity.com
+          resources:
+          - axeraflows
+          - axeraforces
+          - axeraprocesses
+          - axeras
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - platform.axerasecurity.com
+          resources:
+          - axeraflows/finalizers
+          - axeraforces/finalizers
+          - axeraprocesses/finalizers
+          - axeras/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - platform.axerasecurity.com
+          resources:
+          - axeraflows/status
+          - axeraforces/status
+          - axeraprocesses/status
+          - axeras/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - use
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: axera-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: axera-operator
+          control-plane: controller-manager
+        name: axera-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: axera-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: axera-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: quay.io/axera/axera-operator@sha256:7e8131a430ff87bc555c767fd22640f6a002ad6ff42654f64755a92b33a313ef
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              imagePullSecrets:
+              - name: quay-pull-secret
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: axera-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: axera-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - microsegmentation
+  - ndr
+  - networkpolicy
+  - zero-trust
+  - openshift
+  - security
+  - observability
+  links:
+  - name: Axera Security
+    url: https://axerasecurity.com
+  - name: Source
+    url: https://github.com/AxeraSecurity/axera-operator
+  maintainers:
+  - email: support@axerasecurity.com
+    name: Axera Security
+  maturity: alpha
+  minKubeVersion: 1.25.0
+  provider:
+    name: Axera Security
+    url: https://axerasecurity.com
+  relatedImages:
+    - name: axera-operator
+      image: quay.io/axera/axera-operator@sha256:7e8131a430ff87bc555c767fd22640f6a002ad6ff42654f64755a92b33a313ef
+    - name: microsegmentation-api
+      image: quay.io/axera/microsegmentation-api@sha256:7e27c0ee63045e5b3dafae706466da8434587e0f3d11d9d1402a1b406115c815
+    - name: microsegmentation-radar
+      image: quay.io/axera/microsegmentation-radar@sha256:8133abe69dcf7ecd0b5249d5e665b8cc425d64dca82fb6f6f193175d952f8e4d
+    - name: microsegmentation-allowdropmonitor
+      image: quay.io/axera/microsegmentation-allowdropmonitor@sha256:bcb30f3551ef20dd7c749478172ef59d932f9e424bb0d134582364b4824f5806
+    - name: microsegmentation-networkpolicywatcher
+      image: quay.io/axera/microsegmentation-networkpolicywatcher@sha256:6662ca812b6da338cdb7848852678b08b1ec8b5e437b8f4e7916b6a9a8222d2d
+    - name: microsegmentation-frontend
+      image: quay.io/axera/microsegmentation-frontend@sha256:db08adc959ed6818b4478a7f6f84c0ae29e0d42b11bf0f12e0e721d1ebbf5131
+    - name: kafka
+      image: quay.io/axera/kafka@sha256:821720633cf189f4852051569f0794ffbb3aeef3de9e5b47684901af81176852
+    - name: microsegmentation-ollama
+      image: quay.io/axera/microsegmentation-ollama@sha256:a4e95f0a14e6773d2507c593336d94dd5f73fe134fb13438ce069a5a1fefd9fe
+  replaces: axera-operator.v0.9.11
+  version: 0.9.12

--- a/operators/axera-operator/0.9.12/manifests/axera-platform-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/operators/axera-operator/0.9.12/manifests/axera-platform-alerts_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,42 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: axera-platform-alerts
+  labels:
+    app.kubernetes.io/name: axera-operator
+spec:
+  groups:
+    - name: axera.platform
+      rules:
+        - alert: AxeraPlatformNotReady
+          expr: axera_platform_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Axera platform not Ready in namespace {{ $labels.namespace }}"
+            description: "Axera CR {{ $labels.axera }} has been not-Ready for 15 minutes."
+        - alert: AxeraComponentDown
+          expr: axera_component_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Axera component {{ $labels.component }} down in {{ $labels.namespace }}"
+            description: "Managed component {{ $labels.component }} has 0 ready replicas for 15 minutes."
+        - alert: AxeraUpgradeStuck
+          expr: axera_upgrade_in_progress == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Axera upgrade stuck in namespace {{ $labels.namespace }}"
+            description: "The platform has been Upgrading for over 30 minutes — check component rollouts."
+        - alert: AxeraNoManagedPolicies
+          expr: axera_managed_networkpolicies == 0
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "Axera manages 0 NetworkPolicies in namespace {{ $labels.namespace }}"
+            description: "No segmentation policies are being managed — the platform may not be enforcing yet."

--- a/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeraflows.yaml
+++ b/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeraflows.yaml
@@ -1,0 +1,503 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: axeraflows.platform.axerasecurity.com
+spec:
+  group: platform.axerasecurity.com
+  names:
+    categories:
+    - axera
+    kind: AxeraFlow
+    listKind: AxeraFlowList
+    plural: axeraflows
+    shortNames:
+    - axf
+    singular: axeraflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.numberReady
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AxeraFlow is the Schema for the network-flow agent — one CR per
+          monitored cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AxeraFlowSpec is the network-flow agent (netobserv eBPF agent + flowlogs-pipeline)
+              for one monitored cluster. It renders into the `axera-flow` namespace and ships
+              per-cluster flow topics to the central Kafka. Mirrors deploy/Axera-Flow.
+            properties:
+              agent:
+                description: eBPF agent + flowlogs-pipeline images and tuning.
+                properties:
+                  direction:
+                    default: both
+                    description: 'Capture direction: ingress | egress | both.'
+                    enum:
+                    - ingress
+                    - egress
+                    - both
+                    type: string
+                  ebpfImage:
+                    default: quay.io/netobserv/netobserv-ebpf-agent:v1.11.3-community
+                    description: eBPF capture agent image (netobserv-ebpf-agent).
+                    type: string
+                  ebpfResources:
+                    description: Optional resource overrides for the two flow containers.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  enableDnsTracking:
+                    default: true
+                    description: |-
+                      eBPF feature toggles — present only on the live agent, defaulted true so a
+                      chart modeled on the plaintext bundle can't silently drop them.
+                    type: boolean
+                  enablePktTranslation:
+                    default: true
+                    type: boolean
+                  enableRtt:
+                    default: true
+                    type: boolean
+                  excludeInterfaces:
+                    default: lo
+                    description: Interfaces to exclude from capture (comma-separated).
+                    type: string
+                  flpImage:
+                    default: quay.io/axera/axera-flowlogs-pipeline:v1
+                    description: |-
+                      flowlogs-pipeline image. Default = the Axera rebuild that runs live (TLS-capable).
+                      NOTE: for a SASL Kafka broker use a SASL-capable FLP (netobserv community
+                      v1.11.5+); the Axera rebuild does not support the kafka `sasl` encoder field.
+                    type: string
+                  flpResources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  sampling:
+                    description: Flow sampling rate (1 = capture every flow). Unset
+                      = full capture.
+                    format: int32
+                    type: integer
+                type: object
+              clusterName:
+                description: |-
+                  Identity of THIS cluster: stamped as ClusterName on every flow AND used as the
+                  default Kafka flow topic. REQUIRED — a blank name blanks topology attribution.
+                  Constrained to a safe token (no YAML-significant characters) since it is
+                  interpolated into the FLP config and the Kafka topic name.
+                minLength: 1
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]*$
+                type: string
+              clusterPublicIP:
+                description: |-
+                  This cluster's own public/egress IP as a /32 (multi_cluster_division self-label).
+                  Only meaningful when multiCluster is set.
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/32$
+                type: string
+              createSCC:
+                default: true
+                description: |-
+                  Create the OpenShift SecurityContextConstraints (privileged + hostNetwork).
+                  Disable on vanilla Kubernetes or if a cluster admin pre-creates it.
+                type: boolean
+              extraPodCIDRs:
+                description: |-
+                  Additional in-cluster pod/service CIDRs to also label as ClusterSubnet, for when
+                  the cluster's pod network was WIDENED / a second range was added after install.
+                  Each is appended to the FLP ClusterSubnet enrichment alongside podCIDR.
+                items:
+                  type: string
+                type: array
+              kafka:
+                description: Central Kafka the flow pipeline produces to (out + out3
+                  encoders).
+                properties:
+                  bootstrapServers:
+                    description: host:port of the central broker listener the agent
+                      produces to.
+                    minLength: 1
+                    type: string
+                  caCert:
+                    description: |-
+                      Broker CA certificate (PEM) for TLS trust. Rendered into the agent's kafka
+                      Secret and referenced by the writers' caCertPath / ssl.ca.location.
+                    type: string
+                  createSecret:
+                    default: true
+                    description: |-
+                      Create the agent's kafka Secret (CA + SASL creds) from the values above
+                      (default true), or set false to bring your OWN pre-created Secret and keep
+                      credentials out of the CR. When false, pre-create the Secret with keys:
+                        ca.crt, username, password
+                      named per kind: axera-flow-kafka (flow), axera-process-kafka (process); the
+                      force/OneBox agent uses TWO Secrets — kafka-ca (key ca.crt) + kafka-sasl
+                      (keys username, password).
+                    type: boolean
+                  insecureSkipVerify:
+                    default: false
+                    description: Skip broker certificate verification (dev / self-signed
+                      only).
+                    type: boolean
+                  saslMechanism:
+                    default: ScramSha512
+                    description: |-
+                      SASL/SCRAM mechanism (only used for the Sasl* protocols). The chart maps this
+                      ONE value to the FLP (`scramSHA512`) and fluent-bit (`SCRAM-SHA-512`) spellings —
+                      it is never emitted verbatim.
+                    enum:
+                    - Plain
+                    - ScramSha256
+                    - ScramSha512
+                    type: string
+                  saslPassword:
+                    type: string
+                  saslUsername:
+                    type: string
+                  securityProtocol:
+                    default: Plaintext
+                    description: Wire security. Plaintext | Ssl | SaslPlaintext |
+                      SaslSsl.
+                    enum:
+                    - Plaintext
+                    - Ssl
+                    - SaslPlaintext
+                    - SaslSsl
+                    type: string
+                required:
+                - bootstrapServers
+                type: object
+              localNetworkCIDR:
+                default: 192.168.0.0/16
+                description: |-
+                  On-prem / corporate network CIDR (FLP LocalNetwork enrichment label). Review
+                  per customer even though most use the RFC1918 default.
+                type: string
+              multiCluster:
+                description: |-
+                  Cross-cluster flow correlation. OMIT for a single-cluster install — its
+                  presence adds the multi_cluster_division FLP stage.
+                properties:
+                  cidr:
+                    description: CIDR covering every peer cluster's public IP (FLP
+                      MultiCluster enrich label).
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                    type: string
+                  peers:
+                    description: |-
+                      Peer clusters (name → public IP /32). List only the OTHER clusters here —
+                      this cluster's own name+IP come from clusterName / clusterPublicIP.
+                    items:
+                      description: |-
+                        AgentClusterPeer maps a peer cluster's public/egress IP to its name so
+                        cross-cluster egress is attributed correctly (FLP multi_cluster_division stage).
+                      properties:
+                        globalCidr:
+                          description: |-
+                            Peer's Submariner Globalnet SLICE (the CIDR the broker assigned that cluster,
+                            e.g. 242.0.255.0/24 — from `subctl show networks` or spec.global_cidr on its
+                            Cluster CR), NOT the mesh-wide range. Declared here so cross-cluster ingress
+                            SNATed behind this peer's Globalnet address is attributed to it (FLP
+                            multi_cluster_division labeled_src_addr). Slices must not overlap.
+                          pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                          type: string
+                        name:
+                          minLength: 1
+                          type: string
+                        publicIP:
+                          description: Peer public/egress IP as a /32 CIDR, e.g. 203.0.113.11/32.
+                          pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/32$
+                          type: string
+                      required:
+                      - name
+                      - publicIP
+                      type: object
+                    minItems: 1
+                    type: array
+                required:
+                - cidr
+                - peers
+                type: object
+              podCIDR:
+                description: |-
+                  Pod network CIDR of this cluster
+                  (oc get network.config/cluster -o jsonpath='{.spec.clusterNetwork[0].cidr}').
+                  Feeds the FLP ClusterSubnet enrichment label; a wrong value silently drops all
+                  egress flows or marks everything external. REQUIRED — e.g. "10.128.0.0/14".
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                type: string
+              submariner:
+                description: |-
+                  Cross-cluster (Submariner) intercluster flow capture. OMIT for a single-cluster
+                  install; when set, an independent FLP branch keeps flows touching the Submariner
+                  global CIDR (default 242.0.0.0/8) and ships them to a dedicated topic
+                  (default intercluster-flows). Additive to — and independent of — multiCluster.
+                properties:
+                  clusterGlobalCidr:
+                    description: |-
+                      THIS cluster's own Globalnet SLICE (the sub-range the broker assigned this
+                      cluster, e.g. 242.0.0.0/24), NOT the mesh-wide range above. Declared in the
+                      FLP multi_cluster_division so this cluster's own Globalnet-SNATed egress is
+                      attributed to it. Peer slices come from multiCluster.peers[].globalCidr.
+                      Omit for the legacy single-slice behaviour. Slices must not overlap.
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                    type: string
+                  globalCidr:
+                    default: 242.0.0.0/8
+                    description: |-
+                      Submariner global CIDR — the MESH-WIDE globalnet range (Broker
+                      `--globalnet-cidr-range`). Any endpoint in it is a cross-cluster flow; used
+                      for the blanket "Reserved" enrich label. Must match the mesh.
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                    type: string
+                  topic:
+                    default: intercluster-flows
+                    description: Kafka topic for the cross-cluster (intercluster)
+                      flows.
+                    type: string
+                type: object
+              topics:
+                description: Kafka flow topics.
+                properties:
+                  external:
+                    default: external-flows
+                    description: External / egress-flow topic (FLP `out3`). Constant
+                      in practice.
+                    type: string
+                  flow:
+                    description: Primary per-cluster flow topic (FLP `out`). Defaults
+                      to clusterName.
+                    type: string
+                type: object
+            required:
+            - clusterName
+            - kafka
+            - podCIDR
+            type: object
+          status:
+            description: AgentStatus is the DaemonSet-centric observed state shared
+              by every agent kind.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              desiredScheduled:
+                description: Nodes the agent DaemonSet wants a pod on.
+                format: int32
+                type: integer
+              numberReady:
+                description: Agent pods currently Ready.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: Generation last reconciled.
+                format: int64
+                type: integer
+              phase:
+                description: 'Coarse phase: Pending | Ready | Degraded.'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeraforces.yaml
+++ b/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeraforces.yaml
@@ -1,0 +1,1445 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: axeraforces.platform.axerasecurity.com
+spec:
+  group: platform.axerasecurity.com
+  names:
+    categories:
+    - axera
+    kind: AxeraForce
+    listKind: AxeraForceList
+    plural: axeraforces
+    shortNames:
+    - axforce
+    singular: axeraforce
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.numberReady
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AxeraForce is the Schema for the combined flow+process (OneBox) agent — one CR
+          per monitored cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AxeraForceSpec is the combined flow+process "OneBox" agent for one monitored
+              cluster: a single DaemonSet in the `axera` namespace running the eBPF agent +
+              flowlogs-pipeline + Tetragon + fluent-bit shipper as sidecars, sharing one
+              ServiceAccount / RBAC / SCC and ONE Kafka endpoint. Mirrors deploy/Axera-OneBox.
+
+              The OneBox invariant: both writers share one broker + one credential set, so the
+              Kafka block is hoisted to the top level (not split under flow/process).
+
+              PREREQUISITE: the Tetragon CRDs must be installed on the cluster first.
+            properties:
+              affinity:
+                description: Affinity for finer placement rules (node/pod affinity).
+                  Applied verbatim.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              auditForwarder:
+                description: |-
+                  Audit forwarder for NetworkPolicy "Modified By" attribution of changes made ON
+                  THIS monitored cluster — posts this cluster's API audit events to the CENTRAL
+                  Axera. Default off. See AgentAuditForwarder.
+                properties:
+                  caCert:
+                    description: |-
+                      CA certificate (PEM) to trust for the central Route's TLS. OpenShift routers
+                      commonly serve a self-signed/enterprise wildcard the forwarder won't trust by
+                      default — without this (or insecureSkipVerify) every POST fails
+                      "certificate verify failed" and events are dropped. Central's router CA:
+                        oc -n openshift-ingress-operator get secret router-ca -o jsonpath='{.data.tls\.crt}' | base64 -d
+                    type: string
+                  enabled:
+                    default: false
+                    description: |-
+                      Deploy the forwarder on this cluster. Default false (opt-in; it is a privileged,
+                      control-plane DaemonSet).
+                    type: boolean
+                  image:
+                    default: docker.io/timberio/vector:0.40.1-debian
+                    description: Vector image (mirror for disconnected installs).
+                    type: string
+                  insecureSkipVerify:
+                    default: false
+                    description: Skip TLS verification of the central Route (test/self-signed
+                      only — prefer caCert).
+                    type: boolean
+                  internalToken:
+                    description: |-
+                      Shared Internal token (the platform's Internal__Token) to authenticate to
+                      /api/Internal/Audit. Plaintext in the CR; the chart mounts it into the forwarder.
+                      The agent has no axera-app-secret, so it must be supplied here.
+                    type: string
+                  targetUri:
+                    description: |-
+                      Central Axera audit ingest URL — REQUIRED when enabled. The agent is remote, so use
+                      the central API's public Route, e.g.
+                      https://api-axera-central.apps.<clusterDomain>/api/Internal/Audit
+                    type: string
+                type: object
+              clusterName:
+                description: Identity of THIS cluster (flow ClusterName + default
+                  topics).
+                minLength: 1
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]*$
+                type: string
+              clusterPublicIP:
+                description: |-
+                  This cluster's own public/egress IP as a /32 (multi_cluster_division self-label).
+                  Only meaningful when multiCluster is set.
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/32$
+                type: string
+              createSCC:
+                default: true
+                description: Create the OpenShift SecurityContextConstraints (privileged
+                  + hostNetwork).
+                type: boolean
+              extraPodCIDRs:
+                description: |-
+                  Additional in-cluster pod/service CIDRs to also label as ClusterSubnet, for when
+                  the cluster's pod network was WIDENED / a second range was added after install.
+                  Each is appended to the FLP ClusterSubnet enrichment alongside podCIDR; a flow
+                  whose endpoint isn't in any ClusterSubnet is treated as leaving the cluster.
+                items:
+                  type: string
+                type: array
+              flow:
+                description: Flow-specific knobs.
+                properties:
+                  direction:
+                    default: both
+                    description: 'Capture direction: ingress | egress | both.'
+                    enum:
+                    - ingress
+                    - egress
+                    - both
+                    type: string
+                  enableDnsTracking:
+                    default: true
+                    type: boolean
+                  enablePktTranslation:
+                    default: true
+                    type: boolean
+                  enableRtt:
+                    default: true
+                    type: boolean
+                  excludeInterfaces:
+                    default: lo
+                    description: Interfaces to exclude from capture.
+                    type: string
+                  externalTopic:
+                    default: external-flows
+                    description: External / egress-flow topic (FLP `out3`).
+                    type: string
+                  topic:
+                    description: Per-cluster flow topic (FLP `out`). Defaults to clusterName.
+                    type: string
+                type: object
+              images:
+                description: Container images (four containers + init).
+                properties:
+                  ebpfAgent:
+                    default: quay.io/netobserv/netobserv-ebpf-agent:v1.11.3-community
+                    type: string
+                  flp:
+                    default: quay.io/netobserv/flowlogs-pipeline:v1.11.5-community
+                    description: |-
+                      OneBox needs a SASL-capable FLP (the community build; the Axera rebuild lacks
+                      the kafka `sasl` encoder field).
+                    type: string
+                  shipper:
+                    default: cr.fluentbit.io/fluent/fluent-bit:3.1.9
+                    type: string
+                  tetragon:
+                    default: quay.io/cilium/tetragon:v1.4.0
+                    type: string
+                type: object
+              kafka:
+                description: |-
+                  SHARED central Kafka for BOTH writers (flow FLP + process shipper). One broker,
+                  one credential set — the OneBox invariant.
+                properties:
+                  bootstrapServers:
+                    description: host:port of the central broker listener the agent
+                      produces to.
+                    minLength: 1
+                    type: string
+                  caCert:
+                    description: |-
+                      Broker CA certificate (PEM) for TLS trust. Rendered into the agent's kafka
+                      Secret and referenced by the writers' caCertPath / ssl.ca.location.
+                    type: string
+                  createSecret:
+                    default: true
+                    description: |-
+                      Create the agent's kafka Secret (CA + SASL creds) from the values above
+                      (default true), or set false to bring your OWN pre-created Secret and keep
+                      credentials out of the CR. When false, pre-create the Secret with keys:
+                        ca.crt, username, password
+                      named per kind: axera-flow-kafka (flow), axera-process-kafka (process); the
+                      force/OneBox agent uses TWO Secrets — kafka-ca (key ca.crt) + kafka-sasl
+                      (keys username, password).
+                    type: boolean
+                  insecureSkipVerify:
+                    default: false
+                    description: Skip broker certificate verification (dev / self-signed
+                      only).
+                    type: boolean
+                  saslMechanism:
+                    default: ScramSha512
+                    description: |-
+                      SASL/SCRAM mechanism (only used for the Sasl* protocols). The chart maps this
+                      ONE value to the FLP (`scramSHA512`) and fluent-bit (`SCRAM-SHA-512`) spellings —
+                      it is never emitted verbatim.
+                    enum:
+                    - Plain
+                    - ScramSha256
+                    - ScramSha512
+                    type: string
+                  saslPassword:
+                    type: string
+                  saslUsername:
+                    type: string
+                  securityProtocol:
+                    default: Plaintext
+                    description: Wire security. Plaintext | Ssl | SaslPlaintext |
+                      SaslSsl.
+                    enum:
+                    - Plaintext
+                    - Ssl
+                    - SaslPlaintext
+                    - SaslSsl
+                    type: string
+                required:
+                - bootstrapServers
+                type: object
+              localNetworkCIDR:
+                default: 192.168.0.0/16
+                description: On-prem / corporate network CIDR (FLP LocalNetwork enrichment
+                  label).
+                type: string
+              multiCluster:
+                description: Cross-cluster flow correlation. OMIT for a single-cluster
+                  install.
+                properties:
+                  cidr:
+                    description: CIDR covering every peer cluster's public IP (FLP
+                      MultiCluster enrich label).
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                    type: string
+                  peers:
+                    description: |-
+                      Peer clusters (name → public IP /32). List only the OTHER clusters here —
+                      this cluster's own name+IP come from clusterName / clusterPublicIP.
+                    items:
+                      description: |-
+                        AgentClusterPeer maps a peer cluster's public/egress IP to its name so
+                        cross-cluster egress is attributed correctly (FLP multi_cluster_division stage).
+                      properties:
+                        globalCidr:
+                          description: |-
+                            Peer's Submariner Globalnet SLICE (the CIDR the broker assigned that cluster,
+                            e.g. 242.0.255.0/24 — from `subctl show networks` or spec.global_cidr on its
+                            Cluster CR), NOT the mesh-wide range. Declared here so cross-cluster ingress
+                            SNATed behind this peer's Globalnet address is attributed to it (FLP
+                            multi_cluster_division labeled_src_addr). Slices must not overlap.
+                          pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                          type: string
+                        name:
+                          minLength: 1
+                          type: string
+                        publicIP:
+                          description: Peer public/egress IP as a /32 CIDR, e.g. 203.0.113.11/32.
+                          pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/32$
+                          type: string
+                      required:
+                      - name
+                      - publicIP
+                      type: object
+                    minItems: 1
+                    type: array
+                required:
+                - cidr
+                - peers
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  NodeSelector pins the agent to matching nodes (e.g. {"node-role.kubernetes.io/app": ""}).
+                  Applied verbatim; empty = all nodes.
+                type: object
+              podCIDR:
+                description: Pod network CIDR (FLP ClusterSubnet enrichment). REQUIRED
+                  — e.g. "10.128.0.0/14".
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                type: string
+              process:
+                description: Process-specific knobs.
+                properties:
+                  installTracingPolicy:
+                    default: true
+                    description: Apply the observe-only tcp_connect TracingPolicy
+                      (requires the Tetragon CRDs).
+                    type: boolean
+                  topic:
+                    description: Per-cluster process topic (fluent-bit shipper). Default
+                      "<clusterName>-process".
+                    type: string
+                  tracingPolicyPodSelector:
+                    description: podSelector for the TracingPolicy (empty = all pods).
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              submariner:
+                description: |-
+                  Cross-cluster (Submariner) intercluster flow capture. OMIT for a single-cluster
+                  install; when set, an independent FLP branch keeps flows touching the Submariner
+                  global CIDR (default 242.0.0.0/8) and ships them to a dedicated topic
+                  (default intercluster-flows). Additive to — and independent of — multiCluster.
+                properties:
+                  clusterGlobalCidr:
+                    description: |-
+                      THIS cluster's own Globalnet SLICE (the sub-range the broker assigned this
+                      cluster, e.g. 242.0.0.0/24), NOT the mesh-wide range above. Declared in the
+                      FLP multi_cluster_division so this cluster's own Globalnet-SNATed egress is
+                      attributed to it. Peer slices come from multiCluster.peers[].globalCidr.
+                      Omit for the legacy single-slice behaviour. Slices must not overlap.
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                    type: string
+                  globalCidr:
+                    default: 242.0.0.0/8
+                    description: |-
+                      Submariner global CIDR — the MESH-WIDE globalnet range (Broker
+                      `--globalnet-cidr-range`). Any endpoint in it is a cross-cluster flow; used
+                      for the blanket "Reserved" enrich label. Must match the mesh.
+                    pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
+                    type: string
+                  topic:
+                    default: intercluster-flows
+                    description: Kafka topic for the cross-cluster (intercluster)
+                      flows.
+                    type: string
+                type: object
+              tolerations:
+                description: |-
+                  Scheduling overrides for the agent DaemonSet.
+
+                  Tolerations: when OMITTED the agent keeps the default single `{operator: Exists}`
+                  toleration (runs on EVERY node, incl. tainted control-plane/infra — the usual OneBox
+                  posture). Set your own list to restrict which taints it tolerates (this REPLACES the
+                  tolerate-all default).
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - clusterName
+            - kafka
+            - podCIDR
+            type: object
+          status:
+            description: AgentStatus is the DaemonSet-centric observed state shared
+              by every agent kind.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              desiredScheduled:
+                description: Nodes the agent DaemonSet wants a pod on.
+                format: int32
+                type: integer
+              numberReady:
+                description: Agent pods currently Ready.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: Generation last reconciled.
+                format: int64
+                type: integer
+              phase:
+                description: 'Coarse phase: Pending | Ready | Degraded.'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeraprocesses.yaml
+++ b/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeraprocesses.yaml
@@ -1,0 +1,309 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: axeraprocesses.platform.axerasecurity.com
+spec:
+  group: platform.axerasecurity.com
+  names:
+    categories:
+    - axera
+    kind: AxeraProcess
+    listKind: AxeraProcessList
+    plural: axeraprocesses
+    shortNames:
+    - axp
+    singular: axeraprocess
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.numberReady
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AxeraProcess is the Schema for the process agent — one CR per
+          monitored cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AxeraProcessSpec is the process agent (Cilium Tetragon + fluent-bit shipper) for
+              one monitored cluster. It renders into the `axera-process` namespace and ships a
+              per-cluster process topic to the central Kafka. Mirrors deploy/Axera-Process.
+
+              PREREQUISITE: the Tetragon CRDs (tracingpolicies, tracingpoliciesnamespaced,
+              podinfo) must be installed on the cluster first (deploy/Axera-Process/install-crds.sh
+              or an OLM dependency). The operator does not embed them.
+            properties:
+              clusterName:
+                description: |-
+                  Identity of THIS cluster. The process topic defaults to "<clusterName>-process".
+                  Cluster identity is carried ONLY by the topic name (Radar maps topic → cluster),
+                  so a wrong topic silently misattributes every event. REQUIRED.
+                minLength: 1
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]*$
+                type: string
+              createSCC:
+                default: true
+                description: Create the OpenShift SecurityContextConstraints (privileged
+                  + hostNetwork).
+                type: boolean
+              images:
+                description: Tetragon + fluent-bit shipper images.
+                properties:
+                  shipper:
+                    default: cr.fluentbit.io/fluent/fluent-bit:3.1.9
+                    type: string
+                  tetragon:
+                    default: quay.io/cilium/tetragon:v1.4.0
+                    type: string
+                type: object
+              installTracingPolicy:
+                default: true
+                description: Apply the observe-only tcp_connect TracingPolicy (requires
+                  the Tetragon CRDs).
+                type: boolean
+              kafka:
+                description: Central Kafka the process shipper produces to.
+                properties:
+                  bootstrapServers:
+                    description: host:port of the central broker listener the agent
+                      produces to.
+                    minLength: 1
+                    type: string
+                  caCert:
+                    description: |-
+                      Broker CA certificate (PEM) for TLS trust. Rendered into the agent's kafka
+                      Secret and referenced by the writers' caCertPath / ssl.ca.location.
+                    type: string
+                  createSecret:
+                    default: true
+                    description: |-
+                      Create the agent's kafka Secret (CA + SASL creds) from the values above
+                      (default true), or set false to bring your OWN pre-created Secret and keep
+                      credentials out of the CR. When false, pre-create the Secret with keys:
+                        ca.crt, username, password
+                      named per kind: axera-flow-kafka (flow), axera-process-kafka (process); the
+                      force/OneBox agent uses TWO Secrets — kafka-ca (key ca.crt) + kafka-sasl
+                      (keys username, password).
+                    type: boolean
+                  insecureSkipVerify:
+                    default: false
+                    description: Skip broker certificate verification (dev / self-signed
+                      only).
+                    type: boolean
+                  saslMechanism:
+                    default: ScramSha512
+                    description: |-
+                      SASL/SCRAM mechanism (only used for the Sasl* protocols). The chart maps this
+                      ONE value to the FLP (`scramSHA512`) and fluent-bit (`SCRAM-SHA-512`) spellings —
+                      it is never emitted verbatim.
+                    enum:
+                    - Plain
+                    - ScramSha256
+                    - ScramSha512
+                    type: string
+                  saslPassword:
+                    type: string
+                  saslUsername:
+                    type: string
+                  securityProtocol:
+                    default: Plaintext
+                    description: Wire security. Plaintext | Ssl | SaslPlaintext |
+                      SaslSsl.
+                    enum:
+                    - Plaintext
+                    - Ssl
+                    - SaslPlaintext
+                    - SaslSsl
+                    type: string
+                required:
+                - bootstrapServers
+                type: object
+              processTopic:
+                description: Process topic override. Default "<clusterName>-process".
+                type: string
+              tetragon:
+                description: |-
+                  Advanced Tetragon runtime tuning (safe defaults). NOTE: enable-policy-filter is
+                  deliberately NOT here — it is always rendered "true" (a false silently leaves
+                  every policy in load_error).
+                properties:
+                  enableProcessCred:
+                    default: false
+                    type: boolean
+                  enableProcessNs:
+                    default: false
+                    type: boolean
+                  exportFileMaxBackups:
+                    default: 3
+                    type: integer
+                  exportFileMaxSizeMb:
+                    default: 50
+                    type: integer
+                type: object
+              tracingPolicyPodSelector:
+                description: |-
+                  podSelector for the TracingPolicy (empty = all pods; host processes are never
+                  pods and are filtered out regardless).
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - clusterName
+            - kafka
+            type: object
+          status:
+            description: AgentStatus is the DaemonSet-centric observed state shared
+              by every agent kind.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              desiredScheduled:
+                description: Nodes the agent DaemonSet wants a pod on.
+                format: int32
+                type: integer
+              numberReady:
+                description: Agent pods currently Ready.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: Generation last reconciled.
+                format: int64
+                type: integer
+              phase:
+                description: 'Coarse phase: Pending | Ready | Degraded.'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeras.yaml
+++ b/operators/axera-operator/0.9.12/manifests/platform.axerasecurity.com_axeras.yaml
@@ -1,0 +1,1038 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: axeras.platform.axerasecurity.com
+spec:
+  group: platform.axerasecurity.com
+  names:
+    categories:
+    - axera
+    kind: Axera
+    listKind: AxeraList
+    plural: axeras
+    shortNames:
+    - axr
+    singular: axera
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.readyComponents
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Axera is the Schema for the axeras API — one CR deploys the whole
+          platform.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AxeraSpec defines the desired state of the Axera platform.
+            properties:
+              ai:
+                description: AISpec selects internal Ollama vs external LLM endpoint
+                  for incident triage.
+                properties:
+                  advisory:
+                    description: AIAdvisorySpec seeds the initial behavioral-anomaly
+                      advisory settings row.
+                    properties:
+                      cron:
+                        default: 0 */6 * * *
+                        type: string
+                      enabled:
+                        type: boolean
+                      lookbackHours:
+                        default: 24
+                        type: integer
+                      maxDestinationsPerWorkload:
+                        default: 40
+                        type: integer
+                      maxWorkloads:
+                        default: 30
+                        type: integer
+                      minConfidence:
+                        default: 70
+                        type: integer
+                    type: object
+                  baseUrl:
+                    type: string
+                  enabled:
+                    default: true
+                    description: Master switch. false → API runs with Ai__Enabled=false.
+                    type: boolean
+                  external:
+                    default: false
+                    description: true → point at ai.baseUrl; false → deploy Ollama
+                      in-cluster.
+                    type: boolean
+                  extraModels:
+                    items:
+                      type: string
+                    type: array
+                  model:
+                    default: llama3.2:3b
+                    type: string
+                  pullModel:
+                    default: true
+                    type: boolean
+                  storage:
+                    default: 20Gi
+                    description: Internal-Ollama PVC size (external=false).
+                    type: string
+                  temperature:
+                    default: "0.2"
+                    type: string
+                  timeoutSeconds:
+                    default: "120"
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: baseUrl is required when ai.external is true
+                  rule: '!self.external || (has(self.baseUrl) && self.baseUrl != '''')'
+              app:
+                description: |-
+                  AppSpec holds application-wide secrets and config. Empty secret values are
+                  auto-generated on first install and re-read from the Secret on upgrades.
+                properties:
+                  accessTokenSecret:
+                    type: string
+                  adminEmail:
+                    default: admin@example.com
+                    type: string
+                  adminPassword:
+                    type: string
+                  adminUsername:
+                    default: admin
+                    type: string
+                  archiverIntervalMinutes:
+                    default: 60
+                    type: integer
+                  corsOrigins:
+                    description: CORS origins added to all .NET services (frontend
+                      Route URL appended automatically).
+                    items:
+                      type: string
+                    type: array
+                  dpKeysStore:
+                    description: |-
+                      DataProtection key-ring store: "FileSystem" (128Mi RWO PVC, default) or "Database"
+                      (keys in the app DB — storage-less, no PVC, survives restarts). Use Database when the
+                      cluster has no StorageClass.
+                    enum:
+                    - FileSystem
+                    - Database
+                    type: string
+                  encryptionIV:
+                    type: string
+                  encryptionKey:
+                    type: string
+                  internalToken:
+                    type: string
+                  ovn:
+                    description: OVNSpec configures the AllowDropMonitor OVN ACL log
+                      collector.
+                    properties:
+                      aggIntervalMin:
+                        default: 1
+                        type: integer
+                      container:
+                        default: ovn-acl-logging
+                        type: string
+                      logPodLabelSelector:
+                        default: app=ovn-k8s-node
+                        type: string
+                      namespace:
+                        default: openshift-ovn-kubernetes
+                        type: string
+                      podListUrl:
+                        type: string
+                      reconnectSeconds:
+                        default: 5
+                        type: integer
+                      recordRetentionHours:
+                        default: 24
+                        type: integer
+                    type: object
+                type: object
+              backup:
+                description: Scheduled PostgreSQL backups (Level 3 full-lifecycle).
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  pgImage:
+                    description: |-
+                      Postgres image the pg_dump / pg_restore Jobs run. Its MAJOR version MUST be
+                      >= your database server's (pg_dump refuses a newer server). Defaults to a
+                      certified rhel9/postgresql image; override for external servers on newer PG.
+                    type: string
+                  storage:
+                    description: Storage backing for the shared /backups volume (mounted
+                      by the API + the Jobs).
+                    properties:
+                      accessMode:
+                        description: PVC access mode — ReadWriteMany when the cluster
+                          supports it.
+                        type: string
+                      createPvc:
+                        default: false
+                        description: |-
+                          Create the shared backup PVC (type=pvc). Defaults FALSE so clusters without a (RWX)
+                          StorageClass install cleanly — the api pod then does NOT mount /backups and can't wedge
+                          on a missing claim. Set true to auto-create the PVC, or set pvcClaimName to bring your own.
+                        type: boolean
+                      nfs:
+                        description: NFS backing (used when type=nfs).
+                        properties:
+                          path:
+                            type: string
+                          server:
+                            type: string
+                        type: object
+                      pvcClaimName:
+                        description: Name of the shared backup PVC.
+                        type: string
+                      size:
+                        description: PVC size (type=pvc).
+                        type: string
+                      storageClass:
+                        description: PVC StorageClass. Empty → cluster default (must
+                          be RWX-capable, e.g. CephFS/NFS).
+                        type: string
+                      type:
+                        default: pvc
+                        description: 'Storage backing: "pvc" (default) or "nfs".'
+                        type: string
+                    type: object
+                type: object
+              frontend:
+                description: FrontendSpec configures the Next.js frontend.
+                properties:
+                  basepath:
+                    type: string
+                type: object
+              global:
+                description: GlobalSpec holds cluster-wide deployment settings.
+                properties:
+                  clusterDomain:
+                    description: OpenShift apps/wildcard domain used to derive Route
+                      hostnames. Empty → OpenShift auto-assigns.
+                    type: string
+                  createSCC:
+                    default: true
+                    description: Create the SecurityContextConstraints + RBAC. Disable
+                      if a cluster admin pre-creates them.
+                    type: boolean
+                  dpKeysFsGroup:
+                    default: 1001
+                    description: GID that owns the API DataProtection key-ring PVC.
+                      Only used when createSCC=true.
+                    format: int64
+                    type: integer
+                  imageRegistry:
+                    default: quay.io/axera
+                    description: Image registry prefix (no trailing slash). Full path
+                      = <registry>/<repo>:<tag>.
+                    type: string
+                  storageClass:
+                    description: PVC StorageClass for stateful workloads. Empty →
+                      cluster default StorageClass.
+                    type: string
+                type: object
+              imagePullSecret:
+                description: ImagePullSecretSpec configures pulling from a private
+                  registry.
+                properties:
+                  dockerconfigjson:
+                    description: base64-encoded ~/.docker/config.json. Leave empty
+                      to reference a pre-created secret.
+                    type: string
+                  enabled:
+                    default: false
+                    type: boolean
+                  name:
+                    default: axera-pull-secret
+                    type: string
+                type: object
+              images:
+                description: |-
+                  ImagesSpec holds optional per-image overrides. Unset images fall back to built-in
+                  defaults; unset Axera-component tags fall back to .spec.version.
+                properties:
+                  allowdropmonitor:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  api:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  frontend:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  kafka:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  kafkaUi:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  networkpolicywatcher:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  ollama:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  postgres:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  radar:
+                    description: ImageRef is a single container image coordinate.
+                      Registry overrides global.imageRegistry.
+                    properties:
+                      registry:
+                        type: string
+                      repo:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                type: object
+              kafka:
+                description: KafkaSpec selects internal (single-node KRaft) vs external
+                  Kafka.
+                properties:
+                  bootstrapServers:
+                    type: string
+                  caCert:
+                    description: Custom CA certificate (PEM). Empty → system CA bundle.
+                    type: string
+                  enableUI:
+                    default: true
+                    description: Deploy Kafka-UI alongside internal Kafka. Auto-disabled
+                      when external=true.
+                    type: boolean
+                  external:
+                    default: false
+                    type: boolean
+                  globalnet:
+                    description: |-
+                      Globalnet reflector — resolves a Submariner peer's Globalnet egress IP back to
+                      its cluster + workload from the Submariner allocation CRs. Fail-safe on
+                      non-Submariner clusters. Only meaningful with interClusterTopics set.
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                      refreshSeconds:
+                        default: 300
+                        type: integer
+                    type: object
+                  interClusterTopics:
+                    description: |-
+                      Cross-cluster (Submariner/Globalnet) ingress topics — consumed by Radar on a
+                      SEPARATE lane so Globalnet-address sources aren't mistaken for local pods and
+                      dropped. Empty = single-cluster / non-Submariner. Omit clusterName for the
+                      shared intercluster topic (each record carries its own observing-cluster stamp).
+                    items:
+                      description: |-
+                        KafkaInterClusterTopic is a cross-cluster (Submariner) ingress topic Radar
+                        consumes on the Globalnet lane.
+                      properties:
+                        clusterName:
+                          description: Leave empty for the shared intercluster topic
+                            (each record self-stamps its cluster).
+                          type: string
+                        groupId:
+                          type: string
+                        topic:
+                          minLength: 1
+                          type: string
+                      required:
+                      - topic
+                      type: object
+                    type: array
+                  processTopics:
+                    items:
+                      description: KafkaProcessTopic is a per-cluster Tetragon process-event
+                        topic for Radar.
+                      properties:
+                        clusterName:
+                          type: string
+                        groupId:
+                          type: string
+                        topic:
+                          minLength: 1
+                          type: string
+                      required:
+                      - topic
+                      type: object
+                    type: array
+                  saslMechanism:
+                    description: |-
+                      Confluent.Kafka SaslMechanism enum names — the app binds this verbatim via
+                      GetValue<Confluent.Kafka.SaslMechanism>, so it must be the PascalCase form
+                      (NOT Kafka-standard SCRAM-SHA-512, which fails to parse → SASL silently unset).
+                    enum:
+                    - Plain
+                    - ScramSha256
+                    - ScramSha512
+                    - Gssapi
+                    - OAuthBearer
+                    type: string
+                  saslPassword:
+                    type: string
+                  saslUsername:
+                    type: string
+                  securityProtocol:
+                    default: Plaintext
+                    enum:
+                    - Plaintext
+                    - Ssl
+                    - SaslPlaintext
+                    - SaslSsl
+                    type: string
+                  storage:
+                    default: 50Gi
+                    type: string
+                  topics:
+                    items:
+                      description: KafkaTopic is a flow topic consumed by Radar.
+                      properties:
+                        groupId:
+                          type: string
+                        topic:
+                          minLength: 1
+                          type: string
+                      required:
+                      - topic
+                      type: object
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: saslMechanism is required when securityProtocol is SaslPlaintext
+                    or SaslSsl
+                  rule: '!(self.securityProtocol in [''SaslPlaintext'',''SaslSsl''])
+                    || (has(self.saslMechanism) && self.saslMechanism != '''')'
+              licensing:
+                description: LicensingSpec configures trial + node-count strategy.
+                properties:
+                  nodeCountStrategy:
+                    default: MonitoredOnly
+                    enum:
+                    - HostOnly
+                    - MonitoredOnly
+                    - HostPlusMonitored
+                    type: string
+                  trial:
+                    description: TrialSpec configures the 15-day trial bootstrap.
+                    properties:
+                      customer:
+                        default: Trial
+                        type: string
+                      days:
+                        default: 15
+                        type: integer
+                      enabled:
+                        default: true
+                        type: boolean
+                      maxWorkerNodes:
+                        default: 999
+                        type: integer
+                    type: object
+                type: object
+              logging:
+                description: Logging controls the platform's Serilog minimum log levels.
+                properties:
+                  level:
+                    default: Error
+                    description: |-
+                      Global minimum level: Verbose | Debug | Information | Warning | Error | Fatal.
+                      Default Error keeps production quiet (errors only); raise to Information/Debug to troubleshoot.
+                    type: string
+                  overrides:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Per-source minimum-level overrides (source-context → level), applied on top of Level —
+                      e.g. keep noisy framework namespaces (Microsoft.AspNetCore, EntityFrameworkCore) quiet
+                      when Level is raised to Information/Debug.
+                    type: object
+                type: object
+              monitoring:
+                description: 'Deep-Insights monitoring: ServiceMonitor + PrometheusRule
+                  (Level 4).'
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                type: object
+              networkPolicies:
+                description: NetworkPoliciesSpec toggles the defensive NetworkPolicies.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                type: object
+              postgres:
+                description: PostgresSpec selects internal (two StatefulSets) vs external
+                  Postgres.
+                properties:
+                  appDbConnString:
+                    description: .NET ConnectionString used when external=true.
+                    type: string
+                  appDbName:
+                    default: MicrosegmentationDB
+                    type: string
+                  external:
+                    default: false
+                    description: true → use external connection strings; false → deploy
+                      internal Postgres.
+                    type: boolean
+                  password:
+                    description: Empty → strong password generated on first install
+                      and reused on upgrades.
+                    type: string
+                  radarConnString:
+                    type: string
+                  radarDbName:
+                    default: AxeraRadarDB
+                    type: string
+                  runMigrations:
+                    default: true
+                    description: Run EF migration Jobs against both databases (idempotent).
+                    type: boolean
+                  storage:
+                    default: 20Gi
+                    type: string
+                  user:
+                    default: postgres
+                    type: string
+                type: object
+              resources:
+                description: |-
+                  ResourcesSpec holds requests/limits for the stateful workloads. Nil entries
+                  fall back to the chart's defaults (so the operator never clobbers them).
+                properties:
+                  kafka:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  ollama:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  postgres:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              routes:
+                description: RoutesSpec holds the browser-facing Routes.
+                properties:
+                  api:
+                    description: |-
+                      API ingest Route — exposes the audit-ingest PATH so REMOTE agent audit forwarders
+                      (AxeraForce on monitored clusters) can POST to this central. Off by default.
+                    properties:
+                      enabled:
+                        default: false
+                        type: boolean
+                      host:
+                        description: Route host. Empty → api-<namespace>.<clusterDomain>.
+                        type: string
+                      path:
+                        default: /api/Internal/Audit
+                        description: 'Path the Route exposes (path-scoped). Default:
+                          the audit ingest only.'
+                        type: string
+                      tls:
+                        description: RouteTLS configures OpenShift Route TLS.
+                        properties:
+                          insecureEdgeTerminationPolicy:
+                            default: Redirect
+                            enum:
+                            - None
+                            - Allow
+                            - Redirect
+                            type: string
+                          termination:
+                            default: edge
+                            enum:
+                            - edge
+                            - passthrough
+                            - reencrypt
+                            type: string
+                        type: object
+                    type: object
+                  frontend:
+                    description: FrontendRoute is the browser-facing console Route.
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                      host:
+                        type: string
+                      timeout:
+                        default: 180s
+                        description: HAProxy per-request timeout. Keep >= the API's
+                          Ai timeoutSeconds.
+                        type: string
+                      tls:
+                        description: RouteTLS configures OpenShift Route TLS.
+                        properties:
+                          insecureEdgeTerminationPolicy:
+                            default: Redirect
+                            enum:
+                            - None
+                            - Allow
+                            - Redirect
+                            type: string
+                          termination:
+                            default: edge
+                            enum:
+                            - edge
+                            - passthrough
+                            - reencrypt
+                            type: string
+                        type: object
+                    type: object
+                  kafkaUi:
+                    description: KafkaUIRoute is the Kafka-UI Route (auto-disabled
+                      when kafka.external=true).
+                    properties:
+                      enabled:
+                        default: true
+                        type: boolean
+                      host:
+                        type: string
+                      tls:
+                        description: RouteTLS configures OpenShift Route TLS.
+                        properties:
+                          insecureEdgeTerminationPolicy:
+                            default: Redirect
+                            enum:
+                            - None
+                            - Allow
+                            - Redirect
+                            type: string
+                          termination:
+                            default: edge
+                            enum:
+                            - edge
+                            - passthrough
+                            - reencrypt
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              secrets:
+                description: |-
+                  Secret management — set create=false and bring your own pre-created Secrets to
+                  keep all secret material (connection strings, encryption keys, admin password,
+                  Kafka SASL) out of the CR. See SecretsSpec for the required keys.
+                properties:
+                  create:
+                    default: true
+                    description: |-
+                      Create the axera-db-secrets, axera-app-secret and kafka-external-secret objects
+                      from spec/generated values (default true — zero-config install). Set false to bring
+                      your OWN pre-created Secrets so no plaintext secret material lives in the CR. When
+                      false you must pre-create, with these keys:
+                        axera-db-secrets:  POSTGRES_USER, POSTGRES_PASSWORD, APP_DB_NAME, RADAR_DB_NAME,
+                                           APP_DB_CONNSTR, RADAR_DB_CONNSTR
+                        axera-app-secret:  AccessTokenSecret, AdminCredentials__Username, AdminCredentials__Email,
+                                           AdminCredentials__Password, Encryption__Key, Encryption__IV, Internal__Token
+                        kafka-external-secret (external Kafka only): Kafka__BootstrapServers, Kafka__SecurityProtocol,
+                                           Kafka__SaslMechanism, Kafka__SaslUsername, Kafka__SaslPassword,
+                                           Kafka__SslCaLocation, ca.crt
+                    type: boolean
+                type: object
+              version:
+                default: v8.7.0
+                description: |-
+                  Version is informational in the certified build: the six Axera images are
+                  digest-pinned in the bundle's relatedImages, so the operand version moves by
+                  installing a new operator bundle, NOT by editing this field. status.version
+                  always reports the actual deployed platform version (the chart appVersion).
+                  It still fans out to the image tag for any image that has no pinned digest.
+                type: string
+            type: object
+          status:
+            description: AxeraStatus defines the observed state of the Axera platform.
+            properties:
+              components:
+                description: Per-workload health.
+                items:
+                  description: ComponentStatus is the observed health of one managed
+                    workload.
+                  properties:
+                    desiredReplicas:
+                      format: int32
+                      type: integer
+                    kind:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    ready:
+                      type: boolean
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              frontendURL:
+                description: Resolved frontend console URL once the Route is admitted.
+                type: string
+              lastBackupTime:
+                description: Timestamp of the last successful scheduled DB backup
+                  (when backup.enabled).
+                format: date-time
+                type: string
+              managedPolicies:
+                description: |-
+                  Number of NetworkPolicies the platform currently manages in this namespace
+                  (a coarse segmentation-coverage signal surfaced for humans + alerts).
+                format: int32
+                type: integer
+              observedGeneration:
+                description: Generation last reconciled, to detect spec drift.
+                format: int64
+                type: integer
+              phase:
+                description: 'Coarse lifecycle phase: Pending|Installing|Ready|Degraded|Upgrading|Failed.'
+                type: string
+              readyComponents:
+                description: Human-readable ready ratio, e.g. "7/8".
+                type: string
+              version:
+                description: Deployed Axera version (image tag) currently rolled out.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/axera-operator/0.9.12/metadata/annotations.yaml
+++ b/operators/axera-operator/0.9.12/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: axera-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Minimum OpenShift version — must match the replaced bundle (0.3.0 = v4.12).
+  com.redhat.openshift.versions: "v4.12"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/axera-operator/0.9.12/tests/scorecard/config.yaml
+++ b/operators/axera-operator/0.9.12/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Axera platform operator **0.9.12** — operand set bumped to the freshly certified **v9.60.0** images (egress-NAT attribution + Istio L7 mesh-policy management land in the operands).

- **Intercluster source-cluster resolution fix (OneBox agent):** the FLP `intercluster_compact` stage now carries `LabeledSrcAddr → labeled_src_addr` and the intercluster branch follows `multi_cluster_division` when that stage exists — cross-cluster (Submariner/Globalnet) flows are attributed to the right source cluster.
- **Agent config-checksum rollouts:** the agent DaemonSets (flow/process/OneBox + audit forwarder) hash their rendered config into the pod template, so config-only reconciles (like the fix above) roll the pods on upgrade instead of requiring a manual restart — config is read at startup only.
- **Operator RBAC:** the manager ClusterRole gains `k8s.ovn.org/egressips` (get/list/watch) — it grants this read to the integration cluster-read ClusterRole for egress-NAT attribution and must hold what it grants.
- Sample CRs / alm-examples sanitized to documentation-reserved values (kafka.example.com, RFC 5737 addresses).
- Operator image `sha256:7e8131a4…`; `replaces: axera-operator.v0.9.11`. `operator-sdk bundle validate` PASSED. All 5 operand v9.60.0 images preflight-certified and submitted.