### PR TITLE
operator fujitsu-enterprise-postgres-operator (7.3.7)

### DIFF
--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep-ansible-operator-metrics-service_v1_service.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep-ansible-operator-metrics-service_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fujitsu-enterprise-postgres
+    control-plane: controller-manager
+  name: fep-ansible-operator-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep-ansible-operator-metrics_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep-ansible-operator-metrics_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/instance: fep-ansible-operator-metrics
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fujitsu-enterprise-postgres
+    app.kubernetes.io/part-of: fujitsu-enterprise-postgres
+    control-plane: controller-manager
+  name: fep-ansible-operator-metrics
+spec:
+  endpoints:
+  - path: /metrics
+    port: http-metrics
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep-ansible-operator-metrics_v1_service.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep-ansible-operator-metrics_v1_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: fep-ansible-operator
+    app.kubernetes.io/instance: fep-ansible-operator-metrics
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fujitsu-enterprise-postgres
+    app.kubernetes.io/part-of: fujitsu-enterprise-postgres
+    control-plane: controller-manager
+  name: fep-ansible-operator-metrics
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepactions.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepactions.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepactions.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPAction
+    listKind: FEPActionList
+    plural: fepactions
+    singular: fepaction
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPAction is the Schema for the fepactions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          fepActionStatus:
+            description: fepActionStatus defines the observed state of FEPAction
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPAction
+            properties:
+              fepAction:
+                properties:
+                  type:
+                    description: Type of action.
+                    enum:
+                    - restart
+                    - reload
+                    - list
+                    - switchover
+                    - failover
+                    - pgpool2_restart
+                    - pod_restart
+                    - backup
+                    - backup_expire
+                    - open_tde_masterkey
+                    - create_extension
+                    - update_admin_password
+                    - promote_standby
+                    - fixed_stats
+                    - fluentbit_reload
+                    - alter_extension
+                    - update_multi_master_replication
+                    type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              sysExtraEvent:
+                description: Set to True to turn on extra events.
+                type: boolean
+              sysExtraLogging:
+                description: Set to True to turn on debugging log.
+                type: boolean
+              targetClusterName:
+                description: name of FEPCluster to action upon
+                type: string
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPAction
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepautoscales.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepautoscales.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepautoscales.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPAutoscale
+    listKind: FEPAutoscaleList
+    plural: fepautoscales
+    singular: fepautoscale
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPAutoscale is the Schema for the fepautoscales API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPAutoscale
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPAutoscale
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepbackups.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepbackups.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepbackups.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPBackup
+    listKind: FEPBackupList
+    plural: fepbackups
+    singular: fepbackup
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPBackup is the Schema for the fepbackups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPBackup
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPBackup
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepcerts.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepcerts.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepcerts.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPCert
+    listKind: FEPCertList
+    plural: fepcerts
+    singular: fepcert
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPCert is the Schema for the fepcerts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPCert
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPCert
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepclusters.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepclusters.yaml
@@ -1,0 +1,2048 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepclusters.fep.fujitsu.io
+spec:
+  conversion:
+    strategy: None
+  group: fep.fujitsu.io
+  names:
+    kind: FEPCluster
+    listKind: FEPClusterList
+    plural: fepclusters
+    shortNames:
+    - fep
+    singular: fepcluster
+  scope: Namespaced
+  versions:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: FEPCluster is the Schema for the fepclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          fepStatus:
+            description: Status defines the observed state of FEPCluster
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired state of FEPCluster
+            properties:
+              fep:
+                properties:
+                  autoPodRestart:
+                    description: Optional. This parameter affects the behaviour when
+                      value(s) of CPU, memory and/or image for FEP and/or optional
+                      Backup container are updated in FEPCluster CR. If it is NOT
+                      defined or set to True, operator will automatically create an
+                      action CR to make values effective by restarting all pods in
+                      an orderly fashion to minmise outage. If is set to False, automatic
+                      restart of PODs will NOT happen. To make the changes effective,
+                      user must restart pods by creating action CR with type pod_restart
+                      and arguments ALL
+                    type: boolean
+                  autoTuning:
+                    description: Common settings for the FEP autotuning function
+                    properties:
+                      prometheus:
+                        description: Configuring to Connect to Prometheus
+                        properties:
+                          authSecret:
+                            description: This is Optional section. Authentication
+                              secret
+                            properties:
+                              passwordKey:
+                                description: Mandatory Key of password in specified
+                                  secret
+                                type: string
+                              proxyKey:
+                                description: Mandatory Key of proxy in specified secret
+                                type: string
+                              secretName:
+                                description: Mandatory Name of secret that contains
+                                  username and password
+                                type: string
+                              tokenKey:
+                                description: Mandatory Key of token in specified secret
+                                type: string
+                              userKey:
+                                description: Mandatory Key of username in specified
+                                  secret
+                                type: string
+                            type: object
+                          maxRetry:
+                            description: Maximum connection attempts
+                            type: integer
+                          prometheusUrl:
+                            description: URL of Prometheus
+                            type: string
+                          tls:
+                            description: tls section for Prometheus
+                            properties:
+                              caName:
+                                description: This points to Kubernetes configmap that
+                                  contains additional CA for Prometheus to verify
+                                  client. The CA is stored in the key ca.crt
+                                type: string
+                              certificateName:
+                                description: This point to Kubernetes TLS secret that
+                                  contains the certificate for Prometheus. The certificate
+                                  itself is stored in the key tls.crt
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  backupStats:
+                    description: Define a schedule for backing up statistics
+                    properties:
+                      enable:
+                        description: Enable statistics backup schedule
+                        type: boolean
+                      image:
+                        description: Cronjob image backing up statistics.
+                        type: string
+                      pullPolicy:
+                        description: Pull policy for cronjob image
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  customAnnotations:
+                    description: Custom annotations to be added to dependent resources.
+                    properties:
+                      allDeployments:
+                        additionalProperties:
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        description: Contents under this are optional. User can remove
+                          {} and add multiple key-value pairs. All of these pair will
+                          be added to annotations of FEP statefulSet and FEP Pods.
+                          If left at default, no annotation is added to Pods and statefulSets
+                        type: object
+                    type: object
+                  databaseSize:
+                    description: Simplify defining machine specifications for database
+                      containers
+                    enum:
+                    - small
+                    - medium
+                    - large
+                    type: string
+                  externalMonitoring:
+                    description: Specify this option to use an external monitoring
+                      tool.
+                    properties:
+                      cloudWatch:
+                        properties:
+                          authentication:
+                            properties:
+                              cloudWatchConfig:
+                                description: CloudWatch config
+                                type: string
+                              cloudWatchCredentials:
+                                description: CloudWatch credential
+                                type: string
+                            type: object
+                          customMetrics:
+                            description: Specify custom metric definitions
+                            items:
+                              type: string
+                            type: array
+                          databases:
+                            description: Database to get metrics from
+                            items:
+                              type: string
+                            type: array
+                          defaultMetrics:
+                            default: true
+                            description: Enable collection of metrics defined by default
+                            type: boolean
+                          dimensionName:
+                            description: Dimension name to be added
+                            type: string
+                          dimensionValue:
+                            description: Dimension value to be added
+                            type: string
+                          enable:
+                            description: Enable Getting Metrics in CloudWatch
+                            type: boolean
+                          namespace:
+                            description: CloudWatch Namespace for Storing Metrics
+                            type: string
+                          schedule:
+                            description: Get Metrics Schedule
+                            type: string
+                        type: object
+                    type: object
+                  fepEnvSec:
+                    description: Secret name containing FEP environment variables
+                      for Patroni container
+                    type: string
+                  fepVersion:
+                    description: Optional field to specify FEP Server version to be
+                      used. If not specified, operator uses latest FEP Server version
+                      to pickup FEP Server image.
+                    type: integer
+                  fepcronjob:
+                    description: fepcronjob container parameters
+                    properties:
+                      image:
+                        description: URL for fepcronjob image; if not specified, URL
+                          for fepcronjob is fetched from operator environment variable
+                        type: string
+                      imagePullPolicy:
+                        description: Pull policy for fep cronjob image.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                  feputils:
+                    description: feputils side-car container parameters
+                    properties:
+                      PullPolicy:
+                        description: Pull policy for fep utils image.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                      fepUtilsEnvSec:
+                        description: Secret name containing fep-utils optional environment
+                          variables
+                        type: string
+                      image:
+                        description: URL for feputils image; if not specified, URL
+                          for feputils is fetched from operator environment variable
+                        type: string
+                    type: object
+                  fineTuningParams:
+                    description: Control Patroni timer
+                    properties:
+                      loop_wait:
+                        description: the number of seconds the loop will sleep.
+                        type: integer
+                      master_start_timeout:
+                        description: the amount of time a primary is allowed to recover
+                          from failures before failover is triggered (in seconds).
+                        type: integer
+                      master_stop_timeout:
+                        description: The number of seconds Patroni is allowed to wait
+                          when stopping Postgres and effective only when synchronous_mode
+                          is enabled.
+                        type: integer
+                      retry_timeout:
+                        description: timeout for DCS and PostgreSQL operation retries
+                          (in seconds). DCS or network issues shorter than this will
+                          not cause Patroni to demote the leader.
+                        type: integer
+                      ttl:
+                        description: the TTL to acquire the leader lock (in seconds).
+                          Think of it as the length of time before initiation of the
+                          automatic failover process.
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  fixedStats:
+                    description: Defines the schedule for fixing statistics and where
+                      to store statistics
+                    properties:
+                      endpoint:
+                        description: Object storage containing statistics
+                        properties:
+                          authentication:
+                            description: Authentication for accessing object storage
+                              Secret containing sensitive information.
+                            type: string
+                          protocol:
+                            description: Vendor of object storage with statistics.
+                            enum:
+                            - s3
+                            - blob
+                            - gcs
+                            - local
+                            type: string
+                        type: object
+                      image:
+                        description: Statistics Specifies the container image of the
+                          Cronjob to be pinned.
+                        type: string
+                      pullPolicy:
+                        description: Pull policy for cronjob image
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  forceSsl:
+                    description: Setting this to true will force FEP Server to only
+                      accept SSL connection. Changes are reflected in pg_hba.conf
+                    type: boolean
+                  freezingTuples:
+                    description: Defines the schedule for freezingTuples
+                    properties:
+                      enable:
+                        description: Enable freezingTuples schedule
+                        type: boolean
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  image:
+                    description: FEP Server image definition
+                    properties:
+                      image:
+                        description: It is optional. Image line is omitted by default.
+                          In such a case, it will pick up URL of image from operator
+                          container environment. If you specify the image, Operator
+                          will take that image to deploy fep container
+                        type: string
+                      pullPolicy:
+                        description: Pull policy for fep server image
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                  imagePullSecrets:
+                    description: pull secret for fep image
+                    type: string
+                  instances:
+                    description: Number of nodes in the cluster, including both Master
+                      and Replicas. Default is 1. However, user can change it to 3
+                      for 1 master and 2 replicas.
+                    minimum: 1
+                    type: integer
+                  mcSpec:
+                    description: resource specifications for fep-patroni container
+                    properties:
+                      limits:
+                        description: Limits of allocated resources
+                        properties:
+                          cpu:
+                            default: 500m
+                            description: cpu limit for fep-patroni container
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                            x-kubernetes-preserve-unknown-fields: true
+                          memory:
+                            default: 700Mi
+                            description: memory limit for fep-patroni container
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      requests:
+                        description: Initial request of allocated resources
+                        properties:
+                          cpu:
+                            default: 200m
+                            description: cpu request
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                            x-kubernetes-preserve-unknown-fields: true
+                          memory:
+                            default: 512Mi
+                            description: memory request
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  measurement:
+                    description: Defines measurement sub-features, e.g. recallForVector
+                    properties:
+                      recallForVector:
+                        description: Reproducible measurement configuration for vector
+                          DB's recall
+                        properties:
+                          ParallelJobs:
+                            default: 5
+                            description: Number of parallel sub-jobs to run in the
+                              measurement
+                            maximum: 2147483646
+                            minimum: 1
+                            type: integer
+                          alertThreshold:
+                            default: 0
+                            description: Alert if recall < threshold. 0 means no alert
+                            maximum: 1
+                            minimum: 0
+                            type: number
+                          enable:
+                            default: false
+                            description: If true, enable the recallForVector measurement
+                              job
+                            type: boolean
+                          maxDuration:
+                            default: "0"
+                            description: Max duration for the job, e.g. '40h'. '0'
+                              by default which means no limit
+                            type: string
+                          sampleSize:
+                            default: 100
+                            description: Number of samples for recall measurement
+                            maximum: 2147483646
+                            minimum: 1
+                            type: integer
+                          schedule:
+                            default: 15 0 1 * *
+                            description: Cron expression for scheduling the recall
+                              job (e.g. '15 0 1 * *')
+                            type: string
+                          targets:
+                            description: List of DB connection info and table configs
+                            items:
+                              properties:
+                                database:
+                                  description: Name of the target database to measure
+                                    recall
+                                  type: string
+                                tableConfigs:
+                                  description: Table/coulmn config details
+                                  items:
+                                    properties:
+                                      distanceMetric:
+                                        default: cosine
+                                        description: Distance metric (cosine, l2,
+                                          inner_product)
+                                        type: string
+                                      schemaObject:
+                                        description: Schema.Table.Column string
+                                        type: string
+                                    required:
+                                    - schemaObject
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                              type: object
+                            minItems: 1
+                            type: array
+                          topK:
+                            default: 5
+                            description: Top K results for recall measurement
+                            maximum: 2147483646
+                            minimum: 1
+                            type: integer
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  monitoring:
+                    description: This is an Optional section. This defines whether
+                      monitoring enabled(true) or disabled(false) , MTLS enabled or
+                      disabled & Basic authentication enabled or not
+                    properties:
+                      enable:
+                        description: This flag enables the monitoring function. If
+                          set to true, Postgres metric will be exposed via fep-exporter.
+                        type: boolean
+                      fepExporter:
+                        description: This is Optional section. Exporter spec section
+                          applied only if enable is set to true
+                        properties:
+                          authSecret:
+                            description: 'This is Optional section. Base Authentication
+                              secret to provide username & encrypted password of user.
+                              Ref: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md
+                              for details.'
+                            properties:
+                              passwordKey:
+                                description: 'Mandatory: Key in specified secret that
+                                  contains the password '
+                                type: string
+                              secretName:
+                                description: 'Mandatory: Name of secret that contains
+                                  username and password'
+                                type: string
+                              userKey:
+                                description: 'Mandatory: Key in specified secret that
+                                  contains the username'
+                                type: string
+                            type: object
+                          customLabel:
+                            description: Array of custom labels for fepexporter to
+                              be used in ServiceMonitor and PrometheusRule
+                            items:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            type: array
+                          exporterLogLevel:
+                            description: 'Set logging level: one of debug, info, warn,
+                              error'
+                            enum:
+                            - error
+                            - debug
+                            - info
+                            - warn
+                            type: string
+                          fepExporterEnvSec:
+                            description: Secret name containing fep-exporter optional
+                              environment variables
+                            type: string
+                          tls:
+                            description: 'This is optional section. FEPExporter MTLS
+                              specs. Mandatory if tls specs defined for Prometheus
+                              specs. Ref: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md
+                              for details.'
+                            properties:
+                              caName:
+                                description: Mandatory This points to Kubernetes configmap
+                                  that contains additional CA the client use to verify
+                                  a server certificate. The CA is stored in the key
+                                  ca.crt.
+                                type: string
+                              certificateName:
+                                description: Mandatory.This points to Kubernetes TLS
+                                  secret that contains the certificate of FepExporter.
+                                  Prometheus will use this for certificate authentication.
+                                  The certificate itself is stored in the key tls.crt.
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      prometheus:
+                        description: This is Optional section. Prometheus specs are
+                          mandatory if tls specs defined for FEPExporter
+                        properties:
+                          tls:
+                            description: Prometheus MTLS specs
+                            properties:
+                              caName:
+                                description: This is an Optional parameter. This point
+                                  to Kubernetes configmap that contains additional
+                                  CA the client use to verify a server certificate.
+                                  The CA is stored in the key ca.crt.
+                                type: string
+                              certificateName:
+                                description: This is an Optional parameter. These
+                                  points to Kubernetes TLS secret that contains the
+                                  certificate of Prometheus. FEPExporter will use
+                                  this for certificate authentication. The certificate
+                                  itself is stored in the key tls.crt.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  patroni:
+                    description: patroni mtls configuration
+                    properties:
+                      tls:
+                        description: TLS configuration for patroni
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA for Patroni to verify client.
+                              The CA is stored in the key ca.crt
+                            type: string
+                          certificateName:
+                            description: This point to Kubernetes TLS secret that
+                              contains the certificate for Patroni. The certificate
+                              itself is stored in the key tls.crt
+                            type: string
+                          verifyClient:
+                            description: Whether Patroni will verify clients certificate
+                            type: string
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  pgAuditLog:
+                    description: This is an Optional section. To forward audit logs
+                      to external storage
+                    properties:
+                      auditLogPath:
+                        description: log directory for audit logs. This should be
+                          same as fepChildCrVal.customPgAudit.log_directory
+                        type: string
+                      config:
+                        description: ConfigMap name for pgAudit config file. The ConfigMap
+                          needs to have a key pgaudit.conf.
+                        type: string
+                      enable:
+                        description: This will enable pgaudit extension in postgresql.conf.
+                        type: boolean
+                      endpoint:
+                        description: 'Endpoint properties for uploading the auditlog
+                          files. File name: endpoint.conf Format: key=value'
+                        properties:
+                          authentication:
+                            description: |-
+                              Optional: A secret containing authentication info to access endpoint. The end user creates and provides the secret here.  For http protocol, create the secret with: basic_auth: <basic-credentials>  # as defined in RFC7617, https://www.ietf.org/rfc/rfc7617.txt
+                              For s3 protocol, create the secret with: aws_access_key: <AWS Access Key ID> aws_access_secret: <AWS Secret Access Key>
+                              For blob protocol, create the secret with: azure_storage_account_name: <Azure Storage Account Name> azure_storage_account_key: <Azure Storage Account Key>
+                            type: string
+                          azureBlobName:
+                            description: When protocol is blob, specify the name of
+                              Azure Blob for uploading auditlog files.
+                            type: string
+                          azureContainerName:
+                            description: When protocol is blob, specify the name of
+                              Container within Azure Storage Account for uploading
+                              aduitlog files.
+                            type: string
+                          customCertificateName:
+                            description: 'Optional: If the endpoint uses certificate
+                              authentication, this points to a secret that  contains
+                              the certificate to authenticate to the endpoint. Must
+                              be defined in spec.fepChildCrVal.customCertificates.username.
+                              If not defined, certificate will not be used when uploading
+                              file'
+                            type: string
+                          fileUploadParameter:
+                            description: 'Optional: The file upload parameter defined
+                              by the web server. If defined, it will be passed to
+                              the curl command as: curl -F ${fileUploadParameter}=@file_to_upload
+                              $url.'
+                            type: string
+                          insecure:
+                            description: 'Optional: equivalent to curl --insecure,
+                              default to false'
+                            type: boolean
+                          protocol:
+                            description: Protocol of endpoint. Supported values are
+                              http for http(s) endpoint, s3 for S3 endpoint and blob
+                              for Azure Blob storage.
+                            enum:
+                            - http
+                            - s3
+                            - blob
+                            type: string
+                          url:
+                            description: The endpoint url to upload auditlog files
+                              to. When protocol is http, specify in the format https://my.webserver/fep/auditlog
+                              When protocol is s3, specify in the format s3://my-bucket.s3.us-west-2.amazonaws.com
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedules:
+                        description: Set in pgAuditLog cron job template
+                        properties:
+                          upload:
+                            description: A ‘upload’ schedule to upload logs to endpoint,
+                              in the format of cron schedule. e.g. * 5 * * * will
+                              upload auditlog files at 5am daily
+                            type: string
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  pgBadger:
+                    description: This is an Optional section. Defines how pgBadger
+                      runs and processes logs generated
+                    properties:
+                      endpoint:
+                        description: Endpoint properties for uploading the report
+                          file.
+                        properties:
+                          authentication:
+                            description: 'Optional: A secret to contain authentication
+                              info to access endpoint. The end user creates and provides
+                              the secret here'
+                            type: string
+                          customCertificateName:
+                            description: 'Optional: The item must be defined in spec.fepChildCrVal.customCertificates.username.
+                              If not defined, certificate will not be used when uploading
+                              file'
+                            type: string
+                          fileUploadParameter:
+                            description: 'Optional: The file upload parameter defined
+                              by the web server'
+                            type: string
+                          insecure:
+                            description: 'Optional: equivalent to curl --insecure,
+                              default to false'
+                            type: boolean
+                          url:
+                            description: Endpoint url
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      options:
+                        description: 'Optional sub-section: defines optional flags
+                          and parameters for pgBadger'
+                        properties:
+                          incremental:
+                            description: If set to true, pgBadger will process newer
+                              logs since last run. Otherwise all logs are processed
+                            type: boolean
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedules:
+                        description: Set in pgBadger cron job template
+                        properties:
+                          cleanup:
+                            description: Cron expression to run cleanup job
+                            type: string
+                          create:
+                            description: Cron expression to run pgBadger to process
+                              logs
+                            type: string
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  podAntiAffinity:
+                    description: 'If True, it defines that multiple pods should not
+                      run on same worker node '
+                    type: boolean
+                  podDisruptionBudget:
+                    description: If set True, it defines disruption budget that maximum
+                      one node can be unavailable at a time
+                    type: boolean
+                  postgres:
+                    description: Postgres MTLS section
+                    properties:
+                      tls:
+                        description: TLS configuration for postgres
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA for Postgres to verify client.
+                              The CA is stored in the key ca.crt
+                            type: string
+                          certificateName:
+                            description: This point to Kubernetes TLS secret that
+                              contains the certificate for Postgres. The certificate
+                              itself is stored in the key tls.crt
+                            type: string
+                          privateKeyPassword:
+                            description: This points to Kubernetes secret that contains
+                              the password for the above private key
+                            type: string
+                          verifyClient:
+                            description: Whether Postgres will verify clients certificate
+                            type: string
+                        type: object
+                    type: object
+                  remoteLogging:
+                    description: Optional. This section defines remoteLogging configuration
+                      to send log to default or custom destinations.
+                    properties:
+                      awsCredentialSecretRef:
+                        description: |
+                          (Optional)
+                          Kubernetes secret containing the credential to AWS service (e.g. CloudWatch, Kinesis). The credential is stored in Shared Configuration File and Credentials File. Refer
+                          to https://github.com/fluent/fluent-bit-docs/blob/43c4fe134611da471e706b0edb2f9acd7cdfdbc3/administration/aws-credentials.md#2-shared-configuration-and-credentials-files for details.
+                          The name of of the Shared Configuration File must be "config" and the name of the Credentials File must be "credentials".
+                        type: string
+                      enable:
+                        description: |
+                          (Depreciated) enable is depreciated and will be removed in the future. Remote Logging (fluentbit container) is now enabled by default.
+                          This flag enables remoteLogging(Log forwarding to fluentd) functionality. If enabled, adds fluentbit sidecar for log forwarding.
+                        type: boolean
+                      fluentBitEnvSec:
+                        description: Secret name containing fluentbit optional environment
+                          variables
+                        type: string
+                      fluentbitConfigSecretRef:
+                        description: "Name of secret that contains fluentbit configuration
+                          files.\nWhen fluentbitConfigSecretRef is not defined or
+                          defined but the referenced secret doesn’t exist, FEP Operator
+                          will create a default secret with name <fep-cluster>-fluent-bit-conf(1)\nWhen
+                          fluentbitConfigSecretRef is defined, FEP Operator will use
+                          the referenced secret(2).\nWhen the referenced secret as
+                          defined in fluentbitConfigSecretRef exists, the named secret
+                          will be mounted on fep-logging-fluent-bit under /fluent-bit/etc.
+                          \n(1) The default secret contains the required keys fluent-bit.conf,
+                          fluent-bit.yaml and parsers.conf.\n(2) The custom secret
+                          must contain the required key fluent-bit.yaml and optional
+                          included keys, e.g., parsers.conf. Ref: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit
+                          for details.\n"
+                        type: string
+                      fluentbitParams:
+                        description: |
+                          (Depreciated) fluentbitParams is depreciated and will be removed in the future. Use custom fluentbit configuration file referenceed in fluentbitConfigSecretRef to set parameters.
+                          fluentbit config parameters
+                        properties:
+                          memBufLimit:
+                            description: |
+                              (Depreciated) memBufLimit is depreciated and will be removed in the future. Use custom fluentbit configuration file referenceed in fluentbitConfigSecretRef to set parameters.
+                              optional Memory buffer size limit
+                            pattern: ^([0-9.]+)([KMG]B)$
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      fluentdName:
+                        description: |
+                          (Depreciated) fluentdName is depreciated and will be removed in the future.
+                          Fluentd cr name to which log will be forwarded to.
+                        type: string
+                      googleCredentialSecretRef:
+                        description: "(Optional)\nKubernetes secret containing the
+                          credential to Google Cloud service (e.g. Stackdriver, BigQuery).
+                          The credential should be stored as GOOGLE_APPLICATION_CREDENTIALS.
+                          Refer \nto https://cloud.google.com/docs/authentication/application-default-credentials#GAC
+                          for details.\nThe name of the file must be application_default_credentials.json\".\n"
+                        type: string
+                      image:
+                        description: Optional url for fluentbit image to be used.
+                          If omitted, operator will pick up URL of the image from
+                          operator container environment.
+                        type: string
+                      mcSpec:
+                        description: resource specifications for fep-fluentbit container
+                        properties:
+                          limits:
+                            description: Resource Limit section for fluentbit container
+                            properties:
+                              cpu:
+                                description: cpu limit
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                x-kubernetes-preserve-unknown-fields: true
+                              memory:
+                                description: memory limit
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          requests:
+                            description: Resource Request for fluentbit container
+                            properties:
+                              cpu:
+                                description: cpu request
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                x-kubernetes-preserve-unknown-fields: true
+                              memory:
+                                description: memory request
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                        type: object
+                      pullPolicy:
+                        description: Pull policy for fluentbit image
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                      tls:
+                        description: This field defines tls section
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA the client use to verify a server
+                              certificate. The CA is stored in the key ca.crt.
+                            type: string
+                          certificateName:
+                            description: This points to Kubernetes TLS secret that
+                              contains the certificate of fluetbit . FEPLogging will
+                              use this for certificate authentication. The certificate
+                              itself is stored in the key tls.crt.
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  replicationSlots:
+                    description: To configure custom replication slots to be used
+                      for logical replication. These slots are retained after deletion
+                      of subscription and can be reused. This field holds the required
+                      properly formatted string
+                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
+                  servicePort:
+                    description: TCP port for FEP service
+                    type: integer
+                  standby:
+                    description: Standby FEPCluster definition
+                    properties:
+                      enable:
+                        description: Setting this to true will deploy this FEPCluster
+                          as a Standby of an existing cluster.
+                        type: boolean
+                      gcpRepoKeySecretName:
+                        description: 'If the backup repository is on Google Cloud
+                          Storage, specify the secret that has the credentials to
+                          access the storage. '
+                        type: string
+                        x-kubernetes-preserve-unknown-fields: true
+                      method:
+                        description: Method to create Standby cluster. Can be either
+                          archive-recovery or streaming. Both methods will first restore
+                          the files from backup repository. With archive-recovery,
+                          the cluster will fetch archived WAL files from backup repository
+                          and continue the recovery process. With steaming, the cluster
+                          will establish a replication connection with the Primary
+                          cluster and continue streaming replication.
+                        enum:
+                        - archive-recovery
+                        - streaming
+                        type: string
+                      pgBackrestConf:
+                        description: Required for both archive-recovery and streaming
+                          method. Specify the pgbackrest parameter pointing to the
+                          repository where the database will be restored from. This
+                          should match the pgbackrest parameters of the source cluster.
+                        type: string
+                      streaming:
+                        description: Define the source cluster for streaming replication.
+                        properties:
+                          host:
+                            description: FQDN or IP address of source cluster replicating
+                              from.
+                            type: string
+                          port:
+                            description: TCP port of source cluster replicating from.
+                            type: integer
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  sysExtraEvent:
+                    description: Set to True to turn on extra events.
+                    type: boolean
+                  sysExtraLogging:
+                    description: Set to True to turn on debugging log.
+                    type: boolean
+                  usePodName:
+                    description: Setting this key to true will make internal POD communication,
+                      both Patroni and Postgres to use hostname, instead of IP address
+                    type: boolean
+                  vectorTransformation:
+                    description: Define vectorTransformation
+                    properties:
+                      enable:
+                        description: If true vector transformation can use
+                        type: boolean
+                      hostName:
+                        description: Hostname accessible from outside the cluster
+                        type: string
+                      inferenceServer:
+                        description: Defines about inference server
+                        properties:
+                          connectionTls:
+                            description: about TLS connection
+                            properties:
+                              certificate:
+                                description: about certificate for tls
+                                properties:
+                                  grpcCertificateCaName:
+                                    description: grpc certificate chain
+                                    type: string
+                                  grpcCertificateName:
+                                    description: grpc root certficate
+                                    type: string
+                                  grpcPrivateKey:
+                                    description: grpc private key
+                                    type: string
+                                  tritonGrpcCertificateCaName:
+                                    description: triton grpc certificate chain
+                                    type: string
+                                  tritonGrpcCertificateName:
+                                    description: 'triton grpc certificate '
+                                    type: string
+                                  tritonGrpcPrivateKey:
+                                    description: triton grpc private key
+                                    type: string
+                                type: object
+                              enable:
+                                description: true to use tls
+                                type: boolean
+                            type: object
+                          image:
+                            description: type image name
+                            type: string
+                          imagePullsecrets:
+                            description: type image pull secret
+                            type: string
+                          inferenceServerPorts:
+                            description: for Inference Server connection
+                            properties:
+                              grpcPort:
+                                description: The port number for grpc
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              metricsPort:
+                                description: The port number for metrics
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            type: object
+                          mcSpec:
+                            properties:
+                              limits:
+                                properties:
+                                  cpu:
+                                    description: define limit cpu
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  memory:
+                                    description: define limit memory
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              requests:
+                                properties:
+                                  cpu:
+                                    description: define request cpu
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  memory:
+                                    description: define request memory
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      modelRepository:
+                        description: Define users
+                        properties:
+                          modelLoader:
+                            description: define load user name and password
+                            properties:
+                              name:
+                                description: define model loader name
+                                maxLength: 20
+                                pattern: ^[a-zA-Z0-9]{1,20}$
+                                type: string
+                              password:
+                                description: define model loader password
+                                maxLength: 30
+                                pattern: ^[a-zA-Z0-9!-/:-@\[-`{-~]{1,30}$
+                                type: string
+                            type: object
+                          modelOwner:
+                            description: define modelOwner name and password
+                            properties:
+                              name:
+                                description: define model owner name
+                                maxLength: 20
+                                pattern: ^[a-zA-Z0-9]{1,20}$
+                                type: string
+                              password:
+                                description: define model owner password
+                                maxLength: 30
+                                pattern: ^[a-zA-Z0-9!-/:-@\[-`{-~]{1,30}$
+                                type: string
+                            type: object
+                          modelUser:
+                            description: define model user name and password
+                            properties:
+                              name:
+                                description: define model user name
+                                maxLength: 20
+                                pattern: ^[a-zA-Z0-9]{1,20}$
+                                type: string
+                              password:
+                                description: define model user password
+                                maxLength: 30
+                                pattern: ^[a-zA-Z0-9!-/:-@\[-`{-~]{1,30}$
+                                type: string
+                            type: object
+                        type: object
+                      multiMasterReplication:
+                        description: Multi Master Replication settings
+                        properties:
+                          configMapName:
+                            description: ConfigMap name for multi master replication
+                              settings
+                            type: string
+                          enable:
+                            description: Enable multi master replication
+                            type: boolean
+                          replicationHosts:
+                            description: List of replication hosts
+                            items:
+                              properties:
+                                hostName:
+                                  description: Hostname of replication host
+                                  type: string
+                                pgAdminPassword:
+                                  description: Secret name containing replication
+                                    password
+                                  type: string
+                                pgAdminTls:
+                                  description: TLS settings for replication user
+                                  properties:
+                                    caName:
+                                      description: This points to Kubernetes configmap
+                                        that contains additional CA for replication
+                                        user to verify client. The CA is stored in
+                                        the key ca.crt
+                                      type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            maxItems: 4
+                            type: array
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      port:
+                        description: Port numbers of hosts accessible from outside
+                          the cluster
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              fepChildCrVal:
+                description: fepChildCR section
+                properties:
+                  backup:
+                    description: Backup container section
+                    properties:
+                      fepBackupEnvSec:
+                        description: Secret name containing fep-backup optional environment
+                          variables
+                        type: string
+                      image:
+                        description: Backup container image
+                        properties:
+                          image:
+                            description: It is optional. Image line is omitted by
+                              default. In such a case, it will pick up URL of image
+                              from operator container environment.If you specify the
+                              image, Operator will take that image to deploy backup
+                              container
+                            type: string
+                          pullPolicy:
+                            description: Pull policy for backup container
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                      mcSpec:
+                        description: Backup container resources
+                        properties:
+                          limits:
+                            description: Limit section for backup container resources
+                            properties:
+                              cpu:
+                                description: cpu limit
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                x-kubernetes-preserve-unknown-fields: true
+                              memory:
+                                description: memory limit
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          requests:
+                            description: request for resources
+                            properties:
+                              cpu:
+                                description: cpu request
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                x-kubernetes-preserve-unknown-fields: true
+                              memory:
+                                description: memory request
+                                pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                        type: object
+                      pgbackrestParams:
+                        description: ' the parameter set in pgbackrest.conf'
+                        type: string
+                      postScript:
+                        default: '" "'
+                        description: contains the contents of the script to be executed
+                          after the backup
+                        type: string
+                      preScript:
+                        default: '" "'
+                        description: contains the contents of the script to be executed
+                          after the backup
+                        type: string
+                      repoKeySecretName:
+                        description: Storage-account-secret for GCP
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedule:
+                        description: backup schedule
+                        properties:
+                          num:
+                            description: Number of Schedule to set
+                            type: integer
+                        type: object
+                      schedule1:
+                        description: backup schedule
+                        properties:
+                          schedule:
+                            description: backup cron
+                            type: string
+                          type:
+                            description: type of backup. either full on incr
+                            enum:
+                            - full
+                            - incr
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedule2:
+                        description: backup schedule
+                        properties:
+                          schedule:
+                            description: backup schedule cron
+                            type: string
+                          type:
+                            description: type of backup .either full or incr
+                            enum:
+                            - full
+                            - incr
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedule3:
+                        description: backup schedule
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedule4:
+                        description: backup schedule
+                        x-kubernetes-preserve-unknown-fields: true
+                      schedule5:
+                        description: backup schedule
+                        x-kubernetes-preserve-unknown-fields: true
+                      type:
+                        description: Backup Type
+                        enum:
+                        - local
+                        type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  customCertificates:
+                    description: array of elements to define certificates. Used to
+                      setup SSL connection between publisher and subscriber clusters
+                      for logical replication
+                    items:
+                      properties:
+                        caName:
+                          description: This points to Kubernetes configmap that contains
+                            CA certificate to verify server. The CA is stored in the
+                            key ca.crt
+                          type: string
+                        certificateName:
+                          description: This points to Kubernetes TLS secret that contains
+                            the custom certificate. The certificate itself is stored
+                            in the key tls.crt
+                          type: string
+                        userName:
+                          description: This should be the username of the publisher
+                            database. When this parameter is specified, an empty folder
+                            is created under FEP Server Container- /tmp/custom_certs/<username>.  The
+                            custom certificates are mounted in this empty folder.
+                            However, if this parameter is not specified, the section
+                            is ignored and folder is not created; hence the certificates
+                            are not mounted without it
+                          type: string
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type: array
+                    x-kubernetes-preserve-unknown-fields: true
+                  customPgAudit:
+                    description: PgAudit configuration.
+                    type: string
+                  customPgHba:
+                    description: Entries to be inserted into pg_hba.conf
+                    type: string
+                  customPgParams:
+                    description: Postgres configuration in postgresql.conf
+                    type: string
+                  secretStore:
+                    description: cloud key management feature definition
+                    properties:
+                      csi:
+                        description: csi definition
+                        properties:
+                          awsProvider:
+                            description: aws Provider definition
+                            properties:
+                              fepCustomCert:
+                                description: List of custom certificates used for
+                                  this provider
+                                items:
+                                  properties:
+                                    userCa:
+                                      description: Name of secret where CA is stored
+                                      type: string
+                                    userCrt:
+                                      description: Name of secret where client certificate
+                                        is stored
+                                      type: string
+                                    userName:
+                                      description: Name of user
+                                      type: string
+                                  type: object
+                                type: array
+                              fepSecrets:
+                                description: containing mappings of secrets
+                                x-kubernetes-preserve-unknown-fields: true
+                              region:
+                                description: AWS region
+                                type: string
+                              roleName:
+                                description: AWS role mapping access to keyvault
+                                type: string
+                            type: object
+                          azureProvider:
+                            description: azure Provider definition
+                            properties:
+                              credentials:
+                                description: Secret name containing azure vault principal
+                                  secret and client id
+                                type: string
+                              fepCustomCert:
+                                description: List of custom certificates used for
+                                  this provider
+                                items:
+                                  properties:
+                                    userCa:
+                                      description: Name of secret where CA is stored
+                                      type: string
+                                    userCrt:
+                                      description: Name of secret where client certificate
+                                        is stored
+                                      type: string
+                                    userName:
+                                      description: Name of user
+                                      type: string
+                                  type: object
+                                type: array
+                              fepSecrets:
+                                description: containing mappings of secrets
+                                x-kubernetes-preserve-unknown-fields: true
+                              keyvaultname:
+                                description: Azure keyvault name
+                                type: string
+                              tenantid:
+                                description: Tenant id of azure keyvault
+                                type: string
+                            type: object
+                          gcpProvider:
+                            description: gcp Provider definition
+                            properties:
+                              credentials:
+                                description: Secret name containing user id and password
+                                  to connect to gcp keyvault
+                                type: string
+                              fepCustomCert:
+                                description: List of custom certificates used for
+                                  this provider
+                                items:
+                                  properties:
+                                    userCa:
+                                      description: Name of secret where CA is stored
+                                      type: string
+                                    userCrt:
+                                      description: Name of secret where client certificate
+                                        is stored
+                                      type: string
+                                    userName:
+                                      description: Name of user
+                                      type: string
+                                  type: object
+                                type: array
+                              fepSecrets:
+                                description: containing mappings of secrets
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          providerName:
+                            description: provider name for csi
+                            enum:
+                            - azure
+                            - gcp
+                            - aws
+                            - vault
+                            type: string
+                          vaultProvider:
+                            description: HashiCorp Vault Provider definition
+                            properties:
+                              fepCustomCert:
+                                description: List of custom certificates used for
+                                  this provider
+                                items:
+                                  properties:
+                                    userCa:
+                                      description: Name of secret where CA is stored
+                                      type: string
+                                    userCrt:
+                                      description: Name of secret where client certificate
+                                        is stored
+                                      type: string
+                                    userName:
+                                      description: Name of user
+                                      type: string
+                                  type: object
+                                type: array
+                              fepSecrets:
+                                description: containing mappings of secrets
+                                x-kubernetes-preserve-unknown-fields: true
+                              roleName:
+                                description: AWS role mapping access to keyvault
+                                type: string
+                              vaultAddress:
+                                description: vault ip address
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  storage:
+                    description: Storage definition
+                    properties:
+                      accessModes:
+                        description: ' accessModes for Volumes with no accessModes
+                          defined: Specified as an array of accessModes e.g. [ReadWriteMany].
+                          If omitted, it will be treated as [ReadWriteOnce]'
+                        items:
+                          type: string
+                        type: array
+                      archivewalVol:
+                        description: Archive volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for archive volume: Specified
+                              as an array of accessModes e.g. [ReadWriteMany]. If
+                              omitted, it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          size:
+                            default: 1Gi
+                            description: Size of archive volume.The storage volumes
+                              size can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for archive volume: When this
+                              line is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                      autoresize:
+                        description: Defining PVC Extensions
+                        properties:
+                          enable:
+                            description: Enable pvc expand feature by setting enable
+                              to true
+                            type: boolean
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          interval:
+                            description: PVC Usage Check Interval
+                            type: integer
+                          mcSpec:
+                            description: resource specifications for pvc-auto-resize
+                              container
+                            properties:
+                              limits:
+                                description: limits for cpu
+                                properties:
+                                  cpu:
+                                    description: cpu limit for fep-patroni container
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  memory:
+                                    description: memory limit for fep-patroni container
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              requests:
+                                description: resource request for fep-patroni container
+                                properties:
+                                  cpu:
+                                    description: cpu request
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  memory:
+                                    description: memory request
+                                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                      backupVol:
+                        description: Backup volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for backup volume: Specified
+                              as an array of accessModes e.g. [ReadWriteMany]. If
+                              omitted, it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          size:
+                            default: 2Gi
+                            description: Size of backup volume.The storage volumes
+                              size can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for backup volume: When this
+                              line is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                      dataSize:
+                        description: Size of the data to be stored. Estimate the size
+                          of a volume with no defined size from this value.
+                        pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                        type: string
+                      dataVol:
+                        description: data volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for data volume: Specified
+                              as an array of accessModes e.g. [ReadWriteMany]. If
+                              omitted, it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          size:
+                            default: 2Gi
+                            description: Size of data volume.The storage volumes size
+                              can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for data volume: When this
+                              line is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                      inferenceVol:
+                        description: inference volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for log volume: Specified as
+                              an array of accessModes e.g. [ReadWriteMany]. If omitted,
+                              it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          size:
+                            description: Size of inference volume.The storage volumes
+                              size can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for log volume: When this line
+                              is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                        type: object
+                      logVol:
+                        description: log volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for log volume: Specified as
+                              an array of accessModes e.g. [ReadWriteMany]. If omitted,
+                              it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          size:
+                            default: 1Gi
+                            description: Size of log volume.The storage volumes size
+                              can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for log volume: When this line
+                              is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                      modelRepositoryVol:
+                        description: model repository volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for log volume: Specified as
+                              an array of accessModes e.g. [ReadWriteMany]. If omitted,
+                              it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          size:
+                            description: Size of log volume.The storage volumes size
+                              can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for log volume: When this line
+                              is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                        type: object
+                      storageClass:
+                        description: 'StorageClass for Volumes with no storageClass
+                          defined: When this line is omitted, the PV created will
+                          use default storage class in the Kubernetes cluster'
+                        type: string
+                      tablespaceVol:
+                        description: tablespace volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for table volume: Specified
+                              as an array of accessModes e.g. [ReadWriteMany]. If
+                              omitted, it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          size:
+                            default: 512Mi
+                            description: Size of table volume.The storage volumes
+                              size can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for table volume: When this
+                              line is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                      walVol:
+                        description: wal volume section
+                        properties:
+                          accessModes:
+                            description: ' accessModes for wal volume: Specified as
+                              an array of accessModes e.g. [ReadWriteMany]. If omitted,
+                              it will be treated as [ReadWriteOnce]'
+                            items:
+                              type: string
+                            type: array
+                          increase:
+                            description: PVC Expansion Amount
+                            type: integer
+                          increaseType:
+                            description: Method for estimating PVC expansion amount
+                            enum:
+                            - percent
+                            - size
+                            type: string
+                          size:
+                            default: 1200Mi
+                            description: Size of wal volume.The storage volumes size
+                              can be increased provided underlying storage supports
+                              the operation
+                            pattern: ^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$
+                            type: string
+                          storageClass:
+                            description: 'StorageClass for wal volume: When this line
+                              is omitted, the PV created will use default storage
+                              class in the Kubernetes cluster'
+                            type: string
+                          storageLimit:
+                            description: PVC Expansion Limit
+                            type: integer
+                          threshold:
+                            description: Threshold for starting PVC expansion
+                            type: integer
+                        type: object
+                    type: object
+                  sysTde:
+                    description: Not required if using FEP built-in key management
+                      for TDE. Required if using an external Key Management System
+                      (KMS) for TDE encryption key.
+                    properties:
+                      tdeType:
+                        description: Defines the type of external Key Management System
+                          (KMS) to store the encryption key for TDE
+                        enum:
+                        - tdeh
+                        - tdek
+                        type: string
+                      tdeh:
+                        description: Defines the configuration with using HPCS for
+                          encryption key.
+                        properties:
+                          address:
+                            description: HPCS ep11 server address
+                            type: string
+                          apikeyAnonymous:
+                            description: Apikey of Anonymous User
+                            type: string
+                          apikeyNormal:
+                            description: Apikey of Normal User
+                            type: string
+                          apikeySo:
+                            description: Apikey of SO User
+                            type: string
+                          endpoint:
+                            description: https://iam.cloud.ibm.com
+                            type: string
+                          instanceId:
+                            description: HPCS instance ID
+                            type: string
+                          label:
+                            description: Label for the HPCS token
+                            type: string
+                          loglevel:
+                            description: 'Supported logging levels: panic, fatal,
+                              error, warning/warn, info, debug, trace. Set to warning
+                              by default when not defined'
+                            type: string
+                          port:
+                            description: port
+                            type: string
+                          proxy:
+                            description: http and https proxy settings if required
+                              to connect to HPCS instance
+                            type: string
+                          tokenspaceidAnonymous:
+                            description: 128-bit UUID for Anonymous user
+                            type: string
+                          tokenspaceidNormal:
+                            description: 128-bit UUID for Normal user
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      tdek:
+                        description: Defines the configuraion with using KMIP for
+                          encryption key.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  sysUsers:
+                    description: users and password definition
+                    properties:
+                      passwordValid:
+                        description: Valid days for pgadminpassword
+                        properties:
+                          days:
+                            description: No of days for pgadminpassword expiration
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      pgAdminPassword:
+                        description: Optional password for user postgres. If omitted,
+                          operator generates a random password
+                        type: string
+                      pgAdminTls:
+                        description: Tls section for Postgres User
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA the client use to verify a server
+                              certificate. The CA is stored in the key ca.crt
+                            type: string
+                          certificateName:
+                            description: This points to Kubernetes TLS secret that
+                              contains the certificate of Postgres user postgres.
+                              Patroni will use this for certificate authentication.
+                              The certificate itself is stored in the key tls.crt
+                            type: string
+                          sslMode:
+                            description: ' Specify the type of TLS negotiation when
+                              Patroni connects to FEP server. (disable/allow/prefer/require/verify-ca/verify-full)'
+                            enum:
+                            - disable
+                            - allow
+                            - prefer
+                            - required
+                            - verify-ca
+                            - verify-full
+                            type: string
+                        type: object
+                      pgMetricsPassword:
+                        description: Optional password string for pgMetricsUser. If
+                          omitted, operator generates a random password
+                        type: string
+                      pgMetricsUser:
+                        description: user for FEPExporter connection
+                        type: string
+                      pgMetricsUserTls:
+                        description: Tls section for pgMetricsUser
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA the client use to verify a server
+                              certificate. The CA is stored in the key ca.crt
+                            type: string
+                          certificateName:
+                            description: This points to Kubernetes TLS secret that
+                              contains the certificate of pgMetricsUser. FEPExporter
+                              will use this for certificate authentication. The certificate
+                              itself is stored in the key tls.crt
+                            type: string
+                          sslMode:
+                            description: ' Specify the type of TLS negotiation with
+                              server. (disable/allow/prefer/require/verify-ca/verify-full)'
+                            enum:
+                            - disable
+                            - allow
+                            - prefer
+                            - required
+                            - verify-ca
+                            - verify-full
+                            type: string
+                        type: object
+                      pgRewindPassword:
+                        description: Optional password string for database user pgRewindUser.
+                          If omitted, operator generates a random password
+                        type: string
+                      pgRewindUser:
+                        description: Database user for Rewind operation
+                        type: string
+                      pgRewindUserTls:
+                        description: Tls section for pgRewindUser
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA the client use to verify a server
+                              certificate. The CA is stored in the key ca.crt
+                            type: string
+                          certificateName:
+                            description: This points to Kubernetes TLS secret that
+                              contains the certificate of Postgres user rewinduser.
+                              Patroni will use this for certificate authentication.
+                              The certificate itself is stored in the key tls.crt
+                            type: string
+                          sslMode:
+                            description: ' Specify the type of TLS negotiation with
+                              server. (disable/allow/prefer/require/verify-ca/verify-full)'
+                            enum:
+                            - disable
+                            - allow
+                            - prefer
+                            - required
+                            - verify-ca
+                            - verify-full
+                            type: string
+                        type: object
+                      pgSecurityPassword:
+                        description: Security user password
+                        type: string
+                      pgSecurityUser:
+                        description: Security user
+                        type: string
+                      pgdb:
+                        description: Database to be created during provisioning
+                        type: string
+                      pgpassword:
+                        description: Optional password for database user pguser. If
+                          omitted, operator generates a random password
+                        type: string
+                      pgreplUserTls:
+                        description: Tls section for  pgreplUser
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA the client use to verify a server
+                              certificate. The CA is stored in the key ca.crt
+                            type: string
+                          certificateName:
+                            description: This points to Kubernetes TLS secret that
+                              contains the certificate of Postgres user repluser.
+                              Patroni will use this for certificate authentication.
+                              The certificate itself is stored in the key tls.crt
+                            type: string
+                          sslMode:
+                            description: ' Specify the type of TLS negotiation when
+                              Patroni connects to FEP server. (disable/allow/prefer/require/verify-ca/verify-full)'
+                            enum:
+                            - disable
+                            - allow
+                            - prefer
+                            - required
+                            - verify-ca
+                            - verify-full
+                            type: string
+                        type: object
+                      pgreplpassword:
+                        description: Optional password for database user pgrepluser.
+                          If omitted, operator generates a random password
+                        type: string
+                      pgrepluser:
+                        description: Database user for replication
+                        type: string
+                      pguser:
+                        description: Database user to be created during provisioning
+                        type: string
+                      tdepassphrase:
+                        description: TDE keystore passphrase
+                        type: string
+                      vectorizerPassword:
+                        description: vectorizer user password
+                        type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  systemCertificates:
+                    description: Server certificate section
+                    properties:
+                      cacrt:
+                        description: Contains CA certificate for server
+                        type: string
+                      crt:
+                        description: Contains certificate for server
+                        type: string
+                      key:
+                        description: Contains certificate key for server
+                        type: string
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              globalEnvSec:
+                description: Secret name containing Global environment variables for
+                  all FEP containers
+                type: string
+              ldap:
+                description: LDAP configuation for FEP
+                properties:
+                  caConfigMapRef:
+                    description: |
+                      If LDAP server certificate is signed by a private CA, this key should point to a configmap that has the chain of certificates that ldap2pg and FEP should trust.
+                      FEP Operator expects the key name in the configmap be ca.crt(1).
+                      (1) When spec.ldap.caConfigMapRef is defined, and the referenced configmap exist, the named configmap will be mounted on fep-patroni under /tls/ldap.
+                    type: string
+                  ldapconfSecretRef:
+                    description: |
+                      Name of secret that contains the ldap.conf
+                      When spec.ldap is defined but spec.ldap.ldapconfSecretRef is not defined, FEP Operator will create a default secret <fep-cluster>-ldapconf(2).
+                      FEP Operator expects the key name in the secret be ldap.conf.
+                      (2) When the referenced secret spec.ldap.ldapconfSecretRef exists, the named secret will be mounted on fep-patroni under /etc/openldap. The environment variable LDAPCONF=/etc/openldap/ldap.conf will be exported to the fep-patroni container. If this key is not defined, Operator will create and mount default secret <fep-cluster>-ldapconf with the following content.
+                    type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ldap2pg:
+                description: Option to enable ldap2pg in FEP
+                properties:
+                  enable:
+                    description: Setting this to “true” (default) will enable ldap2pg
+                      to execute periodically according to schedule defined. Setting
+                      this to “false” will remove the cronjob that execute the ldap2pg.
+                    type: boolean
+                  ldap2pgymlConfigMapRef:
+                    description: |
+                      Name of configmap that contains the ldap2pg.yml
+                      When spec.ldap2pg is defined but spec.ldap2pg.ldap2pgymlConfigMapRef is not defined, FEP Operator will create a default configmap <fep-cluster>-ldap2pgyml(3).
+                      FEP Operator expects the key name in the configmap be ldap2pg.yml.
+                      (3) When the referenced configmap spec.ldap2pg.ldap2pgymlConfigMapRef exists, the named configmap will be mounted on fep-patroni under /tmp/.config. If the secret does not exist, Operator will create that named secret with the following content.
+                    type: string
+                  mode:
+                    description: Whether ldap2pg should run in “check mode” (default)
+                      or “real” mode. If not defined, ldap2pg will run in check mode.
+                    enum:
+                    - check
+                    - real
+                    type: string
+                  schedule:
+                    description: |
+                      schedule to execute ldap2pg in a crontab format.
+                      If defined, Operator will create a cronjob using fep-cronjob container and remote execute ldap2pg on fep-patroni container on a regular basis.
+                    type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              restoreMode:
+                description: Flag for restore
+                type: string
+            type: object
+          status:
+            description: Status defines the observed state of FEPCluster
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.fepLabelSelector
+        specReplicasPath: .spec.fep.instances
+        statusReplicasPath: .status.fepCurrentInstances
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepconfigs.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepconfigs.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepconfigs.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPConfig
+    listKind: FEPConfigList
+    plural: fepconfigs
+    singular: fepconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPConfig is the Schema for the fepconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPConfig
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPConfig
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepexporters.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepexporters.yaml
@@ -1,0 +1,236 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepexporters.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPExporter
+    listKind: FEPExporterList
+    plural: fepexporters
+    singular: fepexporter
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPExporter is the Schema for the fepexporters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPExporter
+            properties:
+              fepExporter:
+                description: FEPExporter spec section
+                properties:
+                  authSecret:
+                    description: This is Optional section. Base Authentication secret
+                      to provide username & encrypted password of user
+                    properties:
+                      passwordKey:
+                        description: Mandatory Key of password in specified secret
+                        type: string
+                      secretName:
+                        description: Mandatory Name of secret that contains username
+                          and password
+                        type: string
+                      userKey:
+                        description: Mandatory Key of username in specified secret
+                        type: string
+                    type: object
+                  customLabel:
+                    description: Array of custom labels that are added to ServiceMonitor
+                      and PrometheusRules created for this FEPExporter
+                    items:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    type: array
+                  disableDefaultAlertRules:
+                    description: Not defined or set to false => Create default alert
+                      rules. Defined and set to true => Do not create default alert
+                      rules. If Default queries are disabled => Do not create default
+                      alert rule.
+                    type: boolean
+                  disableDefaultQueries:
+                    description: Not defined or set to false => Create default queries.
+                      Defined and set to true => Do not create default queries
+                    type: boolean
+                  exporterLogLevel:
+                    default: error
+                    description: 'Set logging level: one of debug, info, warn, error'
+                    enum:
+                    - error
+                    - debug
+                    - info
+                    - warn
+                    type: string
+                  fepClusterList:
+                    description: Array of names of FEPCluster to be monitored in current
+                      namespace
+                    items:
+                      type: string
+                    type: array
+                  fepExporterEnvSec:
+                    description: Secret name containing fep-exporter optional environment
+                      variables
+                    type: string
+                  fepExporterGlobalEnvSec:
+                    description: Secret name containing fep-exporter global optional
+                      environment variables
+                    type: string
+                  image:
+                    description: FEP exporter image specification
+                    properties:
+                      image:
+                        description: FEP exporter image URL
+                        type: string
+                      pullPolicy:
+                        description: Pull policy for Exporter image.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                  mcSpec:
+                    description: Resource spec section
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            description: cpu limit for Exporter container
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                            x-kubernetes-preserve-unknown-fields: true
+                          memory:
+                            description: memory limit for Exporter container
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            description: cpu request for Exporter container
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                            x-kubernetes-preserve-unknown-fields: true
+                          memory:
+                            description: memory request for Exporter container
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  option:
+                    description: This is optional section. FEPExporter optional parameters
+                    properties:
+                      measurement:
+                        description: Measurement exporter parameters.
+                        properties:
+                          recallForVector:
+                            description: Recall for vector exporter parameters.
+                            properties:
+                              alertThreshold:
+                                default: 0
+                                description: |
+                                  Threshold for Vector DB recall alert.
+                                  0 => Off (no alert triggered)
+                                  Any other number => On (alert if recall < threshold)
+                                type: number
+                              enable:
+                                default: false
+                                description: |
+                                  Enable recall for vector exporter.
+                                  If enable, recall for vector exporter will be created.
+                                type: boolean
+                            type: object
+                        type: object
+                    type: object
+                  restartRequired:
+                    description: |
+                      True: To restart FEPExporter pod, if needed to make any change in FEPExporter or FEPCluster CR effective for metrics scraping
+                      False: Will not restart FEPExporter
+                    type: boolean
+                  scrapeInterval:
+                    default: 30s
+                    description: |
+                      This parameter may be specified to change statistics scraping frequency. If specified, Prometheus will poll FEPExporter at given interval.
+                      CHANGE THIS PARAMETER ONLY IF REALLY REQUIRED
+                    type: string
+                  scrapeTimeout:
+                    default: 30s
+                    description: |
+                      This parameter may be specified to change statistics scraping timeout. If specified, Prometheus will wait for FEPExporter for maximum this given period to return statistics.
+                      CHANGE THIS PARAMETER ONLY IF REALLY REQUIRED
+                    type: string
+                  sysExtraLogging:
+                    description: To turn on extra debugging messages for operator
+                      reconciliation loop for FEPExporter CR, set value to true. It
+                      can turn on/off anytime
+                    type: boolean
+                  tls:
+                    description: This is optional section. FEPExporter MTLS specs.
+                      Mandatory if tls specs defined for Prometheus specs
+                    properties:
+                      caName:
+                        description: |
+                          This points to Kubernetes configmap that contains additional CA the client uses to verify a server certificate.
+                          The CA is stored in the key ca.crt.
+                        type: string
+                      certificateName:
+                        description: |
+                          This points to Kubernetes TLS secret that contains the certificate of FepExporter to listen on.
+                          The certificate itself is stored in the key tls.crt.
+                        type: string
+                    type: object
+                  userCustomQueries:
+                    description: Example user’s custom query to extract additional
+                      metrics.
+                    type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              prometheus:
+                description: Prometheus MTLS spec section
+                properties:
+                  tls:
+                    description: tls section
+                    properties:
+                      caName:
+                        description: This points to Kubernetes configmap that contains
+                          additional CA the client use to verify a server certificate.
+                          The CA is stored in the key ca.crt.
+                        type: string
+                      certificateName:
+                        description: This points to Kubernetes TLS secret that contains
+                          the certificate of Prometheus ServiceMonitor. FEPExporter
+                          will use this for certificate authentication. The certificate
+                          itself is stored in the key tls.crt.
+                        type: string
+                    type: object
+                type: object
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPExporter
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feploggings.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feploggings.yaml
@@ -1,0 +1,219 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: feploggings.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPLogging
+    listKind: FEPLoggingList
+    plural: feploggings
+    singular: feplogging
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPLogging is the Schema for the feploggings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPLogging
+            properties:
+              fepLogging:
+                description: Logging spec section
+                properties:
+                  certCustomProperties:
+                    description: Custom certificate properties for fluentd.
+                    properties:
+                      certValidLength:
+                        description: How long (days) the certificate is valid.
+                        type: integer
+                      renewBefore:
+                        description: How many days before certificate expiry to renew
+                          certificate.
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  customLabel:
+                    additionalProperties:
+                      type: string
+                    description: Custom labels to be added to ServiceMonitor and PrometheusRules
+                      created for FEPLogging.
+                    type: object
+                  elastic:
+                    description: 'Elasticsearch definition. Ref: https://docs.fluentd.org/output/elasticsearch
+                      for details.'
+                    properties:
+                      auditLogstashPrefix:
+                        description: 'logstashPrefix for auditlog will be used in
+                          Elasticsearch logs. Default : postgres '
+                        type: string
+                      authSecret:
+                        description: Section to provide Elasticsearch authentication
+                          details using secret.
+                        properties:
+                          passwordKey:
+                            description: Name of key in secret that contains password
+                              to login to Elasticsearch.
+                            type: string
+                          secretName:
+                            description: Secret that contains Elasticsearch authentication
+                              details.
+                            type: string
+                          userKey:
+                            description: Name of key in secret that contains username
+                              to login to Elasticsearch.
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      host:
+                        description: Elasticsearch host name
+                        type: string
+                      logstashPrefix:
+                        description: 'logstashPrefix will be used in Elasticsearch
+                          logs. Default : postgres '
+                        type: string
+                      port:
+                        description: Elasticsearch port
+                        type: string
+                      scheme:
+                        description: http or https connection to Elasticsearch.
+                        type: string
+                      sslVerify:
+                        description: Verify the SSL certificate of the endpoint. If
+                          false, the endpoint SSL certificate is ignored.
+                        type: boolean
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  fepVersion:
+                    description: FEP version
+                    type: integer
+                  image:
+                    description: Fluentd image specification.
+                    properties:
+                      image:
+                        description: If not specified; image name is picked up from
+                          operator environment variable
+                        type: string
+                      pullPolicy:
+                        description: Pull policy for fluentd image.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        type: string
+                    type: object
+                  mcSpec:
+                    description: cpu and memory spec for fluentd.
+                    properties:
+                      limits:
+                        description: cpu and memory limits
+                        properties:
+                          cpu:
+                            default: 500m
+                            description: cpu limit
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                            x-kubernetes-preserve-unknown-fields: true
+                          memory:
+                            default: 700Mi
+                            description: memory description
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      requests:
+                        description: cpu and memory requests
+                        properties:
+                          cpu:
+                            default: 200m
+                            description: cpu requests
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                            x-kubernetes-preserve-unknown-fields: true
+                          memory:
+                            default: 512Mi
+                            description: memory requests
+                            pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  restartRequired:
+                    description: Set to True if restart of fluentd pod is required
+                      to make configuration change effective
+                    type: boolean
+                  scrapeInterval:
+                    description: Specifies period between scraping of FEPLogging metrics
+                      by Prometheus
+                    type: string
+                  scrapeTimeout:
+                    description: Specifies maximum period Prometheus waits for metrics
+                      to be scraped
+                    type: string
+                  sysExtraLogging:
+                    description: To turn on extra debugging messages for operator
+                      reconciliation loop for FEPLogging CR, set value to true. It
+                      can turn on/off anytime
+                    type: boolean
+                  tls:
+                    description: tls section
+                    properties:
+                      caName:
+                        description: This points to Kubernetes configmap that contains
+                          additional CA the client use to verify a server certificate.
+                          The CA is stored in the key ca.crt.
+                        type: string
+                      certificateName:
+                        description: This points to Kubernetes TLS secret that contains
+                          the certificate of Fluentd. FEPLogging will use this for
+                          certificate authentication. The certificate itself is stored
+                          in the key tls.crt.
+                        type: string
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              prometheus:
+                description: Prometheus MTLS spec section
+                properties:
+                  tls:
+                    description: tls section
+                    properties:
+                      caName:
+                        description: This points to Kubernetes configmap that contains
+                          additional CA the client use to verify a server certificate.
+                          The CA is stored in the key ca.crt.
+                        type: string
+                      certificateName:
+                        description: This points to Kubernetes TLS secret that contains
+                          the certificate of Prometheus ServiceMonitor. FEPExporter
+                          will use this for certificate authentication. The certificate
+                          itself is stored in the key tls.crt.
+                        type: string
+                    type: object
+                type: object
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPLogging
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feppgpool2certs.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feppgpool2certs.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: feppgpool2certs.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPPgpool2Cert
+    listKind: FEPPgpool2CertList
+    plural: feppgpool2certs
+    singular: feppgpool2cert
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPPgpool2Cert is the Schema for the feppgpool2certs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPPgpool2Cert
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPPgpool2Cert
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feppgpool2s.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feppgpool2s.yaml
@@ -1,0 +1,154 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: feppgpool2s.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPPgpool2
+    listKind: FEPPgpool2List
+    plural: feppgpool2s
+    singular: feppgpool2
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPPgpool2 is the Schema for the feppgpool2s API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPPgpool2
+            properties:
+              clientAuthMethod:
+                description: Client authentication method
+                enum:
+                - scram
+                - SCRAM
+                - md5
+                type: string
+              count:
+                default: 2
+                description: The number of FEP Pgpool2 containers to create.
+                minimum: 1
+                type: integer
+              customhba:
+                description: Congfiguration in pool_hba.conf.
+                type: string
+              customlogsize:
+                default: 100Mi
+                description: Log output persistent volume size
+                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                x-kubernetes-int-or-string: true
+              customparams:
+                description: the parameter set in Pgpool-II
+                type: string
+              custompcp:
+                description: Configuration in pcp.conf
+                type: string
+              customsslcacert:
+                description: Contents of the CA root certificate in PEM format
+                type: string
+              customsslcert:
+                description: Contents of public x 509 client Certificate.
+                type: string
+              customsslkey:
+                description: Contents of secret key used for the client certificate.
+                type: string
+              fepVersion:
+                description: Use the specified version of the FEPPgpool2 image.
+                maximum: 18
+                minimum: 14
+                type: integer
+              fepclustername:
+                default: new-fep
+                description: Input FEPCluster name to connect to.
+                type: string
+              image:
+                description: FEP Pgpool2 container image to use
+                type: string
+              imagePullPolicy:
+                description: Pull policy for fep pgpool2 image
+                type: string
+              limits:
+                description: Resource limit for feppgpool2 container
+                properties:
+                  cpu:
+                    default: 400m
+                    description: The number of CPUs (limit) to allocate to resources.limits.cpu.
+                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                    x-kubernetes-preserve-unknown-fields: true
+                  memory:
+                    default: 512Mi
+                    description: Memory size (limit) to allocate to resources.limits.memory.
+                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              requests:
+                description: Resource request for feppgpool2 container
+                properties:
+                  cpu:
+                    default: 200m
+                    description: The number of CPUs (requests) to allocate to resources.requests.cpu.
+                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                    x-kubernetes-preserve-unknown-fields: true
+                  memory:
+                    default: 256Mi
+                    description: Memory size (request) to allocate for resources.requests.memory.
+                    pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              scram:
+                properties:
+                  pgpoolkeySecret:
+                    description: Secret name storing the key to use in encryption/decryption
+                    type: string
+                  userinfoSecret:
+                    description: User name added independently and secret name describing
+                      password for the user
+                    type: string
+                type: object
+              serviceport:
+                default: 9999
+                description: TCP port for connecting to FEP Pgpool2 container.
+                type: integer
+              statusport:
+                default: 9898
+                description: TCP port for connecting to PCP process.
+                type: integer
+              storageclassname:
+                description: Storageclass of log output
+                type: string
+            required:
+            - limits
+            - requests
+            type: object
+          status:
+            description: Status defines the observed state of FEPPgpool2
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feprestores.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_feprestores.yaml
@@ -1,0 +1,697 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: feprestores.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPRestore
+    listKind: FEPRestoreList
+    plural: feprestores
+    singular: feprestore
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPRestore is the Schema for the feprestores API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPRestore
+            properties:
+              changeParams:
+                description: optional. Specify when changes are made during the restoration
+                  to a new DB cluster.
+                properties:
+                  fep:
+                    description: fepCR section
+                    properties:
+                      autoTuning:
+                        description: fep.autoTuning definition
+                        properties:
+                          prometheus:
+                            description: fep.autoTuning.prometheus description
+                            properties:
+                              tls:
+                                description: tls description
+                                properties:
+                                  caName:
+                                    description: Specify this to change the spec.fep.monitoring.prometheus.tls.caName
+                                      setting of toFEPClusterCR.
+                                    type: string
+                                  certificateName:
+                                    description: Specify this to change the spec.fep.monitoring.prometheus.tls.certificateName
+                                      setting of toFEPClusterCR.
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      monitoring:
+                        description: monitoring definition
+                        properties:
+                          fepExporter:
+                            description: fepExporter description
+                            properties:
+                              tls:
+                                description: tls description
+                                properties:
+                                  caName:
+                                    description: Specify this to change the spec.fep.monitoring.fepExporter.tls.caName
+                                      setting of toFEPClusterCR.
+                                    type: string
+                                  certificateName:
+                                    description: Specify this to change the spec.fep.monitoring.fepExporter.tls.certificateName
+                                      setting of toFEPClusterCR.
+                                    type: string
+                                type: object
+                            type: object
+                          prometheus:
+                            description: prometheus description
+                            properties:
+                              tls:
+                                description: tls description
+                                properties:
+                                  caName:
+                                    description: Specify this to change the spec.fep.monitoring.prometheus.tls.caName
+                                      setting of toFEPClusterCR.
+                                    type: string
+                                  certificateName:
+                                    description: Specify this to change the spec.fep.monitoring.prometheus.tls.certificateName
+                                      setting of toFEPClusterCR.
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      patroni:
+                        description: patroni definition
+                        properties:
+                          tls:
+                            description: tls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fep.patroni.tls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fep.patroni.tls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fep.patroni.tls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                        type: object
+                      postgres:
+                        description: postgres definition
+                        properties:
+                          tls:
+                            description: tls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fep.postgres.tls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fep.postgres.tls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fep.postgres.tls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                        type: object
+                      remoteLogging:
+                        description: remoteLogging definition
+                        properties:
+                          fluentbitConfigSecretRef:
+                            description: Specify this to change the spec.fep.remoteLogging.fluentbitConfigSecretRef
+                              setting of toFEPClusterCR
+                            type: string
+                          tls:
+                            description: tls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fep.remoteLogging.tls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fep.remoteLogging.tls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                        type: object
+                      vectorTransformation:
+                        description: Define vectorTransformation
+                        properties:
+                          inferenceServer:
+                            description: Defines about inference server
+                            properties:
+                              connectionTls:
+                                description: about TLS connection
+                                properties:
+                                  certificate:
+                                    description: about certificate for tls
+                                    properties:
+                                      grpcCertificateChain:
+                                        description: grpc certificate chain
+                                        type: string
+                                      grpcPrivateKey:
+                                        description: grpc private key
+                                        type: string
+                                      grpcRootCertificate:
+                                        description: grpc root certficate
+                                        type: string
+                                      tritonGrpcCertificateChain:
+                                        description: triton grpc certificate chain
+                                        type: string
+                                      tritonGrpcPrivateKey:
+                                        description: triton grpc private key
+                                        type: string
+                                      tritonGrpcRootCertificate:
+                                        description: 'triton grpc certificate '
+                                        type: string
+                                    type: object
+                                type: object
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  fepChildCrVal:
+                    description: fepChildCR section
+                    properties:
+                      backup:
+                        description: Backup container section
+                        properties:
+                          caName:
+                            description: This points to Kubernetes configmap that
+                              contains additional CA the client use to verify a server
+                              certificate. The CA is stored in the key ca.crt.
+                            type: string
+                          pgbackrestKeyParams:
+                            description: the parameter set in pgbackrestKey.conf
+                            type: string
+                          pgbackrestParams:
+                            description: the parameter set in pgbackrest.conf
+                            type: string
+                          repoKeySecretName:
+                            description: Storage-account-secret for GCP
+                            type: string
+                        type: object
+                      secretStore:
+                        description: secretStore definition
+                        properties:
+                          csi:
+                            description: csi definition
+                            properties:
+                              awsProvider:
+                                description: aws Provider definition
+                                properties:
+                                  fepCustomCert:
+                                    description: List of custom certificates used
+                                      for this provider
+                                    items:
+                                      properties:
+                                        userCa:
+                                          description: Name of secret where CA is
+                                            stored
+                                          type: string
+                                        userCrt:
+                                          description: Name of secret where client
+                                            certificate is stored
+                                          type: string
+                                        userName:
+                                          description: Name of user
+                                          type: string
+                                      type: object
+                                    type: array
+                                  fepSecrets:
+                                    description: containing mappings of secrets
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  region:
+                                    description: AWS region
+                                    type: string
+                                  roleName:
+                                    description: AWS role mapping access to keyvault
+                                    type: string
+                                type: object
+                              azureProvider:
+                                description: azure Provider definition
+                                properties:
+                                  credentials:
+                                    description: Secret name containing azure vault
+                                      principal secret and client id
+                                    type: string
+                                  fepCustomCert:
+                                    description: List of custom certificates used
+                                      for this provider
+                                    items:
+                                      properties:
+                                        userCa:
+                                          description: Name of secret where CA is
+                                            stored
+                                          type: string
+                                        userCrt:
+                                          description: Name of secret where client
+                                            certificate is stored
+                                          type: string
+                                        userName:
+                                          description: Name of user
+                                          type: string
+                                      type: object
+                                    type: array
+                                  fepSecrets:
+                                    description: containing mappings of secrets
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  keyvaultname:
+                                    description: Azure keyvault name
+                                    type: string
+                                  tenantid:
+                                    description: Tenant id of azure keyvault
+                                    type: string
+                                type: object
+                              gcpProvider:
+                                description: gcp Provider definition
+                                properties:
+                                  credentials:
+                                    description: Secret name containing user id and
+                                      password to connect to gcp keyvault
+                                    type: string
+                                  fepCustomCert:
+                                    description: List of custom certificates used
+                                      for this provider
+                                    items:
+                                      properties:
+                                        userCa:
+                                          description: Name of secret where CA is
+                                            stored
+                                          type: string
+                                        userCrt:
+                                          description: Name of secret where client
+                                            certificate is stored
+                                          type: string
+                                        userName:
+                                          description: Name of user
+                                          type: string
+                                      type: object
+                                    type: array
+                                  fepSecrets:
+                                    description: containing mappings of secrets
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              providerName:
+                                description: provider name for csi
+                                enum:
+                                - azure
+                                - gcp
+                                - aws
+                                - vault
+                                type: string
+                              vaultProvider:
+                                description: HashiCorp Vault Provider definition
+                                properties:
+                                  fepCustomCert:
+                                    description: List of custom certificates used
+                                      for this provider
+                                    items:
+                                      properties:
+                                        userCa:
+                                          description: Name of secret where CA is
+                                            stored
+                                          type: string
+                                        userCrt:
+                                          description: Name of secret where client
+                                            certificate is stored
+                                          type: string
+                                        userName:
+                                          description: Name of user
+                                          type: string
+                                      type: object
+                                    type: array
+                                  fepSecrets:
+                                    description: containing mappings of secrets
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  roleName:
+                                    description: AWS role mapping access to keyvault
+                                    type: string
+                                  vaultAddress:
+                                    description: vault ip address
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      storage:
+                        description: Storage definition
+                        properties:
+                          archivewalVol:
+                            description: Archive volume section
+                            properties:
+                              accessModes:
+                                description: ' accessModes for archive volume: Specified
+                                  as an array of accessModes e.g. [ReadWriteMany].
+                                  If omitted, it will be treated as [ReadWriteOnce]'
+                                items:
+                                  type: string
+                                type: array
+                              size:
+                                description: Size of archive volume.The storage volumes
+                                  size can be increased provided underlying storage
+                                  supports the operation
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: 'StorageClass for archive volume: When
+                                  this line is omitted, the PV created will use default
+                                  storage class in the Kubernetes cluster'
+                                type: string
+                            type: object
+                          backupVol:
+                            description: Backup volume section
+                            properties:
+                              accessModes:
+                                description: ' accessModes for backup volume: Specified
+                                  as an array of accessModes e.g. [ReadWriteMany].
+                                  If omitted, it will be treated as [ReadWriteOnce]'
+                                items:
+                                  type: string
+                                type: array
+                              size:
+                                description: Size of backup volume.The storage volumes
+                                  size can be increased provided underlying storage
+                                  supports the operation
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: 'StorageClass for backup volume: When
+                                  this line is omitted, the PV created will use default
+                                  storage class in the Kubernetes cluster'
+                                type: string
+                            type: object
+                          dataVol:
+                            description: data volume section
+                            properties:
+                              accessModes:
+                                description: ' accessModes for data volume: Specified
+                                  as an array of accessModes e.g. [ReadWriteMany].
+                                  If omitted, it will be treated as [ReadWriteOnce]'
+                                items:
+                                  type: string
+                                type: array
+                              size:
+                                description: Size of data volume.The storage volumes
+                                  size can be increased provided underlying storage
+                                  supports the operation
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: 'StorageClass for data volume: When this
+                                  line is omitted, the PV created will use default
+                                  storage class in the Kubernetes cluster'
+                                type: string
+                            type: object
+                          logVol:
+                            description: log volume section
+                            properties:
+                              accessModes:
+                                description: ' accessModes for log volume: Specified
+                                  as an array of accessModes e.g. [ReadWriteMany].
+                                  If omitted, it will be treated as [ReadWriteOnce]'
+                                items:
+                                  type: string
+                                type: array
+                              size:
+                                description: Size of log volume.The storage volumes
+                                  size can be increased provided underlying storage
+                                  supports the operation
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: 'StorageClass for log volume: When this
+                                  line is omitted, the PV created will use default
+                                  storage class in the Kubernetes cluster'
+                                type: string
+                            type: object
+                          tablespaceVol:
+                            description: tablespace volume section
+                            properties:
+                              accessModes:
+                                description: ' accessModes for table volume: Specified
+                                  as an array of accessModes e.g. [ReadWriteMany].
+                                  If omitted, it will be treated as [ReadWriteOnce]'
+                                items:
+                                  type: string
+                                type: array
+                              size:
+                                description: Size of table volume.The storage volumes
+                                  size can be increased provided underlying storage
+                                  supports the operation
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: 'StorageClass for table volume: When
+                                  this line is omitted, the PV created will use default
+                                  storage class in the Kubernetes cluster'
+                                type: string
+                            type: object
+                          walVol:
+                            description: wal volume section
+                            properties:
+                              accessModes:
+                                description: ' accessModes for wal volume: Specified
+                                  as an array of accessModes e.g. [ReadWriteMany].
+                                  If omitted, it will be treated as [ReadWriteOnce]'
+                                items:
+                                  type: string
+                                type: array
+                              size:
+                                description: Size of wal volume.The storage volumes
+                                  size can be increased provided underlying storage
+                                  supports the operation
+                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                x-kubernetes-int-or-string: true
+                              storageClass:
+                                description: 'StorageClass for wal volume: When this
+                                  line is omitted, the PV created will use default
+                                  storage class in the Kubernetes cluster'
+                                type: string
+                            type: object
+                        type: object
+                      sysUsers:
+                        description: sysUsers definition
+                        properties:
+                          pgAdminTls:
+                            description: pgAdminTls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgAdminTls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgAdminTls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgAdminTls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                              sslMode:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgAdminTls.sslMode
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                          pgMetricsUserTls:
+                            description: pgMetricsUserTls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgMetricsUserTls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgMetricsUserTls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgMetricsUserTls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                              sslMode:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgMetricsUserTls.sslMode
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                          pgRewindUserTls:
+                            description: pgRewindUserTls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgRewindUserTls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgRewindUserTls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgRewindUserTls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                              sslMode:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgRewindUserTls.sslMode
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                          pgrepluserTls:
+                            description: pgrepluserTls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgrepluserTls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgrepluserTls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgrepluserTls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                              sslMode:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.pgrepluserTls.sslMode
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                          vectorizerTls:
+                            description: vectorizerTls description
+                            properties:
+                              caName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.vectorizerTls.caName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              certificateName:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.vectorizerTls.certificateName
+                                  setting of toFEPClusterCR.
+                                type: string
+                              privateKeyPassword:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.vectorizerTls.privateKeyPassword
+                                  setting of toFEPClusterCR.
+                                type: string
+                              sslMode:
+                                description: Specify this to change the spec.fepChildCrVal.sysUsers.vectorizerTls.sslMode
+                                  setting of toFEPClusterCR.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              fepVersion:
+                description: Optional Use the specified version of FEPRestore image.
+                maximum: 18
+                minimum: 14
+                type: integer
+              fromFEPcluster:
+                default: new-fep
+                description: Name of the FEP cluster to restore from
+                type: string
+              image:
+                description: FEPRestore container image to use
+                type: string
+              imagePullPolicy:
+                default: IfNotPresent
+                description: Pull policy for fep restore image
+                type: string
+              mcSpec:
+                description: resource specifications for FEPRestore container
+                properties:
+                  limits:
+                    description: Resource limit for FEPRestore container
+                    properties:
+                      cpu:
+                        default: "0.2"
+                        description: cpu limit for FEPRestore container
+                        pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                        x-kubernetes-preserve-unknown-fields: true
+                      memory:
+                        default: 300Mi
+                        description: memory limit for FEPRestore container
+                        pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  requests:
+                    description: Resource request for FEPRestore container
+                    properties:
+                      cpu:
+                        default: "0.1"
+                        description: cpu limit for FEPRestore container
+                        pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(m|[Ee][-+]?[0-9]+)?$
+                        x-kubernetes-preserve-unknown-fields: true
+                      memory:
+                        default: 200Mi
+                        description: memory limit for FEPRestore container
+                        pattern: ^(([0-9]+(\.[0-9]+)?)|(\.[0-9]+))(([kmKMGTPE])|([KMGTPE]i)|([Ee][+-]?([0-9]+)))?$
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              restoreTargetRepo:
+                description: Optionally, you can also specify a single quotation mark.If
+                  multiple repositories are used, specify the repository from which
+                  to restore.
+                maximum: 256
+                minimum: 1
+                type: integer
+              restoredate:
+                description: 'If spec.restoretype is PITR, specify the PITR date (UTC)
+                  in YYYY-MM-DD format.Be sure to add single quotes.Example: 2020-11-25'
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+              restoretime:
+                description: 'If spec.restoretype is PITR, specify the PITR time (UTC)
+                  in HH:MM:SS format.Be sure to include single quotes.Example: 02:50:43'
+                pattern: ^([01]?[0-9]|2[0-3]):([0-5]?[0-9]):([0-5]?[0-9])$
+                type: string
+              restoretype:
+                default: latest
+                description: 'latest - Restore to the latest state PITR : Restore
+                  date/time'
+                enum:
+                - latest
+                - PITR
+                type: string
+              toFEPcluster:
+                description: Specify the name of the FEP cluster to restore to.If
+                  restoring to an existing cluster, do not specify this parameter
+                  line itself.
+                type: string
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPRestore
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepupgrades.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepupgrades.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepupgrades.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPUpgrade
+    listKind: FEPUpgradeList
+    plural: fepupgrades
+    singular: fepupgrade
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPUpgrade is the Schema for the fepupgrades API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPUpgrade
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPUpgrade
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepusers.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepusers.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepusers.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPUser
+    listKind: FEPUserList
+    plural: fepusers
+    singular: fepuser
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPUser is the Schema for the fepusers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPUser
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPUser
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepvolumes.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep.fujitsu.io_fepvolumes.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: fepvolumes.fep.fujitsu.io
+spec:
+  group: fep.fujitsu.io
+  names:
+    kind: FEPVolume
+    listKind: FEPVolumeList
+    plural: fepvolumes
+    singular: fepvolume
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: FEPVolume is the Schema for the fepvolumes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of FEPVolume
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of FEPVolume
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep_scc_clusterrole.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fep_scc_clusterrole.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: fujitsu-enterprise-postgres
+  name: fep-scc-clusterrole
+rules:
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - fep-restrictedv2-scc

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fujitsu-enterprise-postgres-operator.clusterserviceversion.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/fujitsu-enterprise-postgres-operator.clusterserviceversion.yaml
@@ -1,0 +1,1147 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "fep.fujitsu.io/v1",
+          "kind": "FEPAction",
+          "metadata": {
+            "name": "new-fep-action"
+          },
+          "spec": {
+            "fepAction": {
+              "args": [
+                "new-fep-sts-0",
+                "new-fep-sts-1"
+              ],
+              "type": "reload"
+            },
+            "sysExtraEvent": true,
+            "sysExtraLogging": false,
+            "targetClusterName": "new-fep"
+          }
+        },
+        {
+          "apiVersion": "fep.fujitsu.io/v1",
+          "kind": "FEPExporter",
+          "metadata": {
+            "name": "new-fep-exporter"
+          },
+          "spec": {
+            "fepExporter": {
+              "exporterLogLevel": "error",
+              "fepClusterList": [
+                "new-fep1"
+              ],
+              "image": {
+                "pullPolicy": "IfNotPresent"
+              },
+              "mcSpec": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "700Mi"
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "512Mi"
+                }
+              },
+              "restartRequired": false,
+              "sysExtraEvent": true,
+              "sysExtraLogging": false,
+              "userCustomQueries": "usr_example:\n  query: \"SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag\"\n  master: true\n  metrics:\n    - lag:\n        usage: \"GAUGE\"\n        description: \"Replication lag behind master in seconds\""
+            }
+          }
+        },
+        {
+          "apiVersion": "fep.fujitsu.io/v1",
+          "kind": "FEPLogging",
+          "metadata": {
+            "name": "new-fep-logging"
+          },
+          "spec": {
+            "fepLogging": {
+              "image": {
+                "pullPolicy": "IfNotPresent"
+              },
+              "mcSpec": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "700Mi"
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "512Mi"
+                }
+              },
+              "restartRequired": false,
+              "sysExtraEvent": true,
+              "sysExtraLogging": false
+            }
+          }
+        },
+        {
+          "apiVersion": "fep.fujitsu.io/v1",
+          "kind": "FEPPgpool2",
+          "metadata": {
+            "name": "new-fep-pgpool2"
+          },
+          "spec": {
+            "clientAuthMethod": "scram",
+            "count": 2,
+            "customhba": "local   all         all                               trust\nhost    all         all         127.0.0.1/32          trust\nhost    all         all         ::1/128               trust\n",
+            "customlogsize": "128Mi",
+            "customparams": "listen_addresses = '*'\npcp_listen_addresses = '*'\nnum_init_children = 32\nreserved_connections = 0\nenable_pool_hba = off\nallow_clear_text_frontend_auth = off\nauthentication_timeout = 80\nbackend_weight0 = 1\nbackend_weight1 = 1\nbackend_flag0 = 'ALWAYS_PRIMARY'\nbackend_flag1 = 'DISALLOW_TO_FAILOVER'\nconnection_cache = on\nmax_pool = 4\nlisten_backlog_multiplier = 2\nserialize_accept = off\nchild_life_time = 300\nclient_idle_limit = 0\nchild_max_connections = 0\nconnection_life_time = 0\nreset_query_list = 'ABORT; DISCARD ALL'\nclient_min_messages = info\nlog_min_messages = debug1\nlog_statement = on\nlog_per_node_statement = on\nlog_client_messages = on\nlog_hostname = on\nlog_connections = on\nlog_line_prefix = '%t: pid %p: '\nload_balance_mode = on\nignore_leading_white_space = on\nwhite_function_list = ''\nblack_function_list = 'currval,lastval,nextval,setval'\nblack_query_pattern_list = ''\ndatabase_redirect_preference_list = ''\napp_name_redirect_preference_list = ''\nallow_sql_comments = off\ndisable_load_balance_on_write = 'transaction'\nstatement_level_load_balance = on\nsr_check_period = 0\nsr_check_user = 'postgres'\ndelay_threshold = 0\nlog_standby_delay = 'none'\nssl = on\nssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL'\nssl_prefer_server_ciphers = off\nssl_ecdh_curve = 'prime256v1'\nssl_dh_params_file = ''\nrelcache_expire = 0\nrelcache_size = 256\ncheck_temp_table = catalog\ncheck_unlogged_table = on\nenable_shared_relcache = off\nrelcache_query_target = primary\nwd_port0 = 9000\nfailover_on_backend_error = off\n",
+            "custompcp": "none",
+            "customsslcacert": "none",
+            "customsslcert": "-----BEGIN CERTIFICATE-----\nMIIDTzCCAjegAwIBAgIUYssQ8I74US5g+1+Z7CHuaDgkZnEwDQYJKoZIhvcNAQEL\nBQAwNzEQMA4GA1UECgwHRnVqaXRzdTEjMCEGA1UEAwwaRkVQIFJvb3QgQ0EgZm9y\nIEt1YmVybmV0ZXMwHhcNMjEwMjA2MDM1MjI4WhcNMzEwMjA0MDM1MjI4WjA3MRAw\nDgYDVQQKDAdGdWppdHN1MSMwIQYDVQQDDBpGRVAgUm9vdCBDQSBmb3IgS3ViZXJu\nZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMs97gUF0xkUzCgL\n7MiiDju9ySr/ziwjvcYU7jA9ML+SLmftMs3HtcYbAmSntqI+MDBSR/FAJTOoytuT\npV+mCFcGj2YAjDpliHPeNcUpbryy4YMChF3+MovkIwGCksxo5rhiWhGmoBYpA48P\n4Xe8SPlzqMzhFvNeKzyiUhvjutS2Y1Ss38lsTaurFPx64vQ2PaC54XzdwMptXtpb\ntYmWSzCpJWwxZ6lF3vitdA2w0tnBWNyctAd0+RIM/fvArxiIqseAux9t0uogm5to\nlRIhvekuxOpXBPEqtIYQ4j9XUW2JH8vUDnzPkPvjrq+A3Ug8OyyfGVrW7+VYXozu\nc4aP7P0CAwEAAaNTMFEwHQYDVR0OBBYEFBzCutQ7S74WEhS5V2sNEJBGyLpmMB8G\nA1UdIwQYMBaAFBzCutQ7S74WEhS5V2sNEJBGyLpmMA8GA1UdEwEB/wQFMAMBAf8w\nDQYJKoZIhvcNAQELBQADggEBAMDwD85RAaWEBptFgLzKw+9xEUy1vcZaonAuA1qc\nT342XTueyAugxkC11HwdCGgGS34VyctfMGqj4AW6pA2ez4tLrbOps4DmV4sw8uBL\n8pgRDgfly3ob9FEg2wa0hmrwX9jH5Bt4vySUE2785uPAqaspT2UNtTBxS85BUi1T\nsKId2Rtil6an281Z81wyWVI6Jm2D4MG0mbsiGcTPlCtdg/UljvDYymXlAvd4vNhl\nk9hDa13TgDqJKgKdTIcmZoNQdpEVgFcO0h9AEUy5AuLqxHq60dLfZ6ESGPlMI7Lm\ni4PzYbCnBmOe+7TnHcPSyrnehs66Ik+oifRd82eYS7vKjFw=\n-----END CERTIFICATE-----",
+            "customsslkey": "none",
+            "fepclustername": "new-fep",
+            "imagePullPolicy": "IfNotPresent",
+            "limits": {
+              "cpu": "400m",
+              "memory": "512Mi"
+            },
+            "requests": {
+              "cpu": "200m",
+              "memory": "256Mi"
+            },
+            "serviceport": 9999,
+            "statusport": 9898
+          }
+        },
+        {
+          "apiVersion": "fep.fujitsu.io/v1",
+          "kind": "FEPRestore",
+          "metadata": {
+            "name": "new-fep-restore"
+          },
+          "spec": {
+            "fromFEPcluster": "new-fep",
+            "imagePullPolicy": "IfNotPresent",
+            "mcSpec": {
+              "limits": {
+                "cpu": "200m",
+                "memory": "300Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              }
+            },
+            "restoretype": "latest",
+            "sysExtraEvent": true,
+            "sysExtraLogging": false,
+            "toFEPcluster": "new-fep-2"
+          }
+        },
+        {
+          "apiVersion": "fep.fujitsu.io/v2",
+          "kind": "FEPCluster",
+          "metadata": {
+            "name": "new-fep"
+          },
+          "spec": {
+            "fep": {
+              "customAnnotations": {
+                "allDeployments": {}
+              },
+              "forceSsl": true,
+              "image": {
+                "pullPolicy": "IfNotPresent"
+              },
+              "instances": 1,
+              "mcSpec": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "700Mi"
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "512Mi"
+                }
+              },
+              "podAntiAffinity": false,
+              "podDisruptionBudget": false,
+              "servicePort": 27500,
+              "syncMode": "off",
+              "sysExtraEvent": true,
+              "sysExtraLogging": false,
+              "usePodName": true
+            },
+            "fepChildCrVal": {
+              "backup": {
+                "image": {
+                  "pullPolicy": "IfNotPresent"
+                },
+                "mcSpec": {
+                  "limits": {
+                    "cpu": "200m",
+                    "memory": "300Mi"
+                  },
+                  "requests": {
+                    "cpu": "100m",
+                    "memory": "200Mi"
+                  }
+                },
+                "pgbackrestParams": "# if log volume is not defined, log_directory should be\n# changed to '/database/userdata/data/log'\n[global]\nrepo1-retention-full=7\nrepo1-retention-full-type=time\nlog-path=/database/log/backup\n",
+                "postScript": " ",
+                "preScript": " ",
+                "schedule": {
+                  "num": 2
+                },
+                "schedule1": {
+                  "schedule": "15 0 * * 0",
+                  "type": "full"
+                },
+                "schedule2": {
+                  "schedule": "15 0 * * 1-6",
+                  "type": "incr"
+                },
+                "schedule3": {
+                  "schedule": " ",
+                  "type": " "
+                },
+                "schedule4": {
+                  "schedule": " ",
+                  "type": " "
+                },
+                "schedule5": {
+                  "schedule": " ",
+                  "type": " "
+                }
+              },
+              "customPgAudit": "# define pg audit custom params here to override defaults.\n# if log volume is not defined, log_directory should be\n# changed to '/database/userdata/data/log'\n[output]\nlogger = 'auditlog'\nlog_directory = '/database/log/audit'\nlog_truncate_on_rotation = on\nlog_filename = 'pgaudit-%a.log'\nlog_rotation_age = 1d\nlog_rotation_size = 0\n[rule]\n",
+              "customPgHba": "# define pg_hba custom rules here to be merged with default rules.\n# TYPE     DATABASE        USER        ADDRESS        METHOD\n",
+              "customPgParams": "# define custom postgresql.conf parameters below to override defaults.\n# Current values are as per default FEP deployment\n# If you add a library to shared_preload_libraries, add it after the default value.\n# fsep_operator_security is available in FEP15 and later container images.\nshared_preload_libraries='pgx_datamasking,pg_prewarm,pg_stat_statements,fsep_operator_security'\nsession_preload_libraries='pg_prewarm'\nmax_prepared_transactions = 100\nmax_worker_processes = 30\nmax_connections = 100\nwork_mem = 1MB\nmaintenance_work_mem = 12MB\nshared_buffers = 128MB\neffective_cache_size = 384MB\ncheckpoint_completion_target = 0.8\n# tcp parameters\ntcp_keepalives_idle = 30\ntcp_keepalives_interval = 10\ntcp_keepalives_count = 3\n# logging parameters in default fep installation\n# if log volume is not defined, log_directory should be\n# changed to '/database/userdata/data/log'\nlog_directory = '/database/log'\nlog_filename = 'logfile-%a.log'\nlog_file_mode = 0600\nlog_truncate_on_rotation = on\nlog_rotation_age = 1d\nlog_rotation_size = 0\nlog_checkpoints = on\nlog_line_prefix = '%e %t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h'\nlog_lock_waits = on\nlog_autovacuum_min_duration = 60s\nlogging_collector = on\npgaudit.config_file='/opt/app-root/src/pgaudit-cfg/pgaudit.conf'\nlog_replication_commands = on\nlog_min_messages = WARNING\nlog_destination = csvlog\n# wal_archive parameters in default fep installation\narchive_mode = on\narchive_command = 'pgbackrest --stanza=backupstanza --config=/database/userdata/pgbackrest.conf archive-push %p'\nwal_level = replica\nmax_wal_senders = 12\nwal_keep_segments = 64\ntrack_activities = on\ntrack_counts = on\npassword_encryption = 'scram-sha-256'\n",
+              "storage": {
+                "archivewalVol": {
+                  "size": "1Gi"
+                },
+                "backupVol": {
+                  "size": "2Gi"
+                },
+                "dataVol": {
+                  "size": "2Gi"
+                },
+                "logVol": {
+                  "size": "1Gi"
+                },
+                "tablespaceVol": {
+                  "size": "512Mi"
+                },
+                "walVol": {
+                  "size": "1200Mi"
+                }
+              },
+              "sysUsers": {
+                "pgRewindPassword": "rewind_password",
+                "pgRewindUser": "rewind_user",
+                "pgdb": "mydb",
+                "pgpassword": "mydbpassword",
+                "pgreplpassword": "repluserpwd",
+                "pgrepluser": "repluser",
+                "pguser": "mydbuser",
+                "tdepassphrase": "tde-passphrase"
+              },
+              "systemCertificates": {
+                "cacrt": "-----BEGIN CERTIFICATE-----\nMIIDTzCCAjegAwIBAgIUYssQ8I74US5g+1+Z7CHuaDgkZnEwDQYJKoZIhvcNAQEL\nBQAwNzEQMA4GA1UECgwHRnVqaXRzdTEjMCEGA1UEAwwaRkVQIFJvb3QgQ0EgZm9y\nIEt1YmVybmV0ZXMwHhcNMjEwMjA2MDM1MjI4WhcNMzEwMjA0MDM1MjI4WjA3MRAw\nDgYDVQQKDAdGdWppdHN1MSMwIQYDVQQDDBpGRVAgUm9vdCBDQSBmb3IgS3ViZXJu\nZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMs97gUF0xkUzCgL\n7MiiDju9ySr/ziwjvcYU7jA9ML+SLmftMs3HtcYbAmSntqI+MDBSR/FAJTOoytuT\npV+mCFcGj2YAjDpliHPeNcUpbryy4YMChF3+MovkIwGCksxo5rhiWhGmoBYpA48P\n4Xe8SPlzqMzhFvNeKzyiUhvjutS2Y1Ss38lsTaurFPx64vQ2PaC54XzdwMptXtpb\ntYmWSzCpJWwxZ6lF3vitdA2w0tnBWNyctAd0+RIM/fvArxiIqseAux9t0uogm5to\nlRIhvekuxOpXBPEqtIYQ4j9XUW2JH8vUDnzPkPvjrq+A3Ug8OyyfGVrW7+VYXozu\nc4aP7P0CAwEAAaNTMFEwHQYDVR0OBBYEFBzCutQ7S74WEhS5V2sNEJBGyLpmMB8G\nA1UdIwQYMBaAFBzCutQ7S74WEhS5V2sNEJBGyLpmMA8GA1UdEwEB/wQFMAMBAf8w\nDQYJKoZIhvcNAQELBQADggEBAMDwD85RAaWEBptFgLzKw+9xEUy1vcZaonAuA1qc\nT342XTueyAugxkC11HwdCGgGS34VyctfMGqj4AW6pA2ez4tLrbOps4DmV4sw8uBL\n8pgRDgfly3ob9FEg2wa0hmrwX9jH5Bt4vySUE2785uPAqaspT2UNtTBxS85BUi1T\nsKId2Rtil6an281Z81wyWVI6Jm2D4MG0mbsiGcTPlCtdg/UljvDYymXlAvd4vNhl\nk9hDa13TgDqJKgKdTIcmZoNQdpEVgFcO0h9AEUy5AuLqxHq60dLfZ6ESGPlMI7Lm\ni4PzYbCnBmOe+7TnHcPSyrnehs66Ik+oifRd82eYS7vKjFw=\n-----END CERTIFICATE-----",
+                "crt": "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjmgAwIBAgIRAMocW3qMoHrD6qRvMPppMkMwDQYJKoZIhvcNAQELBQAw\nNzEQMA4GA1UECgwHRnVqaXRzdTEjMCEGA1UEAwwaRkVQIFJvb3QgQ0EgZm9yIEt1\nYmVybmV0ZXMwHhcNMjEwMjA2MDQzMjM2WhcNMjYwMjA1MDQzMjM2WjA/MRAwDgYD\nVQQKEwdGdWppdHN1MSswKQYDVQQDEyJGVUpJVFNVIEVudGVycHJpc2UgUG9zdGdy\nZXMgU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4AI33yvH\nZws+jta6qpV6wzJqF8odIfTIpCfbrVcUUtLFKJ1I2e4SceTKi6O3C/I1XuvWlpng\n5IO65+fQQLO06z1/AuQT78YUn/Wlm9x1aHVsv4ANB5JWWqDOjrRT3o7nRPGXfila\nbP0rGE2mJJcVR9nExJ3IeaktgT3sb8YlXvtchyYpmjdbfxabTz07ig0+6/cwKoRR\nxOK8Uf7f5euE0cI/490J6r5Rs4lgD8sIQNCUFlTFYvmAH7gcdssSFBt8NPlUATHE\nsoFmlW0DKCJWNhTLOht+s6L/1zwTHLjPG2pdkG6Wdgmu5H2pDml8CDNLDv98Aj7i\n+I5SRKKcVPlnuQIDAQABo1AwTjAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH\nAwIwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBQcwrrUO0u+FhIUuVdrDRCQRsi6\nZjANBgkqhkiG9w0BAQsFAAOCAQEAm5dxBoI9pScOCvRAchg4CprdRDSJb9K6yB3O\nnCAxnM47iHeXnY3WlnI388kHu8DU7O4ba1tJbGs3KY9KzioPk43pU12jWkO1onoF\n+mTDjx/Ef1cYWA9r5q/LtgTa6Q2sxV4O2x67QW82aAnaxO34dV5zWCPIvAoovZBV\nHRT+BgCg3r2vD1RGKK2nl1aYJtWhO1SZubam+VttdZ/vbM9oOJctxmImsEtBXjkY\nKteePdQtLL5o03JhyXWyRshCq+HMmKf2KgyY8gvydGcP4eLQdBWcW40LcnVq6UjT\n0kJycJEKngMVademq1ZWHGaiYB7hyT6GhgIcHUJ2cKrPgbEh1Q==\n-----END CERTIFICATE-----",
+                "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA4AI33yvHZws+jta6qpV6wzJqF8odIfTIpCfbrVcUUtLFKJ1I\n2e4SceTKi6O3C/I1XuvWlpng5IO65+fQQLO06z1/AuQT78YUn/Wlm9x1aHVsv4AN\nB5JWWqDOjrRT3o7nRPGXfilabP0rGE2mJJcVR9nExJ3IeaktgT3sb8YlXvtchyYp\nmjdbfxabTz07ig0+6/cwKoRRxOK8Uf7f5euE0cI/490J6r5Rs4lgD8sIQNCUFlTF\nYvmAH7gcdssSFBt8NPlUATHEsoFmlW0DKCJWNhTLOht+s6L/1zwTHLjPG2pdkG6W\ndgmu5H2pDml8CDNLDv98Aj7i+I5SRKKcVPlnuQIDAQABAoIBAFPQYKlOzw/+BA0b\nyMIUpdctIMb/54CR/xR0mVw1DbSjigNVPjHUQvB8Y1B2FAITQObgJO06bAv0QdWN\nRb0/v/yYiNJDFjaLjaIAHlO/2+oWrXbFaZqgpVDJhB+e1xaZr2x7XGxm+p925k30\nl6pvIRY+I8JRKvZiV1VZHwL/R3JOtPr++xMZtLVjVOI+f+ySqJ+TZHuAjm49EKxj\ncEmmJ28b7QcziXsvKy00f+zbqLIBKXQdZAFU5eEr1BsDRXdRW+Kf0XIvftuy4BJZ\nvoKT+VGhEvF/qysswL4+6IAO6tpuYnnM0Y2d3sOGoWPkTcQK0MekYKzL/WmtCjNs\n9hodJtECgYEA5EWyhEOf4uOKe5TDp697UCUvXLoOR58FDe/S8XNvScn29jjOkqIg\nOMoqo9xAkJTNTzqn5UUdt1x/pgM2NxlPLFijrc0zQlX3SoOO2ryDd9WNi7YKtN16\nKJqa536WeZu2OEbuAZ+S3GALVy1RPeTNPnUOmKnF06DjDUGzLNCZy10CgYEA+zfw\n952DWuz1U0Z4wvAEqqcgUKXPKrkTXV/iUnjkDkrLYVr0ZofDNTXrdHl+UedFmaOC\ncieZn6DNhcdz5tKtyysGMH3g/qs9PfoGUngvcXsy0Egk04l3x1jc8TTCLqXZXYaQ\nHMsx51n+R58oncPtzYSUOr9qQ6PbC2CstTbFJA0CgYEAjGEsUliAB/jknfEzjXjG\nPdhQUxb8VyE864Az2lah9t/kJzFyIAziAeqZ5GE7t247AGFTBRTHHI8e1Qoemi3P\nWbc9GVIbFs1lIYbcIDpUIyrKPEP8O5QEXtoNLxXTFgAjRGKiVY87spjCAJ+W2ZhO\ne/1it5GYXfgQCYQA2yuBmOUCgYANRkR2YR1axaCk+NlSu6oTdmdPu6M5x7PNQE7O\nOtMaKjua9lppvIzFGAdMDUtueoEEAE7ZR1xnwfB6PDLUpJdIYAqgr1YfPt8qkjaZ\nTv56yZ7CwL0pbF8m6nwqRrZoDp1wwraEvvvxFKFKGY/k3kCHlpTakdjEoDjn3gDi\nRnWeVQKBgCEneMSzucei5LRppRtRaJw/Btll8qlPMlX3W7dxQ3cLwpmLOn0m51Fp\nPIZ44zYK8R6fu4+/sSrlfaIg86Ugeufp6YNxyNROKxUGza5vDIu5OftwWtBeg+UK\nZ8lLWNdX6pp7WMujmF3H1DrkBbauYMUKZ4UxUYtelgHERMePIxwb\n-----END RSA PRIVATE KEY-----"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Auto Pilot
+    categories: Database
+    certified: "false"
+    containerImage: quay.io/fujitsu/fujitsu-enterprise-postgres-operator@sha256:0f60f7ef8f11e1db59039a945df36fa5dc9b1d0c1f46159462384df5510f0922
+    createdAt: "2026-09-02T02:06:05Z"
+    description: OpenShift Operator for Fujitsu Enterprise Postgres
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=4.1.0 <7.3.7'
+    operators.openshift.io/valid-subscription: '["Fujitsu Enterprise Postgres Advanced
+      Edition Annual Subscription License per Core 17 Operator for Kubernetes"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
+    operators.operatorframework.io/internal-objects: '["fepautoscales.fep.fujitsu.io","fepconfigs.fep.fujitsu.io","fepusers.fep.fujitsu.io","fepcerts.fep.fujitsu.io","fepvolumes.fep.fujitsu.io","fepbackups.fep.fujitsu.io"]'
+    operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
+    support: fj-dbaas-tec@dl.jp.fujitsu.com
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+  name: fujitsu-enterprise-postgres-operator.v7.3.7
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: FEPAction
+      name: fepactions.fep.fujitsu.io
+      version: v1
+    - kind: FEPAutoscale
+      name: fepautoscales.fep.fujitsu.io
+      version: v1
+    - kind: FEPBackup
+      name: fepbackups.fep.fujitsu.io
+      version: v1
+    - kind: FEPCert
+      name: fepcerts.fep.fujitsu.io
+      version: v1
+    - kind: FEPCluster
+      name: fepclusters.fep.fujitsu.io
+      version: v2
+    - kind: FEPConfig
+      name: fepconfigs.fep.fujitsu.io
+      version: v1
+    - kind: FEPExporter
+      name: fepexporters.fep.fujitsu.io
+      version: v1
+    - kind: FEPLogging
+      name: feploggings.fep.fujitsu.io
+      version: v1
+    - kind: FEPPgpool2Cert
+      name: feppgpool2certs.fep.fujitsu.io
+      version: v1
+    - kind: FEPPgpool2
+      name: feppgpool2s.fep.fujitsu.io
+      version: v1
+    - kind: FEPRestore
+      name: feprestores.fep.fujitsu.io
+      version: v1
+    - kind: FEPUpgrade
+      name: fepupgrades.fep.fujitsu.io
+      version: v1
+    - kind: FEPUser
+      name: fepusers.fep.fujitsu.io
+      version: v1
+    - kind: FEPVolume
+      name: fepvolumes.fep.fujitsu.io
+      version: v1
+  description: "Fujitsu Enterprise Postgres 17 delivers an enterprise-grade PostgreSQL
+    on OpenShift Container Platform.\n\nThis solution provides the flexibility of
+    a hybrid cloud solution while delivering an enhanced distribution of PostgreSQL
+    to support enterprise-level workloads and provide improved deployment and management,
+    availability, performance, data governance and security.  \n\nAvailable as a multi-architecture
+    container built for both amd64, s390x and ppc64le.\n\nThe download and Use of
+    the Product is strictly subject to the terms of the End User License Agreement
+    with Fujitsu Limited found at https://www.fast.fujitsu.com/fujitsu-enterprise-postgres-license-agreements.
+    Where the Product that has been embedded as a whole or part into a third party
+    program, only Authorised Customers may download and use the Product.\n"
+  displayName: Fujitsu Enterprise Postgres Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAFAAAAAoCAYAAABpYH0BAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAACK1JREFUeNrsWgtQVNcZPvu4u8hz19UV1AAFFBQWheUl8QF5Wcc0SqwdG8eknWRsJymNtc3otI3RjHbCTIxONFNImjahMWoeZiaxdUImFVF5ybI8FIMKGh8QIMsuiAT2dfudcHY92VJZ0i5hA//MN7v3nHN3//3OOf///eeuhIxDu5q1cEmwTCaXSSSWsFM1RjKOTTKenGnOSM7XCsLvRULCuebWQadzQ0SFsXw8EigdL440pOmemSEIBYy808Ae4DIQo5RKS7Eq104SeGdbCMhCZLLcyMq6pVNPGzYDMdjGv0O7gPaXWjIXyCYJ/O8WGiaXr9CW157sczicrkaQuEchlRzD2wjg0fFGoHysv/BI4hyyYqrqsa+czp/gUgVcAl5QC/J3Z5yurTDb7Q6PW7CrSTGwAgib0AQemh8XslKj+uCWw3kv15zNVtZ6wEb8zMZ6C28HKHkVwCJADTwP9Jtt9gPt2Sk5arlcOoxSeAigK7OHTFQrTogNtC7NqBRzF4nZocHpfF+NPml7z+K0we679a22pRlUA7pJRPvjaBfNd+uvI4loJvIWDmYx72PgBt+RZji7HTLmnkilYvFNh6MMkuVtNF8AVjlEMYVubbT/Jraq3jSRCewDeoH7AC3Qxq3A1VEByhKQRfXfJuARDyGdD2nzzwlfiSCJ7M6bpt6MJFKFy8eBz4DVwFvIwm8pT1Q/3ZSRLNXI5alIvVJoQAlKuePjOTSNtYyhSWQBSyRnPfqOq+Rya1xVvR3vy/wlto+psn+vq9uaGhxUPC9wiskuinTy2gEjVt+GuyqMn7RbbQ5/S44SZLhovP6ACdaRtrsVGGCC1lUtSEHAzeev3Gh+7sp1GuPIjujZoduiZ8VDmoRw4yhh19nnTGPXItdXC8yjZdswQroeSOU+646Gsk/+ZseXbU80tzb9LHw6+du82BSz1ZbDysX5QCNNUmqF0JRrbCp5SKPS5M8Kj0WiknE+CbQ/oaquvbl/wMkOOxK1gjBN5EKfnAX2V5jzI1kNsB/YDbgkBRW/zwFnuHGuZLGDI4QmkVVAJfBnYJlrMCbgk6CyM6sN+iR1uEI4BAeDuM96jCWdd0azMnrt9oIcVegOkHcA5OV5dKex124gj4WMQuBBt08K4bCuuiHfRR73G2gyi3QL6enltWbUmjtG4Rsl4HX3F8nlnxZcbSvE6nMPoO9pG+1zj1MqXl/XdMmA2ra/vLdvX4BU2jFEnkBiK+ue7Hc6++edaTjabbdXS9hKQxI5ifHF8C9vNORhJbVg5XWjbPQkj07yTmAv8AWgmKkQFJtbrpKDnaZi6M82Rh7Rn2l86eyt/i7+c+OrGz6Hf3+V3K6Y6l1JpMe1Rztttg4MDPd0CuI35rRet95stQawmfg2MsbqxTiLRziRwK/sPocjE1KmmjbMViq01xallCFExIPcwcrevsL76j/bhBVHjqcmrjQPWqkMCmSri1onVvmWP16+9sauz4fU0wsxd23dEheVz/nU52Up2cP5Z/G6lMOqac01ntuFldQ+TJzyiUEXiojRul67Y5WLvDtZqaWXLEdMg497WaxzhYiPEaPd5FHb2nptUFJy6sW3O03/U8YfVS0MB51w8CYcHJMamupAbOGGiApjvbf3lJh7bD+qP2+CjyoWYmg4MfMh5vt6HugTM9vtZEvkzBQog7hJAr23q7wYR6xcAllV9Ieomck+rURoZJwuCGrEnRIuzkmQMQf/Zek98mBjc5E/sHfUZLGvaWgue18Xb0LS0zAS7/nt7AjDzpjIw7++cPnZfTc6LvtqBSqA+4EchmUMsX62CukKfIoJf/eCgaxZj+18UczN2gepo/UFgWam+nMZgZTMbcAtf2LvyJfdZP25C4eh6R7ApcEzP4HIX0Fkn3hEq0n/v21hpgOt0IFGDw1Yun9OdKC/BUJIFIqTGyO0WUUJMXkgbRea57hXitWWcCBx7v6WgcY1EN8DPksi0ID2VMPZXn/NKK+2d9olxyvfhQ5MQOWzkVUhjERrxjFd/AM/1WoUEOuiTwj8vtju6+1OSWnla0ggGyGueWFIT71p9eWYJNA7+wg4xl3TZ87BXp72hBHuNObbEPgV4Y7jYXOB4QJxOutzWRu71+eG7RiMbRlxhyEq8s3/3zSw47QBFhuJIV23PCkocLi4v4rLHZZRE4hSiaBUMqJU6mJKPwZK/wlIA3d9TN/TNtrHTmK66D303rEwJITkH4ZPfxOJb6VnH8Q0gajOhy5cPnTyoiArGpvrD3aaKoJlsotcgtnWmJGsiw8McN/bnJG8YapcnsCdB374H0J6hiBIG9J0JLmmcaRzwReBAiZS1+bPmhEJ7GX9m9CWyY1/2eO80Nd2iTgcHZAoR4ET7CyRVic64MfwLZUb+5dZCkXZUxevEI0g35U3TZ10y+GcyzRjeUVKYiE7wtMDvwBHXzOqkErOh50yvCFl+3kZ94FTgHUjKH0blP4ezN6zXDMl7CBD5u2DSUUBHUurg5F+NWY4CjOsF9mjBocoLuzKTg3hx2gFQXZtUUoaPcqi11anqMwODVlwVBfPD+sETrD39Le9wuLen5jGdR2aFkErboVmpNqXrGu6VPsPk+XRKVKpkQtxT5Khv5Y8TRh5sGqmkZ1SOBgNJxbTwxYKRFFDVIBybY0+KXQEoWrDl++EE/R0t4gM/cfFRRJ97ltI+5iD3opwerLd6vKFCeC9HmMooc8wgkrZq5O1uSaYYNJOYfL+TueF84uOow+zXoZvmT8/3/JL6MRvPGt++NzFqk8tvWkoX+nf6T7gJA99Tv1OiEy2MrKyLjv4ZE0nJvg7qlV18Wv6l6R/Qf9xIOZkiTEByjjip/ZdyZgQjyrIMUng6CyL3P6rGt2m/ZMEelvkJ84h96pCUwecTtcKLGIHGJMEemk0q8WxLHggobru/daBQSuZtJHt0Py4oMGl6dVfJ4/crFeh9NX+/pv+LcAAjZdn1eGr5KEAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          - rbac.authorization.k8s.io
+          - authorization.openshift.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - namespaces
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - secrets-store.csi.x-k8s.io
+          resources:
+          - secretproviderclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - clusterissuers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - pods/exec
+          - pods/log
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - events
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          - authorization.openshift.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - fep.fujitsu.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          - certificates
+          - certificaterequests
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - orders
+          - challenges
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - fep-restrictedv2-scc
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: fep-ansible-operator
+      deployments:
+      - label:
+          app.kubernetes.io/component: fep-ansible-operator
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: fujitsu-enterprise-postgres
+          app.kubernetes.io/part-of: fujitsu-enterprise-postgres
+          control-plane: controller-manager
+        name: fep-ansible-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+              name: fep-ansible-operator
+              vendor: Fujitsu
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: fep-ansible-operator
+              labels:
+                control-plane: controller-manager
+                name: fep-ansible-operator
+                vendor: Fujitsu
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:6789
+                - --leader-election-id=fep-ansible-operator
+                env:
+                - name: LATEST_FEP_VERSION_NUMBER
+                  value: "17"
+                - name: RELATED_IMAGE_FEP
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-17-server@sha256:35d32b589cfc2f900bac80c4922cdf79ed38e7dc6b2e81a4b3f71aa97775792e
+                - name: RELATED_IMAGE_FEPUTILS
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-17-utils@sha256:0d906ba9c5c9bd0dda59f624b85cf1a724e23e44c49eadf71442b4022b9232ec
+                - name: RELATED_IMAGE_BACKUP
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-17-backup@sha256:dafdaa1f3f914647d915542d75bdc7e3d4f4c346c8063d19a8942d52030b130a
+                - name: RELATED_IMAGE_RESTORE
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-17-restore@sha256:3f3c3068f2f06a0da0e2a9af4c8b3cd1dbaad91eaa22479a68d83b34237c4077
+                - name: RELATED_IMAGE_PGPOOL2
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-17-pgpool2@sha256:cdf04f3461bf2598a8ec27d315a3a9b8e6d26a79d39cdbb7efe31f9f116b9988
+                - name: RELATED_IMAGE_FEPEXPORTER
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-exporter@sha256:b94bb45167571095bfc29e2f37e51133422089d48cba67e3fc4979e1468893e8
+                - name: RELATED_IMAGE_FEPLOGGING
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-fluentd@sha256:1cd384784bb4d7b3375c75defc1a3c2bc87a356ef280096f1761a04b43ddb594
+                - name: RELATED_IMAGE_FEPLOGGING_FLUENTBIT
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-fluentbit@sha256:f3bada5e033b98fa6e09b704f39bc4b8ad7de956c71bb5fc3d6f10d7fb0cbdff
+                - name: RELATED_IMAGE_CRONJOB
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-cronjob@sha256:92e6bab425ffe135b15a0cd34e8244fb655e55745fbf858d0484b160b564193a
+                - name: RELATED_IMAGE_UPGRADE
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-17-upgrade@sha256:43cd266f22e792cc9eb5d5889644d7772510e2eef68cdee3807afe26f5a3ff86
+                - name: RELATED_IMAGE_FEP_16
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-16-server@sha256:d6278b3fef53a91b6c40aacd808ba2b5df912d7c5575ecebf9ac049dd920a68e
+                - name: RELATED_IMAGE_FEPUTILS_16
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-16-utils@sha256:87c48c59b7cc6323eef1c7885dfb31b7bee7b5fc2c46720948966f722ec96e4b
+                - name: RELATED_IMAGE_BACKUP_16
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-16-backup@sha256:b804a35c7296d8d13db8cd2b0bd3d646c46a1efd2033c86a613556387a2c70ea
+                - name: RELATED_IMAGE_RESTORE_16
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-16-restore@sha256:31e7c770ba8a49ec305bc9f7079d7f3ab4ae1e70439d874606e30b9ce90b2e7b
+                - name: RELATED_IMAGE_PGPOOL2_16
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-16-pgpool2@sha256:2be38800b481d9aa557c2fb3e6503ec3ea760e72b5a27d0dea5ad7a031eb4575
+                - name: RELATED_IMAGE_UPGRADE_16
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-16-upgrade@sha256:7251546fc4b64c0f0686d7aff3e2237eecd557e4ccc55364e95bd96a6145cf98
+                - name: RELATED_IMAGE_FEP_15
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-15-server@sha256:a5508e5d9ffa343d1be3b921d1ba019cbcfc649d2644f0684eeeb5527f170adc
+                - name: RELATED_IMAGE_FEPUTILS_15
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-utils@sha256:9ee41818e201cef12ad34fa6d7a539d285284d5b8a4c6b213e21e36086b96835
+                - name: RELATED_IMAGE_BACKUP_15
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-15-backup@sha256:2b61b4e0bd25ad848bc448bbce05ad998ddfaa71da718efd837ba72e67dbacf7
+                - name: RELATED_IMAGE_RESTORE_15
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-15-restore@sha256:1064528bc3f852122e7f9e98710781b046ad5e845c07816bc20dd27adc26c448
+                - name: RELATED_IMAGE_PGPOOL2_15
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-15-pgpool2@sha256:04495e9781af3d07ace945b5b5b9969fab87beae87f36beb5b405a857011ca3c
+                - name: RELATED_IMAGE_UPGRADE_15
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-15-upgrade@sha256:930250f0f728854d5af9cbe0523cd4889a4bdd7d68188f4c481a27d2506cad4c
+                - name: RELATED_IMAGE_FEP_14
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-14-server@sha256:0b963b6f90ecf2ed63226dedfaf0e07b5275de7ce83f76144dab22d1d79e886e
+                - name: RELATED_IMAGE_BACKUP_14
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-14-backup@sha256:3b5fa14bb570e1246808f06f0acd2c90f1635ee00a5cb807ba51192975acc1f6
+                - name: RELATED_IMAGE_RESTORE_14
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-14-restore@sha256:a99e4edac353dd8da367e1ac35f6bd02a61a538a9e01bc214f11c933d2ef9a90
+                - name: RELATED_IMAGE_PGPOOL2_14
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-14-pgpool2@sha256:e56d83ea8cba245a81cb269e9f20b36e5cc3e1c776fb7c9af817db8dfbcced62
+                - name: RELATED_IMAGE_UPGRADE_14
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-14-upgrade@sha256:cc5970462432105feed4e0f2830544a7cb605bb10ed8d42af4ed82781c3de265
+                - name: RELATED_IMAGE_OPERATOR
+                  value: quay.io/fujitsu/fujitsu-enterprise-postgres-operator@sha256:0f60f7ef8f11e1db59039a945df36fa5dc9b1d0c1f46159462384df5510f0922
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: fep-ansible-operator
+                - name: ANSIBLE_GATHERING
+                  value: explicit
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "false"
+                - name: ANSIBLE_VERBOSITY_FEPCLUSTER_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPCONFIG_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPVOLUME_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPUSER_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPCERT_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPACTION_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPAUTOSCALE_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPEXPORTER_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPLOGGING_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPPGPOOL2_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPBACKUP_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPRESTORE_FEP_FUJITSU_IO
+                  value: "4"
+                - name: ANSIBLE_VERBOSITY_FEPUPGRADE_FEP_FUJITSU_IO
+                  value: "4"
+                - name: KUBECTL_REMOTE_COMMAND_WEBSOCKETS
+                  value: "false"
+                image: quay.io/fujitsu/fujitsu-enterprise-postgres-operator@sha256:0f60f7ef8f11e1db59039a945df36fa5dc9b1d0c1f46159462384df5510f0922
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: fep-ansible-operator
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 6789
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: 1536Mi
+                  requests:
+                    cpu: 500m
+                    memory: 768Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /certs/
+                  name: ca-cert-volume
+                - mountPath: /certmethod/
+                  name: cert-method
+                - mountPath: /fepopr/cacert/
+                  name: fepopr-cacert
+                - mountPath: /fepopr/rootcert/
+                  name: rootsecret
+                - mountPath: /fepopr/clientsecret/
+                  name: clientsecret
+              - args:
+                - certmonitor
+                env:
+                - name: NAME_SPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-utils@sha256:0d906ba9c5c9bd0dda59f624b85cf1a724e23e44c49eadf71442b4022b9232ec
+                imagePullPolicy: Always
+                name: fep-utils-certmonitor
+                resources: {}
+                volumeMounts:
+                - mountPath: /certs/
+                  name: ca-cert-volume
+                - mountPath: /certmethod/
+                  name: cert-method
+                - mountPath: /fepopr/cacert/
+                  name: fepopr-cacert
+                - mountPath: /fepopr/rootcert/
+                  name: rootsecret
+                - mountPath: /fepopr/clientsecret/
+                  name: clientsecret
+              imagePullSecrets:
+              - name: fj-quay-pull-secret
+              - name: quay-pull-secret
+              initContainers:
+              - args:
+                - gencacert
+                env:
+                - name: NAME_SPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-utils@sha256:0d906ba9c5c9bd0dda59f624b85cf1a724e23e44c49eadf71442b4022b9232ec
+                imagePullPolicy: Always
+                name: fep-utils
+                resources: {}
+                volumeMounts:
+                - mountPath: /certs/
+                  name: ca-cert-volume
+                - mountPath: /certmethod/
+                  name: cert-method
+                - mountPath: /fepopr/cacert/
+                  name: fepopr-cacert
+                - mountPath: /fepopr/rootcert/
+                  name: rootsecret
+                - mountPath: /fepopr/clientsecret/
+                  name: clientsecret
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: fep-ansible-operator
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - emptyDir: {}
+                name: ca-cert-volume
+              - configMap:
+                  defaultMode: 420
+                  name: fepopr-cert-method
+                  optional: true
+                name: cert-method
+              - configMap:
+                  defaultMode: 420
+                  name: fepopr-root-cacert
+                  optional: true
+                name: fepopr-cacert
+              - name: rootsecret
+                secret:
+                  optional: true
+                  secretName: fepopr-root-secret
+              - name: clientsecret
+                secret:
+                  optional: true
+                  secretName: fepopr-client-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          - v1
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - policy
+          resources:
+          - pods
+          - pods/exec
+          - serviceaccounts
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - poddisruptionbudgets
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - rbac.authorization.k8s.io
+          - authorization.openshift.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - create
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - fep-ansible-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - fep.fujitsu.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - secrets-store.csi.x-k8s.io
+          resources:
+          - secretproviderclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          - certificates
+          - certificaterequests
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - orders
+          - challenges
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: fep-ansible-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - postgres
+  - postgresql
+  - database
+  - sql
+  - Fujitsu
+  - fep
+  links:
+  - name: Fujitsu Enterprise Postgres
+    url: https://www.postgresql.fastware.com/
+  maintainers:
+  - email: fj-dbaas-tec@dl.jp.fujitsu.com
+    name: Fujitsu
+  maturity: stable
+  provider:
+    name: Fujitsu
+    url: https://www.postgresql.fastware.com/
+  relatedImages:
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-server@sha256:35d32b589cfc2f900bac80c4922cdf79ed38e7dc6b2e81a4b3f71aa97775792e
+    name: fep
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-utils@sha256:0d906ba9c5c9bd0dda59f624b85cf1a724e23e44c49eadf71442b4022b9232ec
+    name: feputils
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-backup@sha256:dafdaa1f3f914647d915542d75bdc7e3d4f4c346c8063d19a8942d52030b130a
+    name: backup
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-restore@sha256:3f3c3068f2f06a0da0e2a9af4c8b3cd1dbaad91eaa22479a68d83b34237c4077
+    name: restore
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-pgpool2@sha256:cdf04f3461bf2598a8ec27d315a3a9b8e6d26a79d39cdbb7efe31f9f116b9988
+    name: pgpool2
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-exporter@sha256:b94bb45167571095bfc29e2f37e51133422089d48cba67e3fc4979e1468893e8
+    name: fepexporter
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-fluentd@sha256:1cd384784bb4d7b3375c75defc1a3c2bc87a356ef280096f1761a04b43ddb594
+    name: feplogging
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-fluentbit@sha256:f3bada5e033b98fa6e09b704f39bc4b8ad7de956c71bb5fc3d6f10d7fb0cbdff
+    name: feplogging-fluentbit
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-cronjob@sha256:92e6bab425ffe135b15a0cd34e8244fb655e55745fbf858d0484b160b564193a
+    name: cronjob
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-17-upgrade@sha256:43cd266f22e792cc9eb5d5889644d7772510e2eef68cdee3807afe26f5a3ff86
+    name: upgrade
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-16-server@sha256:d6278b3fef53a91b6c40aacd808ba2b5df912d7c5575ecebf9ac049dd920a68e
+    name: fep-16
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-16-utils@sha256:87c48c59b7cc6323eef1c7885dfb31b7bee7b5fc2c46720948966f722ec96e4b
+    name: feputils-16
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-16-backup@sha256:b804a35c7296d8d13db8cd2b0bd3d646c46a1efd2033c86a613556387a2c70ea
+    name: backup-16
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-16-restore@sha256:31e7c770ba8a49ec305bc9f7079d7f3ab4ae1e70439d874606e30b9ce90b2e7b
+    name: restore-16
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-16-pgpool2@sha256:2be38800b481d9aa557c2fb3e6503ec3ea760e72b5a27d0dea5ad7a031eb4575
+    name: pgpool2-16
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-16-upgrade@sha256:7251546fc4b64c0f0686d7aff3e2237eecd557e4ccc55364e95bd96a6145cf98
+    name: upgrade-16
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-15-server@sha256:a5508e5d9ffa343d1be3b921d1ba019cbcfc649d2644f0684eeeb5527f170adc
+    name: fep-15
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-utils@sha256:9ee41818e201cef12ad34fa6d7a539d285284d5b8a4c6b213e21e36086b96835
+    name: feputils-15
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-15-backup@sha256:2b61b4e0bd25ad848bc448bbce05ad998ddfaa71da718efd837ba72e67dbacf7
+    name: backup-15
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-15-restore@sha256:1064528bc3f852122e7f9e98710781b046ad5e845c07816bc20dd27adc26c448
+    name: restore-15
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-15-pgpool2@sha256:04495e9781af3d07ace945b5b5b9969fab87beae87f36beb5b405a857011ca3c
+    name: pgpool2-15
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-15-upgrade@sha256:930250f0f728854d5af9cbe0523cd4889a4bdd7d68188f4c481a27d2506cad4c
+    name: upgrade-15
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-14-server@sha256:0b963b6f90ecf2ed63226dedfaf0e07b5275de7ce83f76144dab22d1d79e886e
+    name: fep-14
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-14-backup@sha256:3b5fa14bb570e1246808f06f0acd2c90f1635ee00a5cb807ba51192975acc1f6
+    name: backup-14
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-14-restore@sha256:a99e4edac353dd8da367e1ac35f6bd02a61a538a9e01bc214f11c933d2ef9a90
+    name: restore-14
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-14-pgpool2@sha256:e56d83ea8cba245a81cb269e9f20b36e5cc3e1c776fb7c9af817db8dfbcced62
+    name: pgpool2-14
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-14-upgrade@sha256:cc5970462432105feed4e0f2830544a7cb605bb10ed8d42af4ed82781c3de265
+    name: upgrade-14
+  - image: quay.io/fujitsu/fujitsu-enterprise-postgres-operator@sha256:0f60f7ef8f11e1db59039a945df36fa5dc9b1d0c1f46159462384df5510f0922
+    name: operator
+  skips:
+  - fujitsu-enterprise-postgres-operator.v7.3.1
+  version: 7.3.7

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: fujitsu-enterprise-postgres
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/fujitsu-enterprise-postgres-operator/7.3.7/metadata/annotations.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/7.3.7/metadata/annotations.yaml
@@ -1,0 +1,20 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: fujitsu-enterprise-postgres-operator
+  operators.operatorframework.io.bundle.channels.v1: stable-z
+  operators.operatorframework.io.bundle.channel.default.v1: stable-z
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: ansible.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # Additional Annotations required by Redhat
+  com.redhat.openshift.versions: v4.14-v4.22
+  com.redhat.delivery.backport: false
+  com.redhat.delivery.operator.bundle: true

--- a/operators/fujitsu-enterprise-postgres-operator/ci.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/ci.yaml
@@ -1,2 +1,2 @@
 cert_project_id: 622aae074603d3f541bec891
-merge: false
+merge: true

--- a/operators/fujitsu-enterprise-postgres-operator/ci.yaml
+++ b/operators/fujitsu-enterprise-postgres-operator/ci.yaml
@@ -1,2 +1,2 @@
 cert_project_id: 622aae074603d3f541bec891
-merge: true
+merge: false


### PR DESCRIPTION
This replaces #9486, which failed at `add-bundle-to-index`.

## Why the previous PR failed

```
add prunes bundle ...v7.3.7 from package ..., channel stable:
the head of the channel stable ... is ...v8.3.4. Upgrade graphs follows the
Semantic Versioning 2.0.0 which means that is not possible add new versions
lower then the head of the channel
```

The head of channel `stable` is `v8.3.4`, so `v7.3.7` cannot be added to it.

## What changed

This bundle is published to the **`stable-z`** channel instead of `stable`.

```
operators.operatorframework.io.bundle.channels.v1: stable-z
operators.operatorframework.io.bundle.channel.default.v1: stable-z
```

The 7.x and 8.x lines target different architectures:

| line | architectures |
|---|---|
| 8.x | amd64 |
| 7.x | ppc64le / s390x (built as 3-arch because bundle certification requires amd64) |

Separating the channels reflects that split and lets the 7.x line receive updates independently.

## About the `check_pruned_graph` warning

`olm.skipRange` is set without `replaces`. `replaces` cannot be used here because `stable-z` is a new channel with no earlier bundle in it. `skipRange` and `skips` are kept so that existing 7.x users can upgrade after switching channels.