### PR TITLE
operator zk-operator (0.0.1)

### DIFF
--- a/operators/zk-operator/0.0.1/manifests/zk-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: zk-operator
+    control-plane: controller-manager
+  name: zk-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: zk-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/zk-operator/0.0.1/manifests/zk-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: zk-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/zk-operator/0.0.1/manifests/zk-operator-zkcluster-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator-zkcluster-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: zk-operator
+  name: zk-operator-zkcluster-admin-role
+rules:
+- apiGroups:
+  - zookeeper.transwarp.io
+  resources:
+  - zkclusters
+  verbs:
+  - '*'
+- apiGroups:
+  - zookeeper.transwarp.io
+  resources:
+  - zkclusters/status
+  verbs:
+  - get

--- a/operators/zk-operator/0.0.1/manifests/zk-operator-zkcluster-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator-zkcluster-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: zk-operator
+  name: zk-operator-zkcluster-editor-role
+rules:
+- apiGroups:
+  - zookeeper.transwarp.io
+  resources:
+  - zkclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - zookeeper.transwarp.io
+  resources:
+  - zkclusters/status
+  verbs:
+  - get

--- a/operators/zk-operator/0.0.1/manifests/zk-operator-zkcluster-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator-zkcluster-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: zk-operator
+  name: zk-operator-zkcluster-viewer-role
+rules:
+- apiGroups:
+  - zookeeper.transwarp.io
+  resources:
+  - zkclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - zookeeper.transwarp.io
+  resources:
+  - zkclusters/status
+  verbs:
+  - get

--- a/operators/zk-operator/0.0.1/manifests/zk-operator.clusterserviceversion.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator.clusterserviceversion.yaml
@@ -20,6 +20,13 @@ metadata:
       \        \"maxClientCnxns\": 60,\n        \"syncLimit\": 5,\n        \"tickTime\"\
       : 2000\n      }\n    }\n  }\n]"
     capabilities: Basic Install
+    features.operators.openshift.io/disconnected: 'false'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'false'
+    features.operators.openshift.io/tls-profiles: 'false'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
     categories: Database
     certified: 'true'
     containerImage: quay.io/yrding/tran/zk-operator@sha256:b563e16d46db1d1681bcc8810c763e8b38849339a848c78a1b2a75e51d5afe92

--- a/operators/zk-operator/0.0.1/manifests/zk-operator.clusterserviceversion.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zk-operator.clusterserviceversion.yaml
@@ -1,0 +1,328 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[\n  {\n    \"apiVersion\": \"zookeeper.transwarp.io/v1alpha1\"\
+      ,\n    \"kind\": \"ZKCluster\",\n    \"metadata\": {\n      \"name\": \"zkcluster-sample\"\
+      \n    },\n    \"spec\": {\n      \"image\": {\n        \"pullPolicy\": \"IfNotPresent\"\
+      ,\n        \"repository\": \"quay.io/yrding/tran/zookeeper\",\n        \"tag\"\
+      : \"transwarp-9.5-final-redhat\"\n      },\n      \"jvmOpts\": \"-Xms256m -Xmx512m\"\
+      ,\n      \"persistence\": {\n        \"enabled\": false,\n        \"size\":\
+      \ \"5Gi\"\n      },\n      \"ports\": {\n        \"client\": 2181,\n       \
+      \ \"leaderElection\": 3888,\n        \"quorum\": 2888\n      },\n      \"replicaCount\"\
+      : 1,\n      \"resources\": {\n        \"limits\": {\n          \"cpu\": \"1\"\
+      ,\n          \"memory\": \"1Gi\"\n        },\n        \"requests\": {\n    \
+      \      \"cpu\": \"250m\",\n          \"memory\": \"512Mi\"\n        }\n    \
+      \  },\n      \"securityContext\": {\n        \"runAsNonRoot\": true\n      },\n\
+      \      \"zooConfig\": {\n        \"4lw.commands.whitelist\": \"ruok,srvr,stat,mntr,isro\"\
+      ,\n        \"admin.enableServer\": \"false\",\n        \"clientPort\": 2181,\n\
+      \        \"dataDir\": \"/var/transwarp/data\",\n        \"initLimit\": 10,\n\
+      \        \"maxClientCnxns\": 60,\n        \"syncLimit\": 5,\n        \"tickTime\"\
+      : 2000\n      }\n    }\n  }\n]"
+    capabilities: Basic Install
+    categories: Database
+    certified: 'true'
+    containerImage: quay.io/yrding/tran/zk-operator@sha256:b563e16d46db1d1681bcc8810c763e8b38849339a848c78a1b2a75e51d5afe92
+    createdAt: '2026-09-02T02:42:23Z'
+    description: ZooKeeper operator for deploying and managing Transwarp ZooKeeper
+      clusters on OpenShift
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://www.transwarp.cn
+    support: Transwarp
+  name: zk-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: ZKCluster is the Schema for the zkclusters API
+      displayName: ZooKeeper Cluster
+      kind: ZKCluster
+      name: zkclusters.zookeeper.transwarp.io
+      resources:
+      - kind: StatefulSet
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: PersistentVolumeClaim
+        name: ''
+        version: v1
+      - kind: ServiceAccount
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Number of ZooKeeper instances (standalone=1 on SNO)
+        displayName: Instances
+        path: replicaCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: ZooKeeper container image
+        displayName: Image
+        path: image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Image Repository
+        path: image.repository
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Image Tag
+        path: image.tag
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Image Pull Policy
+        path: image.pullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: JVM Options
+        path: jvmOpts
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Data persistence (emptyDir when disabled)
+        displayName: Persistence
+        path: persistence
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Persistence Enabled
+        path: persistence.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: StorageClass
+        path: persistence.storageClass
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: PVC Size
+        path: persistence.size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Service ports
+        displayName: Ports
+        path: ports
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Client Port
+        path: ports.client
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Quorum Port
+        path: ports.quorum
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Leader Election Port
+        path: ports.leaderElection
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Resources
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Pod security context (OpenShift restricted SCC compatible)
+        displayName: Security Context
+        path: securityContext
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: zoo.cfg Settings
+        path: zooConfig
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      statusDescriptors:
+      - description: The release rendered by the Helm operator
+        displayName: Deployed Release
+        path: deployedRelease
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      version: v1alpha1
+  description: ZooKeeper operator for Transwarp ZK on OpenShift
+  displayName: ZooKeeper Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR4nGNgmL+DtmjUglELRi0YtWDUglELRi0YtWDUglELRi0YKhYAANNkXEwc0Xa+AAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - zookeeper.transwarp.io
+          resources:
+          - zkclusters
+          - zkclusters/status
+          - zkclusters/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: zk-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: zk-operator
+          control-plane: controller-manager
+        name: zk-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: zk-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: zk-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --leader-election-id=zk-operator
+                - --health-probe-bind-address=:8081
+                image: quay.io/yrding/tran/zk-operator@sha256:b563e16d46db1d1681bcc8810c763e8b38849339a848c78a1b2a75e51d5afe92
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              imagePullSecrets:
+              - name: quay-pull-secret
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: zk-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ''
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: zk-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - zookeeper
+  links:
+  - name: ZooKeeper Operator
+    url: https://zk-operator.domain
+  maturity: alpha
+  minKubeVersion: 1.25.0
+  provider:
+    name: Transwarp
+    url: https://www.transwarp.cn
+  version: 0.0.1
+  relatedImages:
+  - name: zk-operator
+    image: quay.io/yrding/tran/zk-operator@sha256:b563e16d46db1d1681bcc8810c763e8b38849339a848c78a1b2a75e51d5afe92

--- a/operators/zk-operator/0.0.1/manifests/zookeeper.transwarp.io_zkclusters.yaml
+++ b/operators/zk-operator/0.0.1/manifests/zookeeper.transwarp.io_zkclusters.yaml
@@ -1,0 +1,122 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: zkclusters.zookeeper.transwarp.io
+spec:
+  group: zookeeper.transwarp.io
+  names:
+    kind: ZKCluster
+    listKind: ZKClusterList
+    plural: zkclusters
+    singular: zkcluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ZKCluster is the Schema for the zkclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ZKCluster
+            properties:
+              image:
+                description: ZooKeeper container image
+                properties:
+                  pullPolicy:
+                    default: IfNotPresent
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  repository:
+                    default: quay.io/yrding/tran/zookeeper
+                    type: string
+                  tag:
+                    default: transwarp-9.5-final-redhat
+                    type: string
+                type: object
+              jvmOpts:
+                default: -Xms256m -Xmx512m
+                description: JVM arguments for the ZooKeeper process
+                type: string
+              persistence:
+                description: Data persistence (emptyDir when disabled)
+                properties:
+                  enabled:
+                    default: false
+                    type: boolean
+                  size:
+                    default: 5Gi
+                    description: PVC size
+                    type: string
+                  storageClass:
+                    description: StorageClass name for PVC (optional)
+                    type: string
+                type: object
+              ports:
+                description: Service ports
+                properties:
+                  client:
+                    default: 2181
+                    description: Client port (2181)
+                    type: integer
+                  leaderElection:
+                    default: 3888
+                    description: Leader election port (3888)
+                    type: integer
+                  quorum:
+                    default: 2888
+                    description: Quorum/sync port (2888)
+                    type: integer
+                type: object
+              replicaCount:
+                default: 1
+                description: Number of ZooKeeper instances (standalone=1 on SNO)
+                maximum: 7
+                minimum: 1
+                type: integer
+              resources:
+                description: Container resource requirements
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              securityContext:
+                description: Pod security context (OpenShift restricted SCC compatible)
+                properties:
+                  runAsNonRoot:
+                    default: true
+                    type: boolean
+                type: object
+              zooConfig:
+                description: zoo.cfg key/value pairs (rendered into the ConfigMap)
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: Status defines the observed state of ZKCluster
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/zk-operator/0.0.1/metadata/annotations.yaml
+++ b/operators/zk-operator/0.0.1/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: zk-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Red Hat certification: supported OpenShift versions (v4.12 and later,
+  # aligned with CSV minKubeVersion 1.25.0; verified on OCP 4.22.10 SNO).
+  com.redhat.openshift.versions: "v4.12"

--- a/operators/zk-operator/ci.yaml
+++ b/operators/zk-operator/ci.yaml
@@ -1,0 +1,1 @@
+cert_project_id: 6a97e10521952d912df3e595

--- a/operators/zk-operator/config.yaml
+++ b/operators/zk-operator/config.yaml
@@ -1,0 +1,1 @@
+organization: certified-operators


### PR DESCRIPTION
## New Operator Submission

**Operator:** zk-operator v0.0.1 (Transwarp)
**Type:** Helm-based operator (operator-sdk v1.42.3, helm.sdk.operatorframework.io/v1)
**Certification Project ID:** 6a97e10521952d912df3e595

### Images
- Operator: `quay.io/yrding/tran/zk-operator@sha256:b563e16d46db1d1681bcc8810c763e8b38849339a848c78a1b2a75e51d5afe92` (certified & published)
- Related: `quay.io/yrding/tran/zookeeper@sha256:` (ZK application image, certified & published)

### Verification
- `operator-sdk bundle validate` basic + operatorhub suite: PASSED
- `preflight check container`: 10/10 PASSED
- Deployed and verified on OpenShift 4.22.10 SNO (OLM: CatalogSource -> Subscription -> CSV succeeded -> ZKCluster CR running)