### PR TITLE
Catalog update [minio-minkms-operator,minio-object-store-operator] [v4.22]

### DIFF
--- a/catalogs/v4.22/minio-minkms-operator/catalog.yaml
+++ b/catalogs/v4.22/minio-minkms-operator/catalog.yaml
@@ -7,11 +7,638 @@ name: minio-minkms-operator
 schema: olm.package
 ---
 entries:
+- name: minio-minkms-operator.v2025.12.20100920
+- name: minio-minkms-operator.v2026.2.9031243
+  replaces: minio-minkms-operator.v2025.12.20100920
+- name: minio-minkms-operator.v2026.3.18173617
+  replaces: minio-minkms-operator.v2026.2.9031243
+- name: minio-minkms-operator.v2026.4.13102716
+  replaces: minio-minkms-operator.v2026.3.18173617
 - name: minio-minkms-operator.v2026.7.16235330
   replaces: minio-minkms-operator.v2026.4.13102716
 name: stable
 package: minio-minkms-operator
 schema: olm.channel
+---
+image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:8f9634ada21dac314549e710a5a3ab384307d27124c094bc666d202c41fcb34e
+name: minio-minkms-operator.v2025.12.20100920
+package: minio-minkms-operator
+properties:
+- type: olm.gvk
+  value:
+    group: minkms.min.io
+    kind: MinKMS
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: minio-minkms-operator
+    version: 2025.12.20100920
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "minkms.min.io/v1alpha1",
+            "kind": "MinKMS",
+            "metadata": {
+              "name": "my-kms",
+              "namespace": "ns-1"
+            },
+            "spec": {
+              "apiKeySecret": {
+                "name": "my-api-key"
+              },
+              "configuration": {
+                "name": "my-kms-server-config"
+              },
+              "hsmSecret": {
+                "name": "my-kms-hsm"
+              },
+              "imagePullSecrets": [
+                {
+                  "name": "registry-creds"
+                }
+              ],
+              "replicas": 2,
+              "volumeClaimTemplate": {
+                "metadata": {
+                  "name": "key-manager-volume"
+                },
+                "spec": {
+                  "accessModes": [
+                    "ReadWriteOnce"
+                  ],
+                  "resources": {
+                    "requests": {
+                      "storage": "100Mi"
+                    }
+                  },
+                  "storageClassName": "standard"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Security, Storage
+      createdAt: "2026-01-09T19:29:12Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.42.0
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: MinKMS
+        name: minkmses.minkms.min.io
+        version: v1alpha1
+    description: |-
+      Highly available, powerful and operationally simple, MinIO's Enterprise Key Management Server is optimized for large storage infrastructures where billions of cryptographic keys are required.
+
+      MinIO's AIStor KMS establishes its foundational trust using the concept of an hardware security module (but given KES is software, this is only a concept). That module assumes a pivotal role in sealing and unsealing the KMS root encryption key. The module responsibility extends to safeguarding the integrity of KMS by allowing the unsealing of its encrypted on-disk state and facilitating communication among nodes within a KMS cluster.
+
+      It solves the challenges associated with billions of cryptographic keys and hundreds of thousands of cryptographic operations per node per second - which are commonplace in larger deployments.
+
+      <b>High Availability and Fault Tolerance</b>
+      In the dynamic landscape of large-scale systems, network or node outages are inevitable. Taking down a cluster for maintenance is rarely feasible. MinIO's AIStor KMS ensures uninterrupted availability, even when faced with such disruptions, mitigating cascading effects that can take down the entire storage infrastructure. Specifically, you could lose all but one node of a cluster and still handle any encryption, decryption or data key generation requests.
+
+      <b>Scalability</b>
+      While the amount of data usually only increases, the load on a large-scale storage system may vary significantly from time to time. MinIO's AIStor KMS supports dynamic cluster resizing and nodes can be added or removed at any point without incurring any downtime.
+
+      <b>Multi-Tenancy</b>
+      Large-scale storage infrastructures are often used by many applications and teams across the entire organization. Isolating teams and groups into their own namespaces is a core requirement. MinIO's AIStor KMS supports namespacing in the form of enclaves. Each tenant can be assigned its own enclave which is completely independent and isolated from all other enclaves on the KMS cluster.
+
+      <b>Predictable Behavior</b>
+      MinIO's AIStor KMS is designed to be easily managed, providing operators with the ability to comprehend its state intuitively. Due to its simple design, MinIO's AIStor KMS is significantly easier to operate than similar solutions that rely on more complex consensus algorithms like Raft, or Paxos.
+
+      <b>Consistent and Performant</b>
+      The responsiveness of the KMS for GET/PUT operations directly influences the overall efficiency and speed of the storage system. MinIO's AIStor KMS nodes don’t have to coordinate when handling such requests from the storage system. Therefore, the performance of a MinIO's AIStor KMS cluster increases linearly with the number of nodes. Further, MinIO's AIStor KMS supports request pipelining to handle hundreds of thousands of cryptographic operations per node and second.
+
+      <b>Simplicity</b>
+      Operating a KMS cluster does not require expertise in cryptography or distributed systems. Everything can be done from the AIStor Console.
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: Minio AIStor Key management System (KMS)
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - MinIO
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/minkms-sidecar@sha256:f460aef51e32fd6bd556f3d30f14f026855cb4010f662c82d1964e1596c50f2a
+  name: minkms-sidecar
+- image: quay.io/minio/aistor/minkms@sha256:4c089d787b4ebf862dbce7826ac6eadeca5e0811b1f0379f43fb732f321fda8f
+  name: minkms
+- image: quay.io/minio/aistor/operator@sha256:880838ba793b6a7fd165ab361d8c24510bc41c66768f44ede26136c36c7557cb
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:8f9634ada21dac314549e710a5a3ab384307d27124c094bc666d202c41fcb34e
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:7a9facacac30c17669b91a5f892d48317b29451f0cb95d9504ec1abc28efd2b6
+name: minio-minkms-operator.v2026.2.9031243
+package: minio-minkms-operator
+properties:
+- type: olm.gvk
+  value:
+    group: minkms.min.io
+    kind: MinKMS
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: minio-minkms-operator
+    version: 2026.2.9031243
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "minkms.min.io/v1alpha1",
+            "kind": "MinKMS",
+            "metadata": {
+              "name": "my-kms",
+              "namespace": "ns-1"
+            },
+            "spec": {
+              "apiKeySecret": {
+                "name": "my-api-key"
+              },
+              "configuration": {
+                "name": "my-kms-server-config"
+              },
+              "hsmSecret": {
+                "name": "my-kms-hsm"
+              },
+              "imagePullSecrets": [
+                {
+                  "name": "registry-creds"
+                }
+              ],
+              "replicas": 2,
+              "volumeClaimTemplate": {
+                "metadata": {
+                  "name": "key-manager-volume"
+                },
+                "spec": {
+                  "accessModes": [
+                    "ReadWriteOnce"
+                  ],
+                  "resources": {
+                    "requests": {
+                      "storage": "100Mi"
+                    }
+                  },
+                  "storageClassName": "standard"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Security, Storage
+      createdAt: "2026-02-18T16:30:49Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.41.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: MinKMS
+        name: minkmses.minkms.min.io
+        version: v1alpha1
+    description: |-
+      Highly available, powerful and operationally simple, MinIO's Enterprise Key Management Server is optimized for large storage infrastructures where billions of cryptographic keys are required.
+
+      MinIO's AIStor KMS establishes its foundational trust using the concept of an hardware security module (but given KES is software, this is only a concept). That module assumes a pivotal role in sealing and unsealing the KMS root encryption key. The module responsibility extends to safeguarding the integrity of KMS by allowing the unsealing of its encrypted on-disk state and facilitating communication among nodes within a KMS cluster.
+
+      It solves the challenges associated with billions of cryptographic keys and hundreds of thousands of cryptographic operations per node per second - which are commonplace in larger deployments.
+
+      <b>High Availability and Fault Tolerance</b>
+      In the dynamic landscape of large-scale systems, network or node outages are inevitable. Taking down a cluster for maintenance is rarely feasible. MinIO's AIStor KMS ensures uninterrupted availability, even when faced with such disruptions, mitigating cascading effects that can take down the entire storage infrastructure. Specifically, you could lose all but one node of a cluster and still handle any encryption, decryption or data key generation requests.
+
+      <b>Scalability</b>
+      While the amount of data usually only increases, the load on a large-scale storage system may vary significantly from time to time. MinIO's AIStor KMS supports dynamic cluster resizing and nodes can be added or removed at any point without incurring any downtime.
+
+      <b>Multi-Tenancy</b>
+      Large-scale storage infrastructures are often used by many applications and teams across the entire organization. Isolating teams and groups into their own namespaces is a core requirement. MinIO's AIStor KMS supports namespacing in the form of enclaves. Each tenant can be assigned its own enclave which is completely independent and isolated from all other enclaves on the KMS cluster.
+
+      <b>Predictable Behavior</b>
+      MinIO's AIStor KMS is designed to be easily managed, providing operators with the ability to comprehend its state intuitively. Due to its simple design, MinIO's AIStor KMS is significantly easier to operate than similar solutions that rely on more complex consensus algorithms like Raft, or Paxos.
+
+      <b>Consistent and Performant</b>
+      The responsiveness of the KMS for GET/PUT operations directly influences the overall efficiency and speed of the storage system. MinIO's AIStor KMS nodes don’t have to coordinate when handling such requests from the storage system. Therefore, the performance of a MinIO's AIStor KMS cluster increases linearly with the number of nodes. Further, MinIO's AIStor KMS supports request pipelining to handle hundreds of thousands of cryptographic operations per node and second.
+
+      <b>Simplicity</b>
+      Operating a KMS cluster does not require expertise in cryptography or distributed systems. Everything can be done from the AIStor Console.
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: Minio AIStor Key management System (KMS)
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - MinIO
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/minkms-sidecar@sha256:4981e1da2eb5bea86281d2633e06072f1a5ed9e9cba95ba3f74f714c72ab0966
+  name: minkms-sidecar
+- image: quay.io/minio/aistor/minkms@sha256:4c089d787b4ebf862dbce7826ac6eadeca5e0811b1f0379f43fb732f321fda8f
+  name: minkms
+- image: quay.io/minio/aistor/operator@sha256:e75807db28ef34db8cdbf886e94c5ea0bcded7f37da152ba311edacde99124e1
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:7a9facacac30c17669b91a5f892d48317b29451f0cb95d9504ec1abc28efd2b6
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:6d38965736a2b3f7a610d346105b3949203a221c0636e906b4f140c14eb51ad4
+name: minio-minkms-operator.v2026.3.18173617
+package: minio-minkms-operator
+properties:
+- type: olm.gvk
+  value:
+    group: minkms.min.io
+    kind: MinKMS
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: minio-minkms-operator
+    version: 2026.3.18173617
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "minkms.min.io/v1alpha1",
+            "kind": "MinKMS",
+            "metadata": {
+              "name": "my-kms",
+              "namespace": "ns-1"
+            },
+            "spec": {
+              "apiKeySecret": {
+                "name": "my-api-key"
+              },
+              "configuration": {
+                "name": "my-kms-server-config"
+              },
+              "hsmSecret": {
+                "name": "my-kms-hsm"
+              },
+              "imagePullSecrets": [
+                {
+                  "name": "registry-creds"
+                }
+              ],
+              "replicas": 2,
+              "volumeClaimTemplate": {
+                "metadata": {
+                  "name": "key-manager-volume"
+                },
+                "spec": {
+                  "accessModes": [
+                    "ReadWriteOnce"
+                  ],
+                  "resources": {
+                    "requests": {
+                      "storage": "100Mi"
+                    }
+                  },
+                  "storageClassName": "standard"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Security, Storage
+      createdAt: "2026-03-19T20:02:26Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.41.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: MinKMS
+        name: minkmses.minkms.min.io
+        version: v1alpha1
+    description: |-
+      Highly available, powerful and operationally simple, MinIO's Enterprise Key Management Server is optimized for large storage infrastructures where billions of cryptographic keys are required.
+
+      MinIO's AIStor KMS establishes its foundational trust using the concept of an hardware security module (but given KES is software, this is only a concept). That module assumes a pivotal role in sealing and unsealing the KMS root encryption key. The module responsibility extends to safeguarding the integrity of KMS by allowing the unsealing of its encrypted on-disk state and facilitating communication among nodes within a KMS cluster.
+
+      It solves the challenges associated with billions of cryptographic keys and hundreds of thousands of cryptographic operations per node per second - which are commonplace in larger deployments.
+
+      <b>High Availability and Fault Tolerance</b>
+      In the dynamic landscape of large-scale systems, network or node outages are inevitable. Taking down a cluster for maintenance is rarely feasible. MinIO's AIStor KMS ensures uninterrupted availability, even when faced with such disruptions, mitigating cascading effects that can take down the entire storage infrastructure. Specifically, you could lose all but one node of a cluster and still handle any encryption, decryption or data key generation requests.
+
+      <b>Scalability</b>
+      While the amount of data usually only increases, the load on a large-scale storage system may vary significantly from time to time. MinIO's AIStor KMS supports dynamic cluster resizing and nodes can be added or removed at any point without incurring any downtime.
+
+      <b>Multi-Tenancy</b>
+      Large-scale storage infrastructures are often used by many applications and teams across the entire organization. Isolating teams and groups into their own namespaces is a core requirement. MinIO's AIStor KMS supports namespacing in the form of enclaves. Each tenant can be assigned its own enclave which is completely independent and isolated from all other enclaves on the KMS cluster.
+
+      <b>Predictable Behavior</b>
+      MinIO's AIStor KMS is designed to be easily managed, providing operators with the ability to comprehend its state intuitively. Due to its simple design, MinIO's AIStor KMS is significantly easier to operate than similar solutions that rely on more complex consensus algorithms like Raft, or Paxos.
+
+      <b>Consistent and Performant</b>
+      The responsiveness of the KMS for GET/PUT operations directly influences the overall efficiency and speed of the storage system. MinIO's AIStor KMS nodes don’t have to coordinate when handling such requests from the storage system. Therefore, the performance of a MinIO's AIStor KMS cluster increases linearly with the number of nodes. Further, MinIO's AIStor KMS supports request pipelining to handle hundreds of thousands of cryptographic operations per node and second.
+
+      <b>Simplicity</b>
+      Operating a KMS cluster does not require expertise in cryptography or distributed systems. Everything can be done from the AIStor Console.
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: Minio AIStor Key management System (KMS)
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - MinIO
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.29.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/minkms-sidecar@sha256:2bb41de8d166ba5a07275263f2622976f02b854a3ad7f664f9defb7c280a3284
+  name: minkms-sidecar
+- image: quay.io/minio/aistor/minkms@sha256:4c089d787b4ebf862dbce7826ac6eadeca5e0811b1f0379f43fb732f321fda8f
+  name: minkms
+- image: quay.io/minio/aistor/operator@sha256:be72c9f1a0b6baa050f59d486452909543758a2424b11920a522e60c7fac76b9
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:6d38965736a2b3f7a610d346105b3949203a221c0636e906b4f140c14eb51ad4
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:7014d7cb0c3068f7b62b8bd3fb6854822549c6e13b2866fd22fce7d214e3b7ae
+name: minio-minkms-operator.v2026.4.13102716
+package: minio-minkms-operator
+properties:
+- type: olm.gvk
+  value:
+    group: minkms.min.io
+    kind: MinKMS
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: minio-minkms-operator
+    version: 2026.4.13102716
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "minkms.min.io/v1alpha1",
+            "kind": "MinKMS",
+            "metadata": {
+              "name": "my-kms",
+              "namespace": "ns-1"
+            },
+            "spec": {
+              "apiKeySecret": {
+                "name": "my-api-key"
+              },
+              "configuration": {
+                "name": "my-kms-server-config"
+              },
+              "hsmSecret": {
+                "name": "my-kms-hsm"
+              },
+              "imagePullSecrets": [
+                {
+                  "name": "registry-creds"
+                }
+              ],
+              "replicas": 2,
+              "volumeClaimTemplate": {
+                "metadata": {
+                  "name": "key-manager-volume"
+                },
+                "spec": {
+                  "accessModes": [
+                    "ReadWriteOnce"
+                  ],
+                  "resources": {
+                    "requests": {
+                      "storage": "100Mi"
+                    }
+                  },
+                  "storageClassName": "standard"
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Security, Storage
+      createdAt: "2026-05-12T18:01:34Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.41.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: MinKMS
+        name: minkmses.minkms.min.io
+        version: v1alpha1
+    description: |-
+      Highly available, powerful and operationally simple, MinIO's Enterprise Key Management Server is optimized for large storage infrastructures where billions of cryptographic keys are required.
+
+      MinIO's AIStor KMS establishes its foundational trust using the concept of an hardware security module (but given KES is software, this is only a concept). That module assumes a pivotal role in sealing and unsealing the KMS root encryption key. The module responsibility extends to safeguarding the integrity of KMS by allowing the unsealing of its encrypted on-disk state and facilitating communication among nodes within a KMS cluster.
+
+      It solves the challenges associated with billions of cryptographic keys and hundreds of thousands of cryptographic operations per node per second - which are commonplace in larger deployments.
+
+      <b>High Availability and Fault Tolerance</b>
+      In the dynamic landscape of large-scale systems, network or node outages are inevitable. Taking down a cluster for maintenance is rarely feasible. MinIO's AIStor KMS ensures uninterrupted availability, even when faced with such disruptions, mitigating cascading effects that can take down the entire storage infrastructure. Specifically, you could lose all but one node of a cluster and still handle any encryption, decryption or data key generation requests.
+
+      <b>Scalability</b>
+      While the amount of data usually only increases, the load on a large-scale storage system may vary significantly from time to time. MinIO's AIStor KMS supports dynamic cluster resizing and nodes can be added or removed at any point without incurring any downtime.
+
+      <b>Multi-Tenancy</b>
+      Large-scale storage infrastructures are often used by many applications and teams across the entire organization. Isolating teams and groups into their own namespaces is a core requirement. MinIO's AIStor KMS supports namespacing in the form of enclaves. Each tenant can be assigned its own enclave which is completely independent and isolated from all other enclaves on the KMS cluster.
+
+      <b>Predictable Behavior</b>
+      MinIO's AIStor KMS is designed to be easily managed, providing operators with the ability to comprehend its state intuitively. Due to its simple design, MinIO's AIStor KMS is significantly easier to operate than similar solutions that rely on more complex consensus algorithms like Raft, or Paxos.
+
+      <b>Consistent and Performant</b>
+      The responsiveness of the KMS for GET/PUT operations directly influences the overall efficiency and speed of the storage system. MinIO's AIStor KMS nodes don’t have to coordinate when handling such requests from the storage system. Therefore, the performance of a MinIO's AIStor KMS cluster increases linearly with the number of nodes. Further, MinIO's AIStor KMS supports request pipelining to handle hundreds of thousands of cryptographic operations per node and second.
+
+      <b>Simplicity</b>
+      Operating a KMS cluster does not require expertise in cryptography or distributed systems. Everything can be done from the AIStor Console.
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: Minio AIStor Key management System (KMS)
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - MinIO
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.29.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/minkms-sidecar@sha256:20c81947d76d7aeac5133d0e3ffedbda5ef619856416d85634afb4568d3a3a8a
+  name: minkms-sidecar
+- image: quay.io/minio/aistor/minkms@sha256:72bf4ed1a5a8612e3dff15aeba7f01c9963e75c3a90f5d52150458cef9a5088c
+  name: minkms
+- image: quay.io/minio/aistor/operator@sha256:a9b5f4d5ecd33886586980dfe5b7aab998773ae8e9ede137618b62435b670afc
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:7014d7cb0c3068f7b62b8bd3fb6854822549c6e13b2866fd22fce7d214e3b7ae
+  name: ""
+schema: olm.bundle
 ---
 image: registry.connect.redhat.com/minio/minio-minkms-operator@sha256:f0c766033c5ac178121d20faaf7496e386b4362a36267a32879a6468c036388d
 name: minio-minkms-operator.v2026.7.16235330

--- a/catalogs/v4.22/minio-object-store-operator/catalog.yaml
+++ b/catalogs/v4.22/minio-object-store-operator/catalog.yaml
@@ -7,6 +7,22 @@ name: minio-object-store-operator
 schema: olm.package
 ---
 entries:
+- name: minio-object-store-operator.v2025.12.19074437
+  replaces: minio-object-store-operator.v2025.8.19175300
+- name: minio-object-store-operator.v2025.12.19091821
+  replaces: minio-object-store-operator.v2025.12.19074437
+- name: minio-object-store-operator.v2025.12.20100920
+  replaces: minio-object-store-operator.v2025.12.19091821
+- name: minio-object-store-operator.v2025.5.12190907
+- name: minio-object-store-operator.v2025.8.19175300
+  replaces: minio-object-store-operator.v2025.5.12190907
+  skipRange: '>=2025.6.3065135 <2025.8.19175300'
+- name: minio-object-store-operator.v2026.2.9031243
+  replaces: minio-object-store-operator.v2025.12.20100920
+- name: minio-object-store-operator.v2026.3.18173617
+  replaces: minio-object-store-operator.v2026.2.9031243
+- name: minio-object-store-operator.v2026.4.13102716
+  replaces: minio-object-store-operator.v2026.3.18173617
 - name: minio-object-store-operator.v2026.7.9050221
   replaces: minio-object-store-operator.v2026.4.13102716
   skips:
@@ -18,6 +34,1890 @@ entries:
 name: stable
 package: minio-object-store-operator
 schema: olm.channel
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:a3e522ef0bf041736016d2e6976fc8107f480eb21c194bb89cfc592432111c81
+name: minio-object-store-operator.v2025.12.19074437
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2025.12.19074437
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "name": "pool-0",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "standard"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2025-12-19T07:44:37Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-unknown
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: "MinIO AIStor is the standard for building large scale AI data infrastructure.
+      It is designed for the exascale data \ninfrastructure challenges presented by
+      modern AI workloads. AIStor provides new features, along with performance and\nscalability
+      improvements, to enable enterprises to store all AI data in one infrastructure.\n\nMinIO
+      is the standard for building <a href=\"https://min.io/solutions/object-storage-for-ai\">large
+      scale AI data infrastructure</a>.\n\nAIStor is a software-defined, Amazon S3
+      compatible object store that will run anywhere - from the public cloud to the
+      edge.<br><br>\n\nEnterprises use MinIO to deliver against artificial intelligence,
+      machine learning, analytics, application, backup and archival workloads - all
+      from a single platform.\n\nThe use cases include storage for HDFS replacements,
+      AI datalakes, SIEM datalakes, analytics datalakes, object storage as a service,
+      streaming and database warm/hot storage.<br><br>\n\nAIStor is the fastest object
+      storage server, with production READ/WRITE speeds in excess of 2.2 TiB/s on
+      commodity hardware.\n\nBuilt for the cloud operating model it is native to the
+      technologies and architectures that define the cloud. These include containerization,
+      orchestration with Kubernetes, microservices and multi-tenancy - making it the
+      most widely integrated object store in the market today.<br><br>\n\nAIStor offers
+      a host of enterprise features including inline erasure coding, bit-rot detection,
+      state-of-the-art encryption, active-active replication, object locking, lifecycle
+      management, observability, key-management, caching, firewall/load balancing,
+      global console, search and identity + access management.<br><br>\n\nAIStor is
+      priced on usable capacity and includes support through the MinIO Subscription
+      Network.\n\nThe Subscription Network is designed to optimize deployments of
+      MinIO and reduce the risk associated with data loss and data breach while providing
+      24/7/365 direct-to-engineering support.<br><br>\n\n<a href=\"https://resources.min.io/request-a-demo-marketplaces/\">Request
+      a demo today</a>"
+    displayName: MinIO AIStor
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    - Iceberg
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/operator@sha256:f80139efa062fdd83f78318b20f371a827b68e854b03dd9706b9eba4c493aeb2
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:a3e522ef0bf041736016d2e6976fc8107f480eb21c194bb89cfc592432111c81
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:443b32c1b45f8fac70a1decb5d03a5ebbf12493ab6b31a6378bd570a2d8a1e3d
+name: minio-object-store-operator.v2025.12.19091821
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2025.12.19091821
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "name": "pool-0",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "standard"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2025-12-19T09:18:21Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-unknown
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: |-
+      MinIO AIStor is the most sophisticated object store on the market. It is designed for the exascale data infrastructure challenges presented by modern AI workloads. AIStor is the standard for building <a href="https://min.io/solutions/object-storage-for-ai">large scale AI data infrastructure</a>.
+
+      AIStor provides the features, performance and scalability that allow enterprises to store  AI data at scale.
+
+      AIStor is a software-defined, Amazon S3-compatible object store that runs anywhere—from the public cloud to the edge.<br><br>
+
+      Enterprises use AIStor to provide object storage for artificial intelligence and machine learning workloads, insights through analytics, and backup and archival capabilities—all from a single platform.
+
+      Use cases include: storage for HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes; object storage as a service; streaming; and hot/warm storage.<br><br>
+
+      AIStor is the fastest object storage server, with production READ/WRITE speeds in excess of 2.2 TiB/s on commodity hardware.
+
+      Built for the cloud operating model, it is native to the technologies and architectures that define the cloud. These include containerization, Kubernetes orchestration, microservices and multi-tenancy—making it the most widely integrated object store in the market today.<br><br>
+
+      AIStor offers a host of enterprise features including inline erasure coding, bit rot detection, state-of-the-art encryption, active-active replication, identity and access management, object locking, lifecycle management, monitoring and key management.<br><br>
+
+      AIStor is priced on usable capacity and includes support through the MinIO Subscription Network (SUBNET).
+
+      SUBNET is designed to provide 24/7/365 direct-to-engineering support. Use this support to optimize deployments and reduce the risk associated with data loss and data breaches.<br><br>
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: MinIO AIStor
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    - Iceberg
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/operator@sha256:f80139efa062fdd83f78318b20f371a827b68e854b03dd9706b9eba4c493aeb2
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:443b32c1b45f8fac70a1decb5d03a5ebbf12493ab6b31a6378bd570a2d8a1e3d
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:60d9db07ded3561c135fc3e11582eb7781e80188026584e8440d48257186b7c0
+name: minio-object-store-operator.v2025.12.20100920
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2025.12.20100920
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "name": "pool-0",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "directpv-min-io"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ],
+              "rollingTimeoutSeconds": 600
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2025-12-20T17:22:16Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.42.0
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: |-
+      MinIO AIStor is the most sophisticated object store on the market. It is designed for the exascale data infrastructure challenges presented by modern AI workloads. AIStor is the standard for building <a href="https://min.io/solutions/object-storage-for-ai">large scale AI data infrastructure</a>.
+
+      AIStor provides the features, performance and scalability that allow enterprises to store  AI data at scale.
+
+      AIStor is a software-defined, Amazon S3-compatible object store that runs anywhere—from the public cloud to the edge.<br><br>
+
+      Enterprises use AIStor to provide object storage for artificial intelligence and machine learning workloads, insights through analytics, and backup and archival capabilities—all from a single platform.
+
+      Use cases include: storage for HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes; object storage as a service; streaming; and hot/warm storage.<br><br>
+
+      AIStor is the fastest object storage server, with production READ/WRITE speeds in excess of 2.2 TiB/s on commodity hardware.
+
+      Built for the cloud operating model, it is native to the technologies and architectures that define the cloud. These include containerization, Kubernetes orchestration, microservices and multi-tenancy—making it the most widely integrated object store in the market today.<br><br>
+
+      AIStor offers a host of enterprise features including inline erasure coding, bit rot detection, state-of-the-art encryption, active-active replication, identity and access management, object locking, lifecycle management, monitoring and key management.<br><br>
+
+      AIStor is priced on usable capacity and includes support through the MinIO Subscription Network (SUBNET).
+
+      SUBNET is designed to provide 24/7/365 direct-to-engineering support. Use this support to optimize deployments and reduce the risk associated with data loss and data breaches.<br><br>
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: MinIO AIStor
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    - Iceberg
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/kes-sidecar@sha256:cc965047df668ab3474f0d1dc8b97f651cb54a745bc4af6176436ad2e4dd3315
+  name: kes-sidecar
+- image: quay.io/minio/aistor/kes@sha256:424a973d98bdee847dc069616c4612e4d22ff4ac196eb1820ab0a26fe9c936a8
+  name: kes
+- image: quay.io/minio/aistor/mc@sha256:c7e82c0a57fc8d30f444d5cd848ea7d12c56b147cc7e5d6f284a61cd6fb4d131
+  name: mc
+- image: quay.io/minio/aistor/minio-sidecar@sha256:1f1854001ece4aa1c8ce2409377d21a4ca42cef35753c38be70f9b9b0888a2ab
+  name: minio-sidecar
+- image: quay.io/minio/aistor/minio@sha256:a26b15bd6f392aecf96148bb3fe3026d3515aef022fc8bcc3ea0d7b89242e748
+  name: minio
+- image: quay.io/minio/aistor/operator@sha256:2c3cb98193815b76f73e89bb3d6311ccd75c3b354bdccd04758715a08b163436
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:60d9db07ded3561c135fc3e11582eb7781e80188026584e8440d48257186b7c0
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:12c78edd21af889e9c57a53e13b68dbaac75d583dccb2cd2c3dfd136a7cd8436
+name: minio-object-store-operator.v2025.5.12190907
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2025.5.12190907
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "name": "pool-0",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "standard"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2025-05-12T21:24:34Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.36.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: "MinIO AIStor extends the most sophisticated object store on the
+      market. It is designed for the exascale data \ninfrastructure challenges presented
+      by modern AI workloads. AIStor provides new features, along with performance
+      and\nscalability improvements, to enable enterprises to store all AI data in
+      one infrastructure.\n\nMinIO is the standard for building <a href=\"https://min.io/solutions/object-storage-for-ai\">large
+      scale AI data infrastructure</a>.\n\nThe MinIO AIStor is a software-defined,
+      Amazon S3 compatible object store that will run anywhere - from the public cloud
+      to the edge.<br><br>\n\nEnterprises use MinIO to deliver against artificial
+      intelligence, machine learning, analytics, application, backup and archival
+      workloads - all from a single platform.\n\nThe use cases include storage for
+      HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes, object
+      storage as a service, streaming and database warm/hot storage.<br><br>\n\nMinIO’s
+      AIStor is the fastest object storage server, with production READ/WRITE speeds
+      in excess of 2.2 TiB/s on commodity hardware.\n\nBuilt for the cloud operating
+      model it is native to the technologies and architectures that define the cloud.
+      These include containerization, orchestration with Kubernetes, microservices
+      and multi-tenancy - making it the most widely integrated object store in the
+      market today.<br><br>\n\nThe AIStor offers a host of enterprise features including
+      inline erasure coding, bit-rot detection, state-of-the-art encryption, active-active
+      replication, object locking, lifecycle management, observability, key-management,
+      caching, firewall/load balancing, global console, search and identity + access
+      management.<br><br>\n\nThe AIStor is priced on usable capacity and includes
+      support through the MinIO Subscription Network.\n\nThe Subscription Network
+      is designed to optimize deployments of MinIO and reduce the risk associated
+      with data loss and data breach while providing 24/7/365 direct-to-engineering
+      support.<br><br>\n\n<a href=\"https://resources.min.io/request-a-demo-marketplaces/\">Request
+      a demo today</a>"
+    displayName: Minio AIStor Object Store
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/operator@sha256:61625a67087fa905fecee44bc8a614b018a14d4de70ce500011b05e2bf927ed4
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:12c78edd21af889e9c57a53e13b68dbaac75d583dccb2cd2c3dfd136a7cd8436
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:c5af6adc5e7f9bb2d5bf6025b1b8c3e33ce5b9349a0246df1a26b7ec91b2ea2f
+name: minio-object-store-operator.v2025.8.19175300
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2025.8.19175300
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "name": "pool-0",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "standard"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ]
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2025-08-27T14:50:56Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-unknown
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: "MinIO AIStor extends the most sophisticated object store on the
+      market. It is designed for the exascale data \ninfrastructure challenges presented
+      by modern AI workloads. AIStor provides new features, along with performance
+      and\nscalability improvements, to enable enterprises to store all AI data in
+      one infrastructure.\n\nMinIO is the standard for building <a href=\"https://min.io/solutions/object-storage-for-ai\">large
+      scale AI data infrastructure</a>.\n\nThe MinIO AIStor is a software-defined,
+      Amazon S3 compatible object store that will run anywhere - from the public cloud
+      to the edge.<br><br>\n\nEnterprises use MinIO to deliver against artificial
+      intelligence, machine learning, analytics, application, backup and archival
+      workloads - all from a single platform.\n\nThe use cases include storage for
+      HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes, object
+      storage as a service, streaming and database warm/hot storage.<br><br>\n\nMinIO’s
+      AIStor is the fastest object storage server, with production READ/WRITE speeds
+      in excess of 2.2 TiB/s on commodity hardware.\n\nBuilt for the cloud operating
+      model it is native to the technologies and architectures that define the cloud.
+      These include containerization, orchestration with Kubernetes, microservices
+      and multi-tenancy - making it the most widely integrated object store in the
+      market today.<br><br>\n\nThe AIStor offers a host of enterprise features including
+      inline erasure coding, bit-rot detection, state-of-the-art encryption, active-active
+      replication, object locking, lifecycle management, observability, key-management,
+      caching, firewall/load balancing, global console, search and identity + access
+      management.<br><br>\n\nThe AIStor is priced on usable capacity and includes
+      support through the MinIO Subscription Network.\n\nThe Subscription Network
+      is designed to optimize deployments of MinIO and reduce the risk associated
+      with data loss and data breach while providing 24/7/365 direct-to-engineering
+      support.<br><br>\n\n<a href=\"https://resources.min.io/request-a-demo-marketplaces/\">Request
+      a demo today</a>"
+    displayName: Minio AIStor Object Store
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/operator@sha256:f80139efa062fdd83f78318b20f371a827b68e854b03dd9706b9eba4c493aeb2
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:c5af6adc5e7f9bb2d5bf6025b1b8c3e33ce5b9349a0246df1a26b7ec91b2ea2f
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:6ed6089976631e2dabb95be1057400950187ad464efff595d9ba5d79eceb9d76
+name: minio-object-store-operator.v2026.2.9031243
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2026.2.9031243
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "annotations": {
+                    "io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel": "true"
+                  },
+                  "name": "pool-0",
+                  "runtimeClassName": "selinux",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "directpv-min-io"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ],
+              "rollingTimeoutSeconds": 600
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2026-02-14T09:26:24Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.41.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: |-
+      MinIO AIStor is the most sophisticated object store on the market. It is designed for the exascale data infrastructure challenges presented by modern AI workloads. AIStor is the standard for building <a href="https://min.io/solutions/object-storage-for-ai">large scale AI data infrastructure</a>.
+
+      AIStor provides the features, performance and scalability that allow enterprises to store  AI data at scale.
+
+      AIStor is a software-defined, Amazon S3-compatible object store that runs anywhere—from the public cloud to the edge.<br><br>
+
+      Enterprises use AIStor to provide object storage for artificial intelligence and machine learning workloads, insights through analytics, and backup and archival capabilities—all from a single platform.
+
+      Use cases include: storage for HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes; object storage as a service; streaming; and hot/warm storage.<br><br>
+
+      AIStor is the fastest object storage server, with production READ/WRITE speeds in excess of 2.2 TiB/s on commodity hardware.
+
+      Built for the cloud operating model, it is native to the technologies and architectures that define the cloud. These include containerization, Kubernetes orchestration, microservices and multi-tenancy—making it the most widely integrated object store in the market today.<br><br>
+
+      AIStor offers a host of enterprise features including inline erasure coding, bit rot detection, state-of-the-art encryption, active-active replication, identity and access management, object locking, lifecycle management, monitoring and key management.<br><br>
+
+      AIStor is priced on usable capacity and includes support through the MinIO Subscription Network (SUBNET).
+
+      SUBNET is designed to provide 24/7/365 direct-to-engineering support. Use this support to optimize deployments and reduce the risk associated with data loss and data breaches.<br><br>
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: MinIO AIStor
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    - Iceberg
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.26.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/kes-sidecar@sha256:21c5372b574d14dbd5cd5e6a3fd1bee41620f6c45fdfa7941c56357b31a8ca8c
+  name: kes-sidecar
+- image: quay.io/minio/aistor/kes@sha256:21ee422b82d022d55f3640758d1d14c4c67c2a4e23500a5ca7b3c65aec816ef0
+  name: kes
+- image: quay.io/minio/aistor/mc@sha256:05ab893ee8d7a3e349f6b91977caf37ec47dcf06aeae50027b72bdb832286869
+  name: mc
+- image: quay.io/minio/aistor/minio-sidecar@sha256:e1d8fd698ead42f36bf87d0884c66f07f668dcc16dbd0598ec0fff2c2cb0c5e1
+  name: minio-sidecar
+- image: quay.io/minio/aistor/minio@sha256:33cf8200d428a9b334867c2f873a68a5ceffeb6930753f91bbb1eb188ea1ef43
+  name: minio
+- image: quay.io/minio/aistor/operator@sha256:e75807db28ef34db8cdbf886e94c5ea0bcded7f37da152ba311edacde99124e1
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:6ed6089976631e2dabb95be1057400950187ad464efff595d9ba5d79eceb9d76
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:79c02fffa136fd0ad32e4d91523e1579281c8174210f77a6c1055394fd9e578b
+name: minio-object-store-operator.v2026.3.18173617
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2026.3.18173617
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "annotations": {
+                    "io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel": "true"
+                  },
+                  "name": "pool-0",
+                  "runtimeClassName": "selinux",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "directpv-min-io"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ],
+              "rollingTimeoutSeconds": 600
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2026-03-19T19:46:12Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.41.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: |-
+      MinIO AIStor is the most sophisticated object store on the market. It is designed for the exascale data infrastructure challenges presented by modern AI workloads. AIStor is the standard for building <a href="https://min.io/solutions/object-storage-for-ai">large scale AI data infrastructure</a>.
+
+      AIStor provides the features, performance and scalability that allow enterprises to store  AI data at scale.
+
+      AIStor is a software-defined, Amazon S3-compatible object store that runs anywhere—from the public cloud to the edge.<br><br>
+
+      Enterprises use AIStor to provide object storage for artificial intelligence and machine learning workloads, insights through analytics, and backup and archival capabilities—all from a single platform.
+
+      Use cases include: storage for HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes; object storage as a service; streaming; and hot/warm storage.<br><br>
+
+      AIStor is the fastest object storage server, with production READ/WRITE speeds in excess of 2.2 TiB/s on commodity hardware.
+
+      Built for the cloud operating model, it is native to the technologies and architectures that define the cloud. These include containerization, Kubernetes orchestration, microservices and multi-tenancy—making it the most widely integrated object store in the market today.<br><br>
+
+      AIStor offers a host of enterprise features including inline erasure coding, bit rot detection, state-of-the-art encryption, active-active replication, identity and access management, object locking, lifecycle management, monitoring and key management.<br><br>
+
+      AIStor is priced on usable capacity and includes support through the MinIO Subscription Network (SUBNET).
+
+      SUBNET is designed to provide 24/7/365 direct-to-engineering support. Use this support to optimize deployments and reduce the risk associated with data loss and data breaches.<br><br>
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: MinIO AIStor
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    - Iceberg
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.29.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/kes-sidecar@sha256:0ec562258344b1f0d8e3680a7f82aab965ce48c8886e4997b44f1ceb5ac70c3d
+  name: kes-sidecar
+- image: quay.io/minio/aistor/kes@sha256:c6d66a87eda5e0fadb17a87895caa75c33cebdc5705a37b7ed34e7d3692c3f91
+  name: kes
+- image: quay.io/minio/aistor/mc@sha256:6c33dc0fbf65c362be95003cd010ed95a41c556500833ea139f86de40c4c4e9f
+  name: mc
+- image: quay.io/minio/aistor/minio-sidecar@sha256:85f55d7238f0ed4ee0cb686f659c5484bc22152e77ccb3dbbf5639c43cac3719
+  name: minio-sidecar
+- image: quay.io/minio/aistor/minio@sha256:944406381b20b7e10f6ff4d35e4d6e2d35f7c254021bf91ec479b92638aa57ae
+  name: minio
+- image: quay.io/minio/aistor/operator@sha256:be72c9f1a0b6baa050f59d486452909543758a2424b11920a522e60c7fac76b9
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:79c02fffa136fd0ad32e4d91523e1579281c8174210f77a6c1055394fd9e578b
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:871cf89d5b97ea3218aa5743f675e7871b3bf7253820d0f28c37d8dcc39c79bd
+name: minio-object-store-operator.v2026.4.13102716
+package: minio-object-store-operator
+properties:
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: AdminJob
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: aistor.min.io
+    kind: ObjectStore
+    version: v1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: sts.min.io
+    kind: PolicyBinding
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: minio-object-store-operator
+    version: 2026.4.13102716
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "aistor.min.io/v1",
+            "kind": "ObjectStore",
+            "metadata": {
+              "annotations": {
+                "prometheus.io/path": "/minio/v2/metrics/cluster",
+                "prometheus.io/port": "9000",
+                "prometheus.io/scrape": "true"
+              },
+              "labels": {
+                "app": "minio"
+              },
+              "name": "my-objectstore"
+            },
+            "spec": {
+              "cache": {
+                "enabled": false
+              },
+              "certificates": {
+                "disableAutoCert": false
+              },
+              "configuration": {
+                "name": "storage-configuration"
+              },
+              "firewall": {
+                "enabled": false
+              },
+              "mountPath": "/export",
+              "podManagementPolicy": "Parallel",
+              "pools": [
+                {
+                  "annotations": {
+                    "io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel": "true"
+                  },
+                  "name": "pool-0",
+                  "runtimeClassName": "selinux",
+                  "securityContext": {
+                    "fsGroupChangePolicy": "OnRootMismatch"
+                  },
+                  "servers": 4,
+                  "volumeClaimTemplate": {
+                    "apiVersion": "v1",
+                    "kind": "persistentvolumeclaims",
+                    "spec": {
+                      "accessModes": [
+                        "ReadWriteOnce"
+                      ],
+                      "resources": {
+                        "requests": {
+                          "storage": "1Ti"
+                        }
+                      },
+                      "storageClassName": "directpv-min-io"
+                    }
+                  },
+                  "volumesPerServer": 4
+                }
+              ],
+              "rollingTimeoutSeconds": 600
+            }
+          },
+          {
+            "apiVersion": "aistor.min.io/v1alpha1",
+            "kind": "AdminJob",
+            "metadata": {
+              "name": "minio-job"
+            },
+            "spec": {
+              "commands": [
+                {
+                  "args": {
+                    "name": "iac-bucket"
+                  },
+                  "op": "make-bucket"
+                }
+              ],
+              "containerSecurityContext": {},
+              "objectStore": {
+                "name": "my-objectstore",
+                "namespace": "my-objectstore"
+              },
+              "securityContext": {},
+              "serviceAccountName": "my-objectstore-sa"
+            }
+          },
+          {
+            "apiVersion": "sts.min.io/v1beta1",
+            "kind": "PolicyBinding",
+            "metadata": {
+              "name": "example-binding"
+            },
+            "spec": {
+              "application": {
+                "namespace": "my-objectstore",
+                "serviceaccount": "my-objectstore-sa"
+              },
+              "policies": [
+                "consoleAdmin"
+              ]
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Storage,AI/Machine Learning
+      createdAt: "2026-05-12T18:01:30Z"
+      description: MinIO AIStor is the standard for building large scale AI data infrastructure.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "false"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      operatorframework.io/suggested-namespace: aistor
+      operators.openshift.io/valid-subscription: Contact MinIO for subscription information.
+      operators.operatorframework.io.bundle.channel.default.v1: stable
+      operators.operatorframework.io/builder: operator-sdk-v1.41.1
+      operators.operatorframework.io/project_layout: unknown
+      support: min.io
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: AdminJob
+        name: adminjobs.aistor.min.io
+        version: v1alpha1
+      - kind: ObjectStore
+        name: objectstores.aistor.min.io
+        version: v1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1alpha1
+      - kind: PolicyBinding
+        name: policybindings.sts.min.io
+        version: v1beta1
+    description: |-
+      MinIO AIStor is the most sophisticated object store on the market. It is designed for the exascale data infrastructure challenges presented by modern AI workloads. AIStor is the standard for building <a href="https://min.io/solutions/object-storage-for-ai">large scale AI data infrastructure</a>.
+
+      AIStor provides the features, performance and scalability that allow enterprises to store  AI data at scale.
+
+      AIStor is a software-defined, Amazon S3-compatible object store that runs anywhere—from the public cloud to the edge.<br><br>
+
+      Enterprises use AIStor to provide object storage for artificial intelligence and machine learning workloads, insights through analytics, and backup and archival capabilities—all from a single platform.
+
+      Use cases include: storage for HDFS replacements, AI datalakes, SIEM datalakes, analytics datalakes; object storage as a service; streaming; and hot/warm storage.<br><br>
+
+      AIStor is the fastest object storage server, with production READ/WRITE speeds in excess of 2.2 TiB/s on commodity hardware.
+
+      Built for the cloud operating model, it is native to the technologies and architectures that define the cloud. These include containerization, Kubernetes orchestration, microservices and multi-tenancy—making it the most widely integrated object store in the market today.<br><br>
+
+      AIStor offers a host of enterprise features including inline erasure coding, bit rot detection, state-of-the-art encryption, active-active replication, identity and access management, object locking, lifecycle management, monitoring and key management.<br><br>
+
+      AIStor is priced on usable capacity and includes support through the MinIO Subscription Network (SUBNET).
+
+      SUBNET is designed to provide 24/7/365 direct-to-engineering support. Use this support to optimize deployments and reduce the risk associated with data loss and data breaches.<br><br>
+
+      <a href="https://resources.min.io/request-a-demo-marketplaces/">Request a demo today</a>
+    displayName: MinIO AIStor
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - AI Storage
+    - S3
+    - MinIO
+    - Object Storage
+    - Iceberg
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Minio AIStor
+      url: https://min.io
+    - name: Support
+      url: https://subnet.min.io
+    - name: Github
+      url: https://github.com/minio/aistor
+    maintainers:
+    - email: dev@min.io
+      name: MinIO
+    maturity: stable
+    minKubeVersion: 1.29.0
+    provider:
+      name: MinIO
+      url: https://min.io
+relatedImages:
+- image: quay.io/minio/aistor/kes-sidecar@sha256:7ad7a7e508aafd367810b9f7198c2f24c70cc6ed8d91a149d40d25df520cc9f6
+  name: kes-sidecar
+- image: quay.io/minio/aistor/kes@sha256:a341d7fca619e3dd0fd75c00b94b2f3de119d3ef8b9ac79c48c41659b3ed4ded
+  name: kes
+- image: quay.io/minio/aistor/mc@sha256:994ab4b6b6c99f13f5a19e29e5982542db5a035fd7745a6838d59d3e9624bb2e
+  name: mc
+- image: quay.io/minio/aistor/minio-sidecar@sha256:a1f42abc8e5f72470fcc8549184cc36e33b778a665b90d10a977079512803b1e
+  name: minio-sidecar
+- image: quay.io/minio/aistor/minio@sha256:c98e3f121a9208290f1b718345408d9084877ba4e2826ba82117ad7cf0ee3ddf
+  name: minio
+- image: quay.io/minio/aistor/operator@sha256:a9b5f4d5ecd33886586980dfe5b7aab998773ae8e9ede137618b62435b670afc
+  name: controller
+- image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:871cf89d5b97ea3218aa5743f675e7871b3bf7253820d0f28c37d8dcc39c79bd
+  name: ""
+schema: olm.bundle
 ---
 image: registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:cb1f5f18095e8f29afeceb4eafcb4f752cf6cd88cf42f68705d2d15dfae8e915
 name: minio-object-store-operator.v2026.7.16235330

--- a/operators/minio-minkms-operator/catalog-templates/v4.22.yaml
+++ b/operators/minio-minkms-operator/catalog-templates/v4.22.yaml
@@ -8,11 +8,30 @@ entries:
   name: minio-minkms-operator
   schema: olm.package
 - entries:
+  - name: minio-minkms-operator.v2025.12.20100920
+  - name: minio-minkms-operator.v2026.2.9031243
+    replaces: minio-minkms-operator.v2025.12.20100920
+  - name: minio-minkms-operator.v2026.3.18173617
+    replaces: minio-minkms-operator.v2026.2.9031243
+  - name: minio-minkms-operator.v2026.4.13102716
+    replaces: minio-minkms-operator.v2026.3.18173617
   - name: minio-minkms-operator.v2026.7.16235330
     replaces: minio-minkms-operator.v2026.4.13102716
   name: stable
   package: minio-minkms-operator
   schema: olm.channel
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-minkms-operator@sha256:8f9634ada21dac314549e710a5a3ab384307d27124c094bc666d202c41fcb34e
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-minkms-operator@sha256:7a9facacac30c17669b91a5f892d48317b29451f0cb95d9504ec1abc28efd2b6
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-minkms-operator@sha256:6d38965736a2b3f7a610d346105b3949203a221c0636e906b4f140c14eb51ad4
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-minkms-operator@sha256:7014d7cb0c3068f7b62b8bd3fb6854822549c6e13b2866fd22fce7d214e3b7ae
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/minio/minio-minkms-operator@sha256:f0c766033c5ac178121d20faaf7496e386b4362a36267a32879a6468c036388d

--- a/operators/minio-object-store-operator/catalog-templates/v4.22.yaml
+++ b/operators/minio-object-store-operator/catalog-templates/v4.22.yaml
@@ -8,6 +8,22 @@ entries:
   name: minio-object-store-operator
   schema: olm.package
 - entries:
+  - name: minio-object-store-operator.v2025.12.19074437
+    replaces: minio-object-store-operator.v2025.8.19175300
+  - name: minio-object-store-operator.v2025.12.19091821
+    replaces: minio-object-store-operator.v2025.12.19074437
+  - name: minio-object-store-operator.v2025.12.20100920
+    replaces: minio-object-store-operator.v2025.12.19091821
+  - name: minio-object-store-operator.v2025.5.12190907
+  - name: minio-object-store-operator.v2025.8.19175300
+    replaces: minio-object-store-operator.v2025.5.12190907
+    skipRange: '>=2025.6.3065135 <2025.8.19175300'
+  - name: minio-object-store-operator.v2026.2.9031243
+    replaces: minio-object-store-operator.v2025.12.20100920
+  - name: minio-object-store-operator.v2026.3.18173617
+    replaces: minio-object-store-operator.v2026.2.9031243
+  - name: minio-object-store-operator.v2026.4.13102716
+    replaces: minio-object-store-operator.v2026.3.18173617
   - name: minio-object-store-operator.v2026.7.9050221
     replaces: minio-object-store-operator.v2026.4.13102716
     skips:
@@ -20,8 +36,32 @@ entries:
   package: minio-object-store-operator
   schema: olm.channel
 - image: 
-    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:55e0198b424aa75d00279a1c2512bc4b4ac3e76a9b2728b4fd544dc3b8492e26
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:443b32c1b45f8fac70a1decb5d03a5ebbf12493ab6b31a6378bd570a2d8a1e3d
   schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:60d9db07ded3561c135fc3e11582eb7781e80188026584e8440d48257186b7c0
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:12c78edd21af889e9c57a53e13b68dbaac75d583dccb2cd2c3dfd136a7cd8436
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:c5af6adc5e7f9bb2d5bf6025b1b8c3e33ce5b9349a0246df1a26b7ec91b2ea2f
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:a3e522ef0bf041736016d2e6976fc8107f480eb21c194bb89cfc592432111c81
+  schema: olm.bundle
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:6ed6089976631e2dabb95be1057400950187ad464efff595d9ba5d79eceb9d76
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:79c02fffa136fd0ad32e4d91523e1579281c8174210f77a6c1055394fd9e578b
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:871cf89d5b97ea3218aa5743f675e7871b3bf7253820d0f28c37d8dcc39c79bd
+- schema: olm.bundle
+  image: 
+    registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:55e0198b424aa75d00279a1c2512bc4b4ac3e76a9b2728b4fd544dc3b8492e26
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/minio/minio-aistor-object-store-operator@sha256:cb1f5f18095e8f29afeceb4eafcb4f752cf6cd88cf42f68705d2d15dfae8e915


### PR DESCRIPTION
After running a basic set of tests in OpenShift `v4.22` for the older Operator versions still not published in this catalog, we decided to also support these versions in Openshift `v4.22`. See https://github.com/miniohq/aistor-operator/pull/1700