### PR TITLE
Catalog update [habana-ai-operator] [v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.20/habana-ai-operator/catalog.yaml
+++ b/catalogs/v4.20/habana-ai-operator/catalog.yaml
@@ -34,6 +34,9 @@ schema: olm.channel
 ---
 entries:
 - name: habana-ai-operator.v1.24.0-1007
+- name: habana-ai-operator.v1.24.1-482
+  replaces: habana-ai-operator.v1.24.0-1007
+  skipRange: '>=1.9.0 <1.24.1-482'
 name: "1.24"
 package: habana-ai-operator
 schema: olm.channel
@@ -58,6 +61,8 @@ entries:
   skipRange: '>=1.9.0 <1.23.0-695'
 - name: habana-ai-operator.v1.24.0-1007
   replaces: habana-ai-operator.v1.23.0-695
+- name: habana-ai-operator.v1.24.1-482
+  replaces: habana-ai-operator.v1.24.0-1007
 name: stable
 package: habana-ai-operator
 schema: olm.channel
@@ -2016,5 +2021,292 @@ relatedImages:
 - image: quay.io/brancz/kube-rbac-proxy@sha256:c2ef3c3fcb4ffcfab30088b19c8ef18931aac8cf072c75ef72c654457e1d632b
   name: kube-rbac-proxy
 - image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai@sha256:1be01f382761ea0e25270a2388f4fad0fe33ce0ae5f9f830f81b196153fb036e
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+name: habana-ai-operator.v1.24.1-482
+package: habana-ai-operator
+properties:
+- type: olm.gvk
+  value:
+    group: habanalabs.habana.ai
+    kind: ClusterPolicy
+    version: v1
+- type: olm.package
+  value:
+    packageName: habana-ai-operator
+    version: 1.24.1-482
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "habanalabs.habana.ai/v1",
+            "kind": "ClusterPolicy",
+            "metadata": {
+              "name": "habana-ai"
+            },
+            "spec": {
+              "accelerator_allocation_mode": "device-plugin",
+              "bmc_monitoring": {
+                "image": {
+                  "repository": "docker.io/intel/gaudi-bmc-exporter",
+                  "tag": "1.24.1-482"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "memory": "250Mi"
+                  },
+                  "requests": {
+                    "cpu": "150m",
+                    "memory": "100Mi"
+                  }
+                }
+              },
+              "device_plugin": {
+                "image": {
+                  "repository": "docker.io/intel/gaudi-device-plugin",
+                  "tag": "1.24.1-482"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "64Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "32Mi"
+                  }
+                }
+              },
+              "dra_resource_driver": {
+                "image": {
+                  "repository": "ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gaudi-resource-driver",
+                  "tag": "v0.6.1"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "64Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "32Mi"
+                  }
+                }
+              },
+              "driver": {
+                "driver_loader": {
+                  "images": {
+                    "rhel_9.6": {
+                      "repository": "docker.io/redhat/ubi9",
+                      "tag": "9.6"
+                    },
+                    "rhel_9.8": {
+                      "repository": "docker.io/redhat/ubi9",
+                      "tag": "9.8"
+                    },
+                    "ubuntu_22.04": {
+                      "repository": "docker.io/ubuntu",
+                      "tag": "22.04"
+                    },
+                    "ubuntu_24.04": {
+                      "repository": "docker.io/ubuntu",
+                      "tag": "24.04"
+                    }
+                  },
+                  "mlnx_ofed_repo_path": "artifactory/gaudi-installer/deps",
+                  "mlnx_ofed_version": "mlnx-ofed-5.8-2.0.3.0-rhel8.4-x86_64.tar.gz",
+                  "repo_path": "artifactory/gaudi-installer/repos",
+                  "repo_server": "vault.habana.ai",
+                  "resources": {
+                    "limits": {
+                      "cpu": "4000m",
+                      "memory": "16Gi"
+                    },
+                    "requests": {
+                      "cpu": "2000m",
+                      "memory": "8Gi"
+                    }
+                  }
+                },
+                "driver_runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-driver-installer",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              },
+              "feature_discovery": {
+                "nfd_plugin": false,
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-feature-discovery",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              },
+              "image_registry": "vault.habana.ai",
+              "metric_exporter": {
+                "interval": 20,
+                "port": 41611,
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-metric-exporter",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "150m",
+                      "memory": "120Mi"
+                    },
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "100Mi"
+                    }
+                  }
+                }
+              },
+              "runtime": {
+                "configuration": {
+                  "container_engine": "crio"
+                },
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-container-runtime",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning, OpenShift Optional
+      certified: "true"
+      containerImage: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+      createdAt: "2026-07-10T12:39:28Z"
+      description: Manages Intel Gaudi AI accelerators within a Kubernetes cluster
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.9.0 <1.24.1-482'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: habana-ai-operator
+      operators.operatorframework.io/builder: operator-sdk-v1.42.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: http://github.com/HabanaAI/habana-ai-operator
+      support: Habana Labs Ltd.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ClusterPolicy is the Schema for the clusterpolicies API.
+        displayName: Cluster Policy
+        kind: ClusterPolicy
+        name: clusterpolicies.habanalabs.habana.ai
+        version: v1
+    description: |
+      Kubernetes provides access to accelerators such as Intel Gaudi AI accelerators and other devices through the [Device Plugin framework](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/). However, configuring and managing nodes with these hardware resources requires configuration of multiple software components such as drivers, container runtimes or other libraries which are difficult and prone to errors.
+      The Intel Gaudi uses the [operator framework](https://coreos.com/blog/introducing-operator-framework) within Kubernetes to automate the management of all Intel Gaudi software components needed to provision and monitor the Intel Gaudi AI accelerators. These components include:
+      * The Intel Gaudi kernel modules to enable the hardware
+      * The Kubernetes DevicePlugin to allow the Intel Gaudi AI accelerator allocation via the kubelet
+      ### Documentation
+      Visit the [Intel Gaudi developer site](https://developer.habana.ai/) for more information.
+      To get started with using Intel Gaudi with OpenShift, see the instructions in the [Intel Gaudi Documentation](https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html).
+    displayName: Intel Gaudi Base Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - habanalabs
+    - hardware
+    - driver
+    links:
+    - name: Intel Gaudi Documentation
+      url: https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html
+    maintainers:
+    - email: erik.berlin@intel.com
+      name: Erik Berlin
+    - email: tal.david@intel.com
+      name: Tal David
+    - email: lukasz.wencel@intel.com
+      name: Lukasz Wencel
+    maturity: stable
+    provider:
+      name: Habana Labs Ltd.
+      url: https://habana.ai
+relatedImages:
+- image: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+  name: gaudi-base-operator-fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59-annotation
+- image: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+  name: manager
+- image: docker.io/intel/gaudi-bmc-exporter@sha256:58ec8ccc005be06cba2bd415c8884f1b4733a4996c393c5c77f250d287a6d04b
+  name: gaudi-bmc-exporter
+- image: docker.io/intel/gaudi-container-runtime@sha256:79b3cea7157e229796576832614f6b4a47bc841f478b505675daad5488e48f90
+  name: gaudi-container-runtime
+- image: docker.io/intel/gaudi-device-plugin@sha256:ffd3c446093b4605d96a00998cd54e403f84179faa63e62c6c88ced8f0d35975
+  name: gaudi-device-plugin
+- image: docker.io/intel/gaudi-driver-installer@sha256:eef69985c7374403f0aeabe6f9dd31c10ca11bbf01050df6383b1260edd24f99
+  name: gaudi-driver-installer
+- image: docker.io/intel/gaudi-feature-discovery@sha256:08ed19730e1e07980b94eb47fe0271cd3b1824f6c144200c6d8ee95ef71866f6
+  name: gaudi-feature-discovery
+- image: docker.io/intel/gaudi-metric-exporter@sha256:6c158db28975613e4a16ac4afaf08c5ea0e9ca27d5d0011f6288cef790d686c7
+  name: gaudi-metric-exporter
+- image: docker.io/redhat/ubi9@sha256:8bf0e8f20737e9c8a68c8a498299e9504ab397b1b1f2837acb2fef12ec698f0e
+  name: driver-loader-rhel-9.8
+- image: docker.io/redhat/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc
+  name: driver-loader-rhel-9.6
+- image: docker.io/ubuntu@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+  name: driver-loader-ubuntu-22.04
+- image: docker.io/ubuntu@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+  name: driver-loader-ubuntu-24.04
+- image: ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gaudi-resource-driver@sha256:b0e255bb5403ec35f1cb040e55b227ad40539577437db5420b1987ca9c283391
+  name: intel-gaudi-resource-driver
+- image: quay.io/brancz/kube-rbac-proxy@sha256:c2ef3c3fcb4ffcfab30088b19c8ef18931aac8cf072c75ef72c654457e1d632b
+  name: kube-rbac-proxy
+- image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/habana-ai-operator/catalog.yaml
+++ b/catalogs/v4.21/habana-ai-operator/catalog.yaml
@@ -15,6 +15,8 @@ schema: olm.channel
 ---
 entries:
 - name: habana-ai-operator.v1.24.0-1007
+- name: habana-ai-operator.v1.24.1-482
+  replaces: habana-ai-operator.v1.24.0-1007
 name: "1.24"
 package: habana-ai-operator
 schema: olm.channel
@@ -592,5 +594,292 @@ relatedImages:
 - image: quay.io/brancz/kube-rbac-proxy@sha256:c2ef3c3fcb4ffcfab30088b19c8ef18931aac8cf072c75ef72c654457e1d632b
   name: kube-rbac-proxy
 - image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai@sha256:1be01f382761ea0e25270a2388f4fad0fe33ce0ae5f9f830f81b196153fb036e
+  name: ""
+schema: olm.bundle
+---
+image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+name: habana-ai-operator.v1.24.1-482
+package: habana-ai-operator
+properties:
+- type: olm.gvk
+  value:
+    group: habanalabs.habana.ai
+    kind: ClusterPolicy
+    version: v1
+- type: olm.package
+  value:
+    packageName: habana-ai-operator
+    version: 1.24.1-482
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "habanalabs.habana.ai/v1",
+            "kind": "ClusterPolicy",
+            "metadata": {
+              "name": "habana-ai"
+            },
+            "spec": {
+              "accelerator_allocation_mode": "device-plugin",
+              "bmc_monitoring": {
+                "image": {
+                  "repository": "docker.io/intel/gaudi-bmc-exporter",
+                  "tag": "1.24.1-482"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "memory": "250Mi"
+                  },
+                  "requests": {
+                    "cpu": "150m",
+                    "memory": "100Mi"
+                  }
+                }
+              },
+              "device_plugin": {
+                "image": {
+                  "repository": "docker.io/intel/gaudi-device-plugin",
+                  "tag": "1.24.1-482"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "64Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "32Mi"
+                  }
+                }
+              },
+              "dra_resource_driver": {
+                "image": {
+                  "repository": "ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gaudi-resource-driver",
+                  "tag": "v0.6.1"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "64Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "32Mi"
+                  }
+                }
+              },
+              "driver": {
+                "driver_loader": {
+                  "images": {
+                    "rhel_9.6": {
+                      "repository": "docker.io/redhat/ubi9",
+                      "tag": "9.6"
+                    },
+                    "rhel_9.8": {
+                      "repository": "docker.io/redhat/ubi9",
+                      "tag": "9.8"
+                    },
+                    "ubuntu_22.04": {
+                      "repository": "docker.io/ubuntu",
+                      "tag": "22.04"
+                    },
+                    "ubuntu_24.04": {
+                      "repository": "docker.io/ubuntu",
+                      "tag": "24.04"
+                    }
+                  },
+                  "mlnx_ofed_repo_path": "artifactory/gaudi-installer/deps",
+                  "mlnx_ofed_version": "mlnx-ofed-5.8-2.0.3.0-rhel8.4-x86_64.tar.gz",
+                  "repo_path": "artifactory/gaudi-installer/repos",
+                  "repo_server": "vault.habana.ai",
+                  "resources": {
+                    "limits": {
+                      "cpu": "4000m",
+                      "memory": "16Gi"
+                    },
+                    "requests": {
+                      "cpu": "2000m",
+                      "memory": "8Gi"
+                    }
+                  }
+                },
+                "driver_runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-driver-installer",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              },
+              "feature_discovery": {
+                "nfd_plugin": false,
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-feature-discovery",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              },
+              "image_registry": "vault.habana.ai",
+              "metric_exporter": {
+                "interval": 20,
+                "port": 41611,
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-metric-exporter",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "150m",
+                      "memory": "120Mi"
+                    },
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "100Mi"
+                    }
+                  }
+                }
+              },
+              "runtime": {
+                "configuration": {
+                  "container_engine": "crio"
+                },
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-container-runtime",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning, OpenShift Optional
+      certified: "true"
+      containerImage: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+      createdAt: "2026-07-10T12:39:28Z"
+      description: Manages Intel Gaudi AI accelerators within a Kubernetes cluster
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.9.0 <1.24.1-482'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: habana-ai-operator
+      operators.operatorframework.io/builder: operator-sdk-v1.42.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: http://github.com/HabanaAI/habana-ai-operator
+      support: Habana Labs Ltd.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ClusterPolicy is the Schema for the clusterpolicies API.
+        displayName: Cluster Policy
+        kind: ClusterPolicy
+        name: clusterpolicies.habanalabs.habana.ai
+        version: v1
+    description: |
+      Kubernetes provides access to accelerators such as Intel Gaudi AI accelerators and other devices through the [Device Plugin framework](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/). However, configuring and managing nodes with these hardware resources requires configuration of multiple software components such as drivers, container runtimes or other libraries which are difficult and prone to errors.
+      The Intel Gaudi uses the [operator framework](https://coreos.com/blog/introducing-operator-framework) within Kubernetes to automate the management of all Intel Gaudi software components needed to provision and monitor the Intel Gaudi AI accelerators. These components include:
+      * The Intel Gaudi kernel modules to enable the hardware
+      * The Kubernetes DevicePlugin to allow the Intel Gaudi AI accelerator allocation via the kubelet
+      ### Documentation
+      Visit the [Intel Gaudi developer site](https://developer.habana.ai/) for more information.
+      To get started with using Intel Gaudi with OpenShift, see the instructions in the [Intel Gaudi Documentation](https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html).
+    displayName: Intel Gaudi Base Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - habanalabs
+    - hardware
+    - driver
+    links:
+    - name: Intel Gaudi Documentation
+      url: https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html
+    maintainers:
+    - email: erik.berlin@intel.com
+      name: Erik Berlin
+    - email: tal.david@intel.com
+      name: Tal David
+    - email: lukasz.wencel@intel.com
+      name: Lukasz Wencel
+    maturity: stable
+    provider:
+      name: Habana Labs Ltd.
+      url: https://habana.ai
+relatedImages:
+- image: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+  name: gaudi-base-operator-fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59-annotation
+- image: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+  name: manager
+- image: docker.io/intel/gaudi-bmc-exporter@sha256:58ec8ccc005be06cba2bd415c8884f1b4733a4996c393c5c77f250d287a6d04b
+  name: gaudi-bmc-exporter
+- image: docker.io/intel/gaudi-container-runtime@sha256:79b3cea7157e229796576832614f6b4a47bc841f478b505675daad5488e48f90
+  name: gaudi-container-runtime
+- image: docker.io/intel/gaudi-device-plugin@sha256:ffd3c446093b4605d96a00998cd54e403f84179faa63e62c6c88ced8f0d35975
+  name: gaudi-device-plugin
+- image: docker.io/intel/gaudi-driver-installer@sha256:eef69985c7374403f0aeabe6f9dd31c10ca11bbf01050df6383b1260edd24f99
+  name: gaudi-driver-installer
+- image: docker.io/intel/gaudi-feature-discovery@sha256:08ed19730e1e07980b94eb47fe0271cd3b1824f6c144200c6d8ee95ef71866f6
+  name: gaudi-feature-discovery
+- image: docker.io/intel/gaudi-metric-exporter@sha256:6c158db28975613e4a16ac4afaf08c5ea0e9ca27d5d0011f6288cef790d686c7
+  name: gaudi-metric-exporter
+- image: docker.io/redhat/ubi9@sha256:8bf0e8f20737e9c8a68c8a498299e9504ab397b1b1f2837acb2fef12ec698f0e
+  name: driver-loader-rhel-9.8
+- image: docker.io/redhat/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc
+  name: driver-loader-rhel-9.6
+- image: docker.io/ubuntu@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+  name: driver-loader-ubuntu-22.04
+- image: docker.io/ubuntu@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+  name: driver-loader-ubuntu-24.04
+- image: ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gaudi-resource-driver@sha256:b0e255bb5403ec35f1cb040e55b227ad40539577437db5420b1987ca9c283391
+  name: intel-gaudi-resource-driver
+- image: quay.io/brancz/kube-rbac-proxy@sha256:c2ef3c3fcb4ffcfab30088b19c8ef18931aac8cf072c75ef72c654457e1d632b
+  name: kube-rbac-proxy
+- image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/habana-ai-operator/catalog.yaml
+++ b/catalogs/v4.22/habana-ai-operator/catalog.yaml
@@ -1,0 +1,306 @@
+---
+defaultChannel: stable
+icon:
+  base64data: iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAALiMAAC4jAXilP3YAABRGSURBVHhe3VoJlFbVka5uaBYXkE0EZBdBxQVFDYoIYkAjGsVt3NBxjxJFZ06OGE3EDRUVN5JozIijI45RE8dEXOJCcNzNEYxEiQwElEU2EXBBoKe+qrr31n3/+wFtz5lz5r6urq++qnvfrY/7///rbmpadh6ynohq2LZwWGlNmMJevvDNc8CSiHENj4CjN6ypAs9WQ7VZzN/YeU4xroAj5zC8izkZaixfz0vjW309f6kn2ljPAh0iqS0buIHBiMPmAifAfIixESE19jk2nQ/jzRrOBQtNhtoUCxdiJ2YSUX0xho+CiRgV4sDXc3ZLBxYzGHHYcOAEmA8xNgcfNpZy8g8pvJnjU12aFxsKecbljedcWVwUB8LU10MUNhVHjCu2ZGAxgxGjuYRlAyVexbEYGzJBZNNVRNNY60Jem3T1skbC8FnjjoPPYzMTIQqD2E5S4LlqcwOLGwyNsselfOJ8LJdszFnIOeyt2FziLZY5mi8VojZw6jMxspjzQQR3Wvhb4i3m6k0N3Mh8aEiQ44XLY82bBRxygfeGGYJt87E2NGV1EhdqsxrPbSK2E5OJ4yyIA8wzqg0sSDRu7Dl0zqijdGGwciPg5Gsb1VLfPj2oU8d2Ke9rzJDbqXsnum/ipTRs8D6xJvuXjbU+xjZ9kyFXwtUyV/Uk8TL2UsIVBBGzOImjdTyrbGBh9ReddwIdf/RQCWUzmkCgmP1WzZvR9D/eRZePOTVy0RsOwrVu1YKOGj6AenbtwHHYvK8tcoqTEInPOXgnBgulYsEjz0ubGCKCtygOiyKnKp0snl0YcjMBEg4beTGNGXub8sZFLLVmYRRzjIM4kcdgj0vimA9Nw6xRxukEJL4oDuIkrPoYY1jD/uUjZoLoG7XjJVcUKCyGjYuroQvOOpaOGXEw7b1Hb3r43nF04jFD6Td3XMYnZhLddcMYatOqJZdp/cEH7EU3X3W+zOvaeQeaNP7HNP33t9DDd19Og763O/O4nbsH5omhkaI4iqXJWKt8UbCiWMpZLH1qw7k46aTEE5UJpzyvgoGF2SKG443wdejB/al/vz7Urm0rGj50f7rzxkvkJfXZmrV0yvHfp7tuvFjn8GjE70V1dXXUYYc29NwjN9CgAXvQjL/NpY7t29Cj915Bgw/Yg5e1+8g9tJlwLx8LF7GrK3BJrGRRMPRpTaeXVRKGvyW+RBxgrChfOgIOGxaSR8L3PfQUnXTeNTTi5LE08705NHTQ3vxS52V4vPDyO3Txlb+g80eNoJbbbk2jfjyBbpr0KJ0+5lb6eNEyuuSco3mdsCjWVMtPgOJciHKuLE7ipEbLHgDlMoy6wAN7nldEFgMLq0/iyDcbimfM+h/DNTRn3kKqa9yY6prUSQ4Dm+zZrSOfpMb0/G9voHf+NInemno7dem0PfXosgMqQqGYNhkahYUmFcNnjTsOPo/NrMGqD4AOex44Fy0+KNqG2OPSHgIXhmIsEBrAMhjrvt4gvgWfGtR9OHchrV+/gYYcdxn1GHAW9Rp4Lh1+6lV04MjL4ppyJ26mefOmEoXmSoX4rh8Aq1jZicKqurBsE1iRcsrLiNDnlFz39Xr62+z5dMSh+9Gjv76C7v6Pp2nlqjX0u99cQZOu+xFNfXAcPTn5SurVvWOcA9dtx+3psIP2oh3atZI1kzjqtfEit4lYmtqyB0Axw+BxeS7gRs226/lzbFdvxOYFYI8Hu5n8spo5ay61bLE1vfTKDFqwcJnkOvCb7+o1X9CTz71OL736LjVt2oRWrV5Lj019hX7/zOtS340/zT5atJzGT3qMpr0xS05MW34Wmv7mBzR/0QreQg0tWf4Zfb2emypt3Dg800Qu1IQ8etGmYqOuSeEjzl9ylaIhVA65mpZdv7/R1NEkYBRJY0lHzrxhnVrgsfksZsPbnY+tUa0LTSvWuiSE1FWLMay56ieERSnlE/Y8huTqN9bXxuYxApaNqH0zcbDpzYmjNcDZe4fhojiIv504OClVHgDZqooTcsbhTnbzggUByvIhFw3L2OazeuVzcRRLk7HW5lp94IpipRqOZf+uodigChP5LKc48o4LGJfMN453wRgDNw0bRpvCW+xzbFnDorFyuRDGy7wUCxexqytwSaxkkUNP1kBqNgnD3xJvdVV5l1dxcg535C8256VRa9znRAThzRyf6tI85d06jHMhyrmyOK5lDaDRhjwARt4MV0WOMe7MADdXr+JYjA2ZILLpKqJprHUhX1EvayQMnzXuOPg8NgvNFE5L5AvNebwp0bJ5YpwyDnfWjQRxvHkRDHsrNpd4H2u+VIj/wwdAYOELnPeA2IWIo5tkC9iLUzTMEGybj7WhqcApzmp9TcZtIpYGvtsHwApBC3Uyj43/DbERM4/ZojiFmuxf1iw1DdM85ue1vnHjNvsAqC+n2GihoVwcrvUf74bVrAYrOVzpAS1mw250YxUilPBx846TJTynOG9acVEI5djLb/3Uvv1vAIEDn2rEBGu+qjhsyGVz2WOHDLAhs1JxrBlfJ/nQNExrgIunRuZGrB5xElZ9jDHcpuOGBasYDX0ArMgVOfPYkW0SG3PiiCFtm8/EUT4XR7E0GWttrtUHrihWquFY9qaby5u1UxL4LKc48o4LuEIAZymHNHyI/UtMNhkwb1a0Uy4XwngRIcXCRezqClwSK1nkZI+6udRsEoa/JT40UY13+SRA4gKuyBV8Tavex6QfVmWj7O0ERGE4btasKQ05YHfabecu1KRJHX20eAW9+Op79NGSlZwunCau37FDGzpon52pS8e2XN+YlqxYTW/MnEcz/75Qa2R99YcP3JWa8Zq/e2EG78k2CFHCZtmOG7Y3rVr9OT373+8Jf2C/nahju5ZWw46/beS6T5atojdnzqEvvvxK5nkBRgzZmxrx+9sTz71ZkcOX+hBLvr6mdZ+RvBN8mCUxdPMhrqUTRhxIV//rydS2dQusEseGjRvp4SdfoStu/S2t/XId19fKrzwmjj2ZRg7rz++5mJ+Pt2fNp0snPE6z/7FU6nGPV+8fQ9u32YZ6/OAq3aDbpGyUxVo07Wb6YN5iGjzqJuEeuPFsGjawry5aGPgVzF0PPEu3T55KGzZsiOvNeGoCNWtaR72HXITmI68eMMXC8L9WY96hChEFCeLo5i8c9QMa9y8nyS/Axt32CL3Ap2btF+uod89OdMaxB9MpPxxIq9d+RT+743Gpx28XV6z6nKa9+QHdMvlZeu/DRUzXUvfO7Wjkof3o3OMH0n/deR4dMfpumvPRirQpDGC3SRhOlJyqihodF1x1P61YuZpRPZ+OWurTo4Psa+yPfki777wjnXXZr+Rk+TkV4kgqcXo/QH6Jtd7l+I2iSIk4fXt3peenXE2fLF9FI84cT/MXLZea9BKpoWMP25+emjaTvli33uaCb8QlNfjfNcZpPfzRh+xJv7ryRHrq5Vl01s+n8CY20qsPXMonaFvqcdjP4ibhgzD1fFIXT7+FPpi7hAafdoPwD0w4l4bzCdrrqJ/SQrzMQy37rZs3oX+/+QIatN8u9NMJU+ieKc9JbsbUW+QE7Tx4dKxXD5jmu7g+vUmLOGgkNFND550yXP6Ug5uIOJZXPRU/9uxbThzlWBf+MK4UB3OemPZX+viTVTRgj258f3sADMNtOogjnGAM8HhvsvcnjJi3OWxrP/+Szr38HlrDfvTph8ntQ7kMq1ef4oI44k0g3bxiM04N2Kc3v9mto6nT3pEa8Gi6cV1jea8J1oytpraR5vmYHzZwd7ru4qPp3mtG0f3Xn073Xwc7jSZfeypNvvoU+RduymuEhtLQuPQBMI7CHMFJnJBfvvIz+tPLM6nD9q2oR+f2mo8j1ALqHM0HPnl0LVcUBia61VCrFtvQik/X0PqNXIzmpa6Wrrv0BFow/XZa8OfbaMG0iTT/pVtozz5dJPfrcSzK+H+ms48dSIfs15v27duNrSvtuxusi9g2WzXFFtxGbOBEiSjGewsjchYzKIoT/JKln0pFqxZbKReGq5ErxpIUXga72vzkAKs4iBcv+5TfG1rIX1L9y+/Nv86jh558jR76w2s0Z/4nuhjz+Og9csieNPejZTTojInU44iraLeR19Nux45nD7ue+o68jpaz6DKwERbk6/UbqK4xn8DAhU0armuse8KfkmJeDGGqi3PMenRpLzWLl4b3KB7ikMeX1oVYfYjV20ssiJNOCQzPOfgD4ElHHuBqaunRZ96iS8ZPYXuYXp2BPyQizW/q/KmB8Z/P/IVmz1/GnInqbj50/97UnkWXYadl9rwlIhBOWagLG4QA39uzp6w/e+6ilI9D6/wc+J5d29PgAX3pgzkf619hpM4G53Nxil6KOHTvQfB6chTD7p7yPL/hfUVXjh5JA/r1inw6dbW07dbNsJrghfzmi9Fvl86ctrXsprhZ906tacKlR0uNDOZwPfTH1yW8/pJjqAW//Pyc7bZpTteOOVbyD/Ezl+Qkb0NKA6e+S6e29MDEi0T0G37xWOSlViONA5/FEnCocU2bPUfJx7w0JG9JKgKaA3f4wXvRvdefzQ99+on14mvvy0Nh9x3bycupP7/HLFi8kg4//y5axc9DU395IfXdqQM988r7NGXq2/KkvS03Pbh/Lzpr5AB+Rlore2nbih8Mh1+uG2O7feyJ9E9H7E8LFq2g+x6fTnMXLOU313Z05nGDqFP7VjT5sT/TT258KG78wVsupOGD9qSJ9/6BVq35HF3JU3Iffj47cmh/fvJvQrfe8wRdP+lRvQfPmfnsHfKB0uugcyVWHlDz+MI3vYfg+po2e53OP2rYk3R8eeWnqd+u3ejaS46jfXfvrvNsfM5CPfL023Tjvz1HK1d/KXNab7cNjb/oSBoxaLeKJ+k33p1HF1wzhSZfN0oE7jFsrG6ODb/luPjUQ2n0aUP5TdxOJY/P+Kn49slPy5PxRn4eki64/sFbR4tAZePd9/9BN/3ycZr64l840nr4mc/daQKdYxxozYXYiSNBTdt+Z/AJQifl4sBrXEPdOrWjXXt14o/oOlq8fDXNmP0xffHVeldjc/gmO/CPDnjWac8PgBByxvsL6B025Hp25p/P6hrRrA/55zK3QWxuq2Z1cirbbrc1LeWf3956Fz9XrZOcr+3KL6MWeHljnnD4wifXSlrKD7Zai3Kdg/l9eu4ov2qa9ff5wuFLvdaqOIptHgu095lRoFwYxaWcE1NrAraF2XTTziyOmxA+nYicZxgw+6I4uQcscvCAGms+xTHvcFpDooDxH8nR2JaIA29i4PVg9s1+AwiMTy6zjFcsJjXKxbVC3tUhl82NHlDjqnmHU41EGUaHFSdChcg5xP7TCz7GshYWLWsWPjwAWuPOyuthmFPgXB0ufEWu4OWKsa8DTHhT4qBG/zZf2njiqtdwLGvqYnmzQZCSRg1H3nEB4ypyVXOZx1ceqw+xebZNiwOPz3VpNFjxlEAcny9wcTG7mZg7KZzbrDiBd3lcRS7gilzBbzrPjr/JZTjmBFdy6JafhiDIJl5CLo6nyRZBo9osixLeO8BZTmLczOFS3gxXRc5wnmOXxZLNYhmFer234qymyEmtHAc9EVsijmI2WTDczE5MWBy8w54H3pRo2TyXg4+5Kh4o530sAYfGl9V4TmrVQxknhFomRhZzHWay6V857cSExcGbL7NNiVPkvMeV8QIDLlkXI4vDPTACB6i5hAUY1Fh/msdHtYlU9umVi4NfcqWXkrdqjYLH5bmAY3OO8z7O8+ZqYuMlOfVwFjsu1kQswGDi0wnCM40XQ8QBhqFYT0zFhi3OxcFLzuojDjkzrORwpQe0OMsBapyJE/JCGQaKOQkMm8ewOsQKc55VUBHiSTL77h8AnVCyGeND3nnksrnRA2pcNe9wqpGogOGSV2j5wHMgAulJSacnxlKDSYUNRWwnRMzl2MrrYSXPRa5Oc0wVc+blirGvA0y4osZjCSUQj0t58y62B8UScaRGi/JmgyAljRqOvOMCls0UuKq5zOMrj9WH2DzbZsWJnN1TKPPCq8OoaT/oJxv4JWUnyYRyN00iuFPCuc2KE3iXl80IBzrgYg5eClwsWRdLUBHrGinXvE0Hqmu+rcbFIXPLRs7XtB982QY+NVAnEyedAhbGbgjTTZgVcDXR4OM88XABl+SyWLJZLKNQL/eWAU5xix17UdMWbQR/2+F+FjNx2LRReymFG4J32PPA1cQBn81zOfiYq+KBct7HEnBofEVNw4e8tPQ9Rxf/f/cA2MABdXRBvOmWPa+wVWsUPC7PBRybc5z3cZ43VxMbL8mph7PYcbEm4oaN2vBSqtiwxbk4eMlZfcQhZ4aVHK70gBZnOUCNM3FCXijDQDEngWHzGFbX0IE3Hr2ZN7uZbkIFUXE8rziJplxcK+SdRy6bGz2gxlXzDqcaiQoYzvx3MGqzDUVsJ0TM5djK62Elz0WuTnNMFXPm5YqxrwNMuKLGYwklSL6Bg19iWBgWBClp1HDkHRcwriJXNZd5fOWx+hCbZ9usOJGze34HwwTaxEukGu/yspkCF3BFruDzPLuSWK5iTnA5J2vKCP7bD34PUnF0E1gdi5o3XMqb4arIGc5z7LJYslmce0lymLDmAEs4qZXvFga+YUNOkCwqq2PRHFcTDT6bVy1XxQPlvI8l4ND4ihoBGVZYrGn40DfpKlZNHPC4POd9zMUawIB1vuBYZ3k3r7o4Zi6v0OJsnsEGDPcmjdXUZwIEb1g3nnPex3nROOVqYuMh73Lq4Sx2XKyJWIDBSj5QDR3yHCRv0t/kAdBxyQNaXJFTn4kTeKEMA8WcBIbNY1gdYoWVvFIhbtjQJ2lZNDSgOImmXGw+5J1HLpsbPaDGVfMOpxqJChgueYWWD3yxPvpvP1ggXIUGMhweGh3n6mReWU6S+B/KXBGKyrxhjCwn2BYD5/L4VlnrY8w036BB9f8LOu8Lag8vJ8oAAAAASUVORK5CYII=
+  mediatype: image/png
+name: habana-ai-operator
+schema: olm.package
+---
+entries:
+- name: habana-ai-operator.v1.24.1-482
+name: "1.24"
+package: habana-ai-operator
+schema: olm.channel
+---
+entries:
+- name: habana-ai-operator.v1.24.1-482
+name: stable
+package: habana-ai-operator
+schema: olm.channel
+---
+image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+name: habana-ai-operator.v1.24.1-482
+package: habana-ai-operator
+properties:
+- type: olm.gvk
+  value:
+    group: habanalabs.habana.ai
+    kind: ClusterPolicy
+    version: v1
+- type: olm.package
+  value:
+    packageName: habana-ai-operator
+    version: 1.24.1-482
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "habanalabs.habana.ai/v1",
+            "kind": "ClusterPolicy",
+            "metadata": {
+              "name": "habana-ai"
+            },
+            "spec": {
+              "accelerator_allocation_mode": "device-plugin",
+              "bmc_monitoring": {
+                "image": {
+                  "repository": "docker.io/intel/gaudi-bmc-exporter",
+                  "tag": "1.24.1-482"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "memory": "250Mi"
+                  },
+                  "requests": {
+                    "cpu": "150m",
+                    "memory": "100Mi"
+                  }
+                }
+              },
+              "device_plugin": {
+                "image": {
+                  "repository": "docker.io/intel/gaudi-device-plugin",
+                  "tag": "1.24.1-482"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "64Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "32Mi"
+                  }
+                }
+              },
+              "dra_resource_driver": {
+                "image": {
+                  "repository": "ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gaudi-resource-driver",
+                  "tag": "v0.6.1"
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "64Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "32Mi"
+                  }
+                }
+              },
+              "driver": {
+                "driver_loader": {
+                  "images": {
+                    "rhel_9.6": {
+                      "repository": "docker.io/redhat/ubi9",
+                      "tag": "9.6"
+                    },
+                    "rhel_9.8": {
+                      "repository": "docker.io/redhat/ubi9",
+                      "tag": "9.8"
+                    },
+                    "ubuntu_22.04": {
+                      "repository": "docker.io/ubuntu",
+                      "tag": "22.04"
+                    },
+                    "ubuntu_24.04": {
+                      "repository": "docker.io/ubuntu",
+                      "tag": "24.04"
+                    }
+                  },
+                  "mlnx_ofed_repo_path": "artifactory/gaudi-installer/deps",
+                  "mlnx_ofed_version": "mlnx-ofed-5.8-2.0.3.0-rhel8.4-x86_64.tar.gz",
+                  "repo_path": "artifactory/gaudi-installer/repos",
+                  "repo_server": "vault.habana.ai",
+                  "resources": {
+                    "limits": {
+                      "cpu": "4000m",
+                      "memory": "16Gi"
+                    },
+                    "requests": {
+                      "cpu": "2000m",
+                      "memory": "8Gi"
+                    }
+                  }
+                },
+                "driver_runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-driver-installer",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              },
+              "feature_discovery": {
+                "nfd_plugin": false,
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-feature-discovery",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              },
+              "image_registry": "vault.habana.ai",
+              "metric_exporter": {
+                "interval": 20,
+                "port": 41611,
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-metric-exporter",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "150m",
+                      "memory": "120Mi"
+                    },
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "100Mi"
+                    }
+                  }
+                }
+              },
+              "runtime": {
+                "configuration": {
+                  "container_engine": "crio"
+                },
+                "runner": {
+                  "image": {
+                    "repository": "docker.io/intel/gaudi-container-runtime",
+                    "tag": "1.24.1-482"
+                  },
+                  "resources": {
+                    "limits": {
+                      "cpu": "20m",
+                      "memory": "64Mi"
+                    },
+                    "requests": {
+                      "cpu": "10m",
+                      "memory": "32Mi"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: AI/Machine Learning, OpenShift Optional
+      certified: "true"
+      containerImage: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+      createdAt: "2026-07-10T12:39:28Z"
+      description: Manages Intel Gaudi AI accelerators within a Kubernetes cluster
+      features.operators.openshift.io/disconnected: "false"
+      features.operators.openshift.io/fips-compliant: "false"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "false"
+      features.operators.openshift.io/token-auth-aws: "false"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=1.9.0 <1.24.1-482'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: habana-ai-operator
+      operators.operatorframework.io/builder: operator-sdk-v1.42.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: http://github.com/HabanaAI/habana-ai-operator
+      support: Habana Labs Ltd.
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: ClusterPolicy is the Schema for the clusterpolicies API.
+        displayName: Cluster Policy
+        kind: ClusterPolicy
+        name: clusterpolicies.habanalabs.habana.ai
+        version: v1
+    description: |
+      Kubernetes provides access to accelerators such as Intel Gaudi AI accelerators and other devices through the [Device Plugin framework](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/). However, configuring and managing nodes with these hardware resources requires configuration of multiple software components such as drivers, container runtimes or other libraries which are difficult and prone to errors.
+      The Intel Gaudi uses the [operator framework](https://coreos.com/blog/introducing-operator-framework) within Kubernetes to automate the management of all Intel Gaudi software components needed to provision and monitor the Intel Gaudi AI accelerators. These components include:
+      * The Intel Gaudi kernel modules to enable the hardware
+      * The Kubernetes DevicePlugin to allow the Intel Gaudi AI accelerator allocation via the kubelet
+      ### Documentation
+      Visit the [Intel Gaudi developer site](https://developer.habana.ai/) for more information.
+      To get started with using Intel Gaudi with OpenShift, see the instructions in the [Intel Gaudi Documentation](https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html).
+    displayName: Intel Gaudi Base Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - habanalabs
+    - hardware
+    - driver
+    links:
+    - name: Intel Gaudi Documentation
+      url: https://docs.habana.ai/en/latest/Orchestration/HabanaAI_Operator/index.html
+    maintainers:
+    - email: erik.berlin@intel.com
+      name: Erik Berlin
+    - email: tal.david@intel.com
+      name: Tal David
+    - email: lukasz.wencel@intel.com
+      name: Lukasz Wencel
+    maturity: stable
+    provider:
+      name: Habana Labs Ltd.
+      url: https://habana.ai
+relatedImages:
+- image: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+  name: gaudi-base-operator-fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59-annotation
+- image: docker.io/intel/gaudi-base-operator@sha256:fce663267a1a9bbd44aef9e86a36ae46afeb910dfe63ad4129b8b7d66be2fa59
+  name: manager
+- image: docker.io/intel/gaudi-bmc-exporter@sha256:58ec8ccc005be06cba2bd415c8884f1b4733a4996c393c5c77f250d287a6d04b
+  name: gaudi-bmc-exporter
+- image: docker.io/intel/gaudi-container-runtime@sha256:79b3cea7157e229796576832614f6b4a47bc841f478b505675daad5488e48f90
+  name: gaudi-container-runtime
+- image: docker.io/intel/gaudi-device-plugin@sha256:ffd3c446093b4605d96a00998cd54e403f84179faa63e62c6c88ced8f0d35975
+  name: gaudi-device-plugin
+- image: docker.io/intel/gaudi-driver-installer@sha256:eef69985c7374403f0aeabe6f9dd31c10ca11bbf01050df6383b1260edd24f99
+  name: gaudi-driver-installer
+- image: docker.io/intel/gaudi-feature-discovery@sha256:08ed19730e1e07980b94eb47fe0271cd3b1824f6c144200c6d8ee95ef71866f6
+  name: gaudi-feature-discovery
+- image: docker.io/intel/gaudi-metric-exporter@sha256:6c158db28975613e4a16ac4afaf08c5ea0e9ca27d5d0011f6288cef790d686c7
+  name: gaudi-metric-exporter
+- image: docker.io/redhat/ubi9@sha256:8bf0e8f20737e9c8a68c8a498299e9504ab397b1b1f2837acb2fef12ec698f0e
+  name: driver-loader-rhel-9.8
+- image: docker.io/redhat/ubi9@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc
+  name: driver-loader-rhel-9.6
+- image: docker.io/ubuntu@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+  name: driver-loader-ubuntu-22.04
+- image: docker.io/ubuntu@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+  name: driver-loader-ubuntu-24.04
+- image: ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gaudi-resource-driver@sha256:b0e255bb5403ec35f1cb040e55b227ad40539577437db5420b1987ca9c283391
+  name: intel-gaudi-resource-driver
+- image: quay.io/brancz/kube-rbac-proxy@sha256:c2ef3c3fcb4ffcfab30088b19c8ef18931aac8cf072c75ef72c654457e1d632b
+  name: kube-rbac-proxy
+- image: registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+  name: ""
+schema: olm.bundle

--- a/operators/habana-ai-operator/catalog-templates/v4.20.yaml
+++ b/operators/habana-ai-operator/catalog-templates/v4.20.yaml
@@ -31,6 +31,14 @@ entries:
   name: '1.23'
   package: habana-ai-operator
   schema: olm.channel
+- schema: olm.channel
+  name: '1.24'
+  package: habana-ai-operator
+  entries:
+  - name: habana-ai-operator.v1.24.0-1007
+  - name: habana-ai-operator.v1.24.1-482
+    skipRange: '>=1.9.0 <1.24.1-482'
+    replaces: habana-ai-operator.v1.24.0-1007
 - entries:
   - name: habana-ai-operator.v1.22.1-6-2
     skipRange: '>=1.9.0 <1.22.1-6-2'
@@ -51,6 +59,8 @@ entries:
     replaces: habana-ai-operator.v1.22.2-32-2
   - name: habana-ai-operator.v1.24.0-1007
     replaces: habana-ai-operator.v1.23.0-695
+  - name: habana-ai-operator.v1.24.1-482
+    replaces: habana-ai-operator.v1.24.0-1007
   name: stable
   package: habana-ai-operator
   schema: olm.channel
@@ -72,12 +82,11 @@ entries:
 - image: 
     registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai@sha256:ec735480a20d3dc648b0b90ebcec4dcd853ec4cbc7645c0e0a9eb8f5ca4ebd52
   schema: olm.bundle
-- schema: olm.channel
-  name: '1.24'
-  package: habana-ai-operator
-  entries:
-  - name: habana-ai-operator.v1.24.0-1007
-- schema: olm.bundle
-  image: 
+- image: 
     registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai@sha256:1be01f382761ea0e25270a2388f4fad0fe33ce0ae5f9f830f81b196153fb036e
+  schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+  schema: olm.bundle
+
 schema: olm.template.basic

--- a/operators/habana-ai-operator/catalog-templates/v4.21.yaml
+++ b/operators/habana-ai-operator/catalog-templates/v4.21.yaml
@@ -24,11 +24,16 @@ entries:
 - image: 
     registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai@sha256:ec735480a20d3dc648b0b90ebcec4dcd853ec4cbc7645c0e0a9eb8f5ca4ebd52
   schema: olm.bundle
+- image: 
+    registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+  schema: olm.bundle
 - schema: olm.channel
   name: '1.24'
   package: habana-ai-operator
   entries:
   - name: habana-ai-operator.v1.24.0-1007
+  - name: habana-ai-operator.v1.24.1-482
+    replaces: habana-ai-operator.v1.24.0-1007
 - schema: olm.bundle
   image: 
     registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai@sha256:1be01f382761ea0e25270a2388f4fad0fe33ce0ae5f9f830f81b196153fb036e

--- a/operators/habana-ai-operator/catalog-templates/v4.22.yaml
+++ b/operators/habana-ai-operator/catalog-templates/v4.22.yaml
@@ -6,12 +6,17 @@ entries:
     mediatype: image/png
   name: habana-ai-operator
   schema: olm.package
-- entries: []
+- entries:
+  - name: habana-ai-operator.v1.24.1-482
   name: '1.24'
   package: habana-ai-operator
   schema: olm.channel
-- entries: []
+- entries:
+  - name: habana-ai-operator.v1.24.1-482
   name: stable
   package: habana-ai-operator
   schema: olm.channel
+- image: 
+    registry.connect.redhat.com/ospid-627904f807c06bb948c71e73/habana-ai:1.24.1-482
+  schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
- Introduced new catalog file for Intel Gaudi Base Operator version 1.24.1-482, including metadata, images, and CRD descriptions.
- Updated catalog templates for versions 4.20, 4.21, and 4.22 to include the new operator version and its corresponding image.
- Added entries for version 1.24 in the channel schemas, ensuring proper versioning and replacement references.
- Enhanced the operator's metadata with detailed descriptions, capabilities, and maintainers for better clarity and support.